### PR TITLE
refine: cert-verified SAN URI as canonical WebID with owl:sameAs aliases in whoami

### DIFF
--- a/agent-rdf-memory/howto/agent-identity.ttl
+++ b/agent-rdf-memory/howto/agent-identity.ttl
@@ -24,9 +24,8 @@
 • Name: Kingsley Uyi Idehen
 • Email: kidehen@openlinksw.com
 • Role: Founder & CEO, OpenLink Software
-• WebID: https://www.linkedin.com/in/kidehen#this
-• Verified Identity: {user SAN URI} {✅ | ⚠️ Unverified}
-• Aliases: https://x.com/kidehen#this, https://substack.com/@kidehen#this
+• WebID: {user SAN URI} {✅ | ⚠️ Unverified}
+• owl:sameAs: https://www.linkedin.com/in/kidehen#this, https://x.com/kidehen#this, https://substack.com/@kidehen#this
 
 **Agent (me)**
 • Model: {model name} ({llm-id used in session filenames})
@@ -38,7 +37,8 @@
 • On-Behalf-Of WebID: https://www.linkedin.com/in/kidehen#this
 • Agent WebID: {agent SAN URI} {✅ | ⚠️ Unverified}
 
-Use the current session's model and environment — never copy from a prior session. Fill the artifact output root from step-outputDirs rules based on the active LLM model ID. Always emit both Verified Identity and Agent WebID lines even when unverified."""@en .
+The cert-verified SAN URI is the canonical WebID. owl:sameAs lists all known equivalent IRIs.
+Use the current session's model and environment — never copy from a prior session. Fill the artifact output root from step-outputDirs rules based on the active LLM model ID. Always emit the WebID and Agent WebID lines even when unverified."""@en .
 
 # ── Step 2: Verified Identity Gate ───────────────────────────────────────────
 

--- a/agent-rdf-memory/howto/verified-identity.ttl
+++ b/agent-rdf-memory/howto/verified-identity.ttl
@@ -129,9 +129,8 @@ Fill runtime values (model, env, path, project) from current session context.
 • Name: Kingsley Uyi Idehen
 • Email: kidehen@openlinksw.com
 • Role: Founder & CEO, OpenLink Software
-• WebID: https://www.linkedin.com/in/kidehen#this
-• Verified Identity: {user SAN URI} {✅ | ⚠️ Unverified}
-• Aliases: https://x.com/kidehen#this, https://substack.com/@kidehen#this
+• WebID: {user SAN URI} {✅ | ⚠️ Unverified}
+• owl:sameAs: https://www.linkedin.com/in/kidehen#this, https://x.com/kidehen#this, https://substack.com/@kidehen#this
 
 **Agent (me)**
 • Model: {model name} ({llm-id used in session filenames})
@@ -143,5 +142,7 @@ Fill runtime values (model, env, path, project) from current session context.
 • On-Behalf-Of WebID: https://www.linkedin.com/in/kidehen#this
 • Agent WebID: {agent SAN URI} {✅ | ⚠️ Unverified}
 
-If verification is skipped (cert files absent, openssl unavailable) emit both lines
-with ⚠️ Unverified rather than omitting them — absence of the badge is informative."""@en .
+The cert-verified SAN URI is the canonical WebID — the primary authoritative identifier.
+owl:sameAs lists all known equivalent IRIs (LinkedIn, X, Substack, etc.).
+If verification is skipped (cert files absent, openssl unavailable) emit the WebID line
+with ⚠️ Unverified and fall back to the memory-known SAN URI rather than omitting it."""@en .

--- a/agent-rdf-memory/preferences.ttl
+++ b/agent-rdf-memory/preferences.ttl
@@ -1631,9 +1631,8 @@ Response format (after gate):
 • Name: Kingsley Uyi Idehen
 • Email: kidehen@openlinksw.com
 • Role: Founder & CEO, OpenLink Software
-• WebID: https://www.linkedin.com/in/kidehen#this
-• Verified Identity: {user SAN URI} {✅ | ⚠️ Unverified}
-• Aliases: https://x.com/kidehen#this, https://substack.com/@kidehen#this
+• WebID: {user SAN URI} {✅ | ⚠️ Unverified}
+• owl:sameAs: https://www.linkedin.com/in/kidehen#this, https://x.com/kidehen#this, https://substack.com/@kidehen#this
 
 **Agent (me)**
 • Model: {model name} ({llm-id})
@@ -1645,7 +1644,8 @@ Response format (after gate):
 • On-Behalf-Of WebID: https://www.linkedin.com/in/kidehen#this
 • Agent WebID: {agent SAN URI} {✅ | ⚠️ Unverified}
 
-Always emit both Verified Identity and Agent WebID lines even when unverified — ⚠️ is informative."""@en ;
+The cert-verified SAN URI is the canonical WebID. owl:sameAs lists all known equivalent IRIs.
+Always emit the WebID and Agent WebID lines even when unverified — ⚠️ is informative."""@en ;
     onto:hasTrigger onto:triggerWhoamiQuery ;
     schema:url <howto/verified-identity.ttl> .
 


### PR DESCRIPTION
## Summary

Promotes the cert-verified SAN URI to the canonical `WebID` line in `whoami` responses, with all known platform IRIs (LinkedIn, X, Substack) moved to an `owl:sameAs` line as declared equivalents.

## Motivation

The previous format presented a static LinkedIn IRI as the `WebID` and the cryptographically-verified SAN URI on a separate `Verified Identity` line. This inverted the identity hierarchy: the cert-backed IRI is the *more authoritative* identifier — platform IRIs are aliases that happen to be well-known, not the canonical identity.

The corrected model: verification *determines* the canonical WebID; `owl:sameAs` *declares* all known equivalents.

## Before / After

**Before:**
```
• WebID: https://www.linkedin.com/in/kidehen#this
• Verified Identity: {SAN URI} ✅
• Aliases: https://x.com/kidehen#this, https://substack.com/@kidehen#this
```

**After:**
```
• WebID: {SAN URI} ✅
• owl:sameAs: https://www.linkedin.com/in/kidehen#this, https://x.com/kidehen#this, https://substack.com/@kidehen#this
```

The Agent section is unchanged — `Agent WebID` already used the SAN URI directly.

## Files Changed

| File | Change |
|---|---|
| `agent-rdf-memory/preferences.ttl` | `step-verifiedWhoami` — response format block updated |
| `agent-rdf-memory/howto/agent-identity.ttl` | `step-whoamiFormat` — same update; added canonical note |
| `agent-rdf-memory/howto/verified-identity.ttl` | `step-assembleVerifiedWhoami` — same update; clarifies fallback to memory-known SAN URI when cert absent |

All three files also add the rule: *"The cert-verified SAN URI is the canonical WebID. owl:sameAs lists all known equivalent IRIs."*

## Test Plan

- [ ] Trigger `whoami` — confirm `• WebID:` line shows the SAN URI (not the LinkedIn IRI) with ✅ badge
- [ ] Confirm `• owl:sameAs:` line lists LinkedIn, X, and Substack IRIs
- [ ] Remove cert temporarily — confirm `• WebID:` shows memory-known SAN URI with ⚠️ Unverified (line not omitted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)