### PR TITLE
fix: canonical WebID / owl:sameAs pattern applied to On-Behalf-Of in whoami agent section

### DIFF
--- a/agent-rdf-memory/howto/agent-identity.ttl
+++ b/agent-rdf-memory/howto/agent-identity.ttl
@@ -34,11 +34,13 @@
 • Active project: {current task/project or 'none yet this session'}
 • Memory store: {absolute path to agent-rdf-memory/}
 • Behavioral contract: preferences.ttl ({count} standing instructions, incl. {notable recent additions})
-• On-Behalf-Of WebID: https://www.linkedin.com/in/kidehen#this
 • Agent WebID: {agent SAN URI} {✅ | ⚠️ Unverified}
+• On-Behalf-Of: {user SAN URI} {✅ | ⚠️ Unverified}
+• owl:sameAs: https://www.linkedin.com/in/kidehen#this, https://x.com/kidehen#this, https://substack.com/@kidehen#this
 
-The cert-verified SAN URI is the canonical WebID. owl:sameAs lists all known equivalent IRIs.
-Use the current session's model and environment — never copy from a prior session. Fill the artifact output root from step-outputDirs rules based on the active LLM model ID. Always emit the WebID and Agent WebID lines even when unverified."""@en .
+The cert-verified SAN URI is canonical for both the agent and the On-Behalf-Of delegator.
+The owl:sameAs on the On-Behalf-Of line lists the delegator's known platform IRIs.
+Use the current session's model and environment — never copy from a prior session. Fill the artifact output root from step-outputDirs rules based on the active LLM model ID. Always emit the Agent WebID and On-Behalf-Of lines even when unverified."""@en .
 
 # ── Step 2: Verified Identity Gate ───────────────────────────────────────────
 

--- a/agent-rdf-memory/howto/verified-identity.ttl
+++ b/agent-rdf-memory/howto/verified-identity.ttl
@@ -139,10 +139,11 @@ Fill runtime values (model, env, path, project) from current session context.
 • Active project: {current task/project or 'none yet this session'}
 • Memory store: {absolute path to agent-rdf-memory/}
 • Behavioral contract: preferences.ttl ({count} standing instructions, incl. {notable recent additions})
-• On-Behalf-Of WebID: https://www.linkedin.com/in/kidehen#this
 • Agent WebID: {agent SAN URI} {✅ | ⚠️ Unverified}
+• On-Behalf-Of: {user SAN URI} {✅ | ⚠️ Unverified}
+• owl:sameAs: https://www.linkedin.com/in/kidehen#this, https://x.com/kidehen#this, https://substack.com/@kidehen#this
 
-The cert-verified SAN URI is the canonical WebID — the primary authoritative identifier.
-owl:sameAs lists all known equivalent IRIs (LinkedIn, X, Substack, etc.).
-If verification is skipped (cert files absent, openssl unavailable) emit the WebID line
-with ⚠️ Unverified and fall back to the memory-known SAN URI rather than omitting it."""@en .
+The cert-verified SAN URI is canonical for both the agent and the delegator (On-Behalf-Of).
+owl:sameAs on the On-Behalf-Of line lists the delegator's known platform IRIs.
+If verification is skipped (cert files absent, openssl unavailable) emit all lines
+with ⚠️ Unverified and fall back to memory-known SAN URIs rather than omitting them."""@en .

--- a/agent-rdf-memory/preferences.ttl
+++ b/agent-rdf-memory/preferences.ttl
@@ -1641,11 +1641,13 @@ Response format (after gate):
 • Active project: {current task/project or 'none yet this session'}
 • Memory store: {absolute path to agent-rdf-memory/}
 • Behavioral contract: preferences.ttl ({count} standing instructions, incl. {notable recent additions})
-• On-Behalf-Of WebID: https://www.linkedin.com/in/kidehen#this
 • Agent WebID: {agent SAN URI} {✅ | ⚠️ Unverified}
+• On-Behalf-Of: {user SAN URI} {✅ | ⚠️ Unverified}
+• owl:sameAs: https://www.linkedin.com/in/kidehen#this, https://x.com/kidehen#this, https://substack.com/@kidehen#this
 
-The cert-verified SAN URI is the canonical WebID. owl:sameAs lists all known equivalent IRIs.
-Always emit the WebID and Agent WebID lines even when unverified — ⚠️ is informative."""@en ;
+The cert-verified SAN URI is canonical for both the agent and the On-Behalf-Of delegator.
+owl:sameAs on the On-Behalf-Of line lists the delegator's known platform IRIs.
+Always emit the Agent WebID and On-Behalf-Of lines even when unverified — ⚠️ is informative."""@en ;
     onto:hasTrigger onto:triggerWhoamiQuery ;
     schema:url <howto/verified-identity.ttl> .
 


### PR DESCRIPTION
## Summary

The `On-Behalf-Of` line in the whoami Agent section previously hardcoded the LinkedIn IRI as the delegator's WebID — inconsistent with the user section (PR #36) where the cert-verified SAN URI is the canonical identifier.

## Problem

```
• On-Behalf-Of WebID: https://www.linkedin.com/in/kidehen#this   ← static LinkedIn IRI
```

The user's canonical WebID was changed to the cert-verified SAN URI in PR #36, but the `On-Behalf-Of` reference — which points to the same user — was not updated. This made the two references to the same identity use different IRIs in the same response.

## Fix

The Agent section now mirrors the User section exactly:

**Before:**
```
• On-Behalf-Of WebID: https://www.linkedin.com/in/kidehen#this
• Agent WebID: {agent SAN URI} ✅
```

**After:**
```
• Agent WebID: {agent SAN URI} ✅
• On-Behalf-Of: {user SAN URI} ✅
• owl:sameAs: https://www.linkedin.com/in/kidehen#this, https://x.com/kidehen#this, https://substack.com/@kidehen#this
```

The user SAN URI is already resolved by Step 2 of the verified identity gate, so no additional `openssl` call is needed — the value flows from the gate into both the User and Agent sections.

## Files Changed

| File | Change |
|---|---|
| `agent-rdf-memory/preferences.ttl` | `step-verifiedWhoami` agent section updated |
| `agent-rdf-memory/howto/agent-identity.ttl` | `step-whoamiFormat` agent section updated |
| `agent-rdf-memory/howto/verified-identity.ttl` | `step-assembleVerifiedWhoami` agent section updated; note added that canonical-SAN rule applies to both agent and On-Behalf-Of |

## Test Plan

- [ ] Trigger `whoami` — confirm `• On-Behalf-Of:` shows the cert SAN URI (not the LinkedIn IRI) with ✅ badge
- [ ] Confirm `• owl:sameAs:` beneath it lists LinkedIn, X, and Substack as delegator aliases
- [ ] Confirm `• Agent WebID:` shows agent SAN URI with independent badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)