### PR TITLE
rdf-infographic-skill: add URL fragment identifier contract for section anchors

### DIFF
--- a/rdf-infographic-skill/SKILL.md
+++ b/rdf-infographic-skill/SKILL.md
@@ -154,7 +154,7 @@ Pass the RDF data and parameters to generate a complete, single-file HTML docume
 - Floating, draggable, resizable navigation panel
 - Scroll-triggered animations using Intersection Observer API
 - Interactive FAQ accordion with smooth transitions
-- Section anchors with copy-to-clipboard functionality
+- Section anchors with stable URL fragment identifiers and copy-to-clipboard functionality
 - Entity linking to external URIs
 - Comprehensive metadata (JSON-LD, microdata, Open Graph)
 - Professional typography and color schemes
@@ -301,10 +301,13 @@ See `references/design-patterns.md` for detailed design system guidelines.
 - Implemented via Intersection Observer API for performance
 - Staggered animation timing for visual flow
 
-#### Section Anchors
-- Heading hover shows visible 🔗 icon
-- Click copies direct link to clipboard
-- Enables shareable section references
+#### Section Anchors and URL Fragment Identifiers
+- **Every section/subsection heading MUST carry a stable, unique HTML `id` attribute** serving as a URL-addressable fragment identifier (e.g., `<h2 id="overview">`, `<h3 id="faq-what-is-opal">`).
+- Fragment IDs MUST use lowercase kebab-case: alphanumeric characters and hyphens only (no spaces, underscores, special characters, or leading digits).
+- Fragment IDs MUST be stable across regenerations of the same content — derive them from the section heading text (slugified) or the RDF entity IRI local name, never from auto-incrementing counters, timestamps, or random values.
+- The URL fragment MUST resolve natively: `<a href="#id">` scrolls to the correct section without JavaScript dependency (`html { scroll-behavior: smooth; }` is sufficient).
+- Heading hover shows visible 🔗 icon that copies the full page URL with the fragment to clipboard.
+- **Enables shareable section references** — both via the 🔗 copy mechanism and by direct URL fragment navigation (e.g., `page.html#faq-what-is-opal`).
 
 #### Entity Linking
 - First occurrence of RDF entities become hyperlinks
@@ -358,7 +361,9 @@ Use this checklist to validate generated infographics:
 ### Content Structure
 - [ ] All RDF entities are represented
 - [ ] Acronyms expanded on first use
-- [ ] Section anchors have copy functionality
+- [ ] Every section/subsection heading has a unique, stable HTML `id` attribute (lowercase kebab-case)
+- [ ] Fragment IDs are directly addressable via URL (e.g., `page.html#section-id` scrolls to the correct section)
+- [ ] Section anchors have copy-to-clipboard functionality
 - [ ] Entity links point to correct external URIs
 - [ ] Problem-solution framing is clear
 
@@ -1163,6 +1168,9 @@ Navigation state persistence **MUST** handle these edge cases:
 - [ ] Dark mode: both `html[data-theme="dark"]` and `@media (prefers-color-scheme: dark)` produce equivalent rendering; no hardcoded colors outside CSS variables.
 - [ ] Dark mode CSS blocks are **not** comma-combined: `html[data-theme="dark"] { … }` and `@media (prefers-color-scheme:dark) { … }` must be two entirely separate blocks. A trailing comma after a selector followed by an `@media` rule is invalid CSS and silently fails in most browsers.
 - [ ] Light/dark theme toggle is present in the **nav panel header bar** (`#fnav-header`) — not inside the collapsible `#fnav-links` section — so it is accessible whether the nav is collapsed or expanded. The button must carry `title` and `aria-label` attributes and update its icon/label to reflect the current theme state on each click.
+- [ ] Every section heading (`h1`–`h4`) throughout the document carries a unique HTML `id` attribute in lowercase kebab-case.
+- [ ] Fragment IDs are stable (derived from heading text slug or entity IRI local name, not from counters or timestamps).
+- [ ] Each fragment ID resolves natively: `<a href="#id">` positions the section correctly without JavaScript dependency.
 
 ---
 

--- a/rdf-infographic-skill/assets/html-template.html
+++ b/rdf-infographic-skill/assets/html-template.html
@@ -596,13 +596,14 @@
     <section class="section" id="faq">
         <div class="container">
             <h2>Frequently Asked Questions</h2>
+            <!-- Each FAQ question heading MUST carry a unique stable id attribute in lowercase kebab-case (e.g., id="faq-what-is-main-title") -->
             <div style="max-width: 800px; margin: 0 auto;">
                 <div class="card" style="margin-bottom: 1rem;">
-                    <h4>What is [MAIN_TITLE]?</h4>
+                    <h4 id="faq-sample-question">What is [MAIN_TITLE]?</h4>
                     <p>Provide a comprehensive answer to this question.</p>
                 </div>
                 <div class="card">
-                    <h4>How do I get started?</h4>
+                    <h4 id="faq-get-started">How do I get started?</h4>
                     <p>Provide step-by-step instructions for getting started.</p>
                 </div>
             </div>
@@ -613,17 +614,18 @@
     <section class="section" id="glossary">
         <div class="container">
             <h2>Key Terms</h2>
+            <!-- Each glossary term heading MUST carry a unique stable id attribute in lowercase kebab-case (e.g., id="glossary-term-1") -->
             <div class="grid-3">
                 <div class="card">
-                    <h4 style="color: var(--primary);">Term 1 (T1)</h4>
+                    <h4 id="glossary-term-1" style="color: var(--primary);">Term 1 (T1)</h4>
                     <p>Definition of the term and its relevance to the solution.</p>
                 </div>
                 <div class="card">
-                    <h4 style="color: var(--primary);">Term 2 (T2)</h4>
+                    <h4 id="glossary-term-2" style="color: var(--primary);">Term 2 (T2)</h4>
                     <p>Definition of the term and its relevance to the solution.</p>
                 </div>
                 <div class="card">
-                    <h4 style="color: var(--primary);">Term 3 (T3)</h4>
+                    <h4 id="glossary-term-3" style="color: var(--primary);">Term 3 (T3)</h4>
                     <p>Definition of the term and its relevance to the solution.</p>
                 </div>
             </div>


### PR DESCRIPTION
Adds an explicit contract stipulating that every section/subsection heading MUST carry a stable, unique HTML `id` attribute serving as a URL-addressable fragment identifier. Previously the skill only had a copy-to-clipboard UX description with no requirement that `id` attributes exist, are stable, or follow a naming convention.

### Changes

- **SKILL.md Section Anchors** — expanded from 3 vague bullets to a full contract: unique lowercase kebab-case `id` required on every heading, stable across regenerations, native URL fragment resolution, plus 🔗 copy behavior
- **Quality Checklist** — added checks for unique `id` attributes and direct URL addressability
- **Validation Checklist** — 3 new GATE items: unique `id` on every `h1`–`h4`, stable IDs, native fragment resolution
- **HTML template** — added `id` attributes and enforcement comments to FAQ and glossary item headings
- **ZIP bundle** — repackaged