### PR TITLE
feat(memory): add Steps 62–63 — residence/birthplace gate and blank node prohibition

### DIFF
--- a/agent-rdf-memory/howto/no-blank-nodes-resolver-entities.ttl
+++ b/agent-rdf-memory/howto/no-blank-nodes-resolver-entities.ttl
@@ -1,0 +1,61 @@
+@prefix : <#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix onto: <http://www.openlinksw.com/ontology/> .
+
+: a schema:CreativeWork ;
+    schema:about :noBlankNodesRule .
+
+:noBlankNodesRule a schema:HowTo ;
+    schema:name "No blank nodes for resolver-addressable entities"@en ;
+    schema:description "Pre-build gate requiring named IRIs for all entities that need resolver URLs, SPARQL addressability, or HTML hyperlinking. Blank nodes are prohibited for schema:Answer, schema:HowToStep, schema:DefinedTerm, schema:Question, schema:Quotation, and all custom class instances."@en ;
+    schema:dateCreated "2026-06-23T00:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-23T00:00:00Z"^^xsd:dateTime ;
+    schema:step :step1, :step2, :step3, :step4 .
+
+:step1 a schema:HowToStep ;
+    schema:position 1 ;
+    schema:name "Understand why blank nodes fail"@en ;
+    schema:text """Blank nodes have no stable IRI. This means:
+1. No resolver URL can be constructed — linkeddata.uriburner.com/describe/?url= requires an IRI.
+2. No SPARQL query can address the entity by IRI — it can only be reached by traversal from a named subject.
+3. No HTML hyperlink can point to the entity — the infographic entity-link contract requires a resolver-wrapped IRI.
+
+A blank node answer, step, or glossary term is invisible to the resolver and violates the skill contract."""@en .
+
+:step2 a schema:HowToStep ;
+    schema:position 2 ;
+    schema:name "Apply the naming convention"@en ;
+    schema:text """Use predictable, position-based local names:
+- FAQ answers: :Answer1, :Answer2, … :AnswerN
+- HowTo steps: :HowToStep1, :HowToStep2, … (already required by skill contract)
+- Glossary terms: :GlossaryWebID, :GlossaryNetID, … (already named)
+- Quotations: :PrincipalQuote, :Quote2, …
+
+Every named answer MUST include schema:isPartOf pointing back to its question, e.g.:
+  :Answer1 a schema:Answer ; schema:isPartOf :FAQ1 ."""@en .
+
+:step3 a schema:HowToStep ;
+    schema:position 3 ;
+    schema:name "Pre-build verification grep"@en ;
+    schema:text """Before delivering any companion TTL, run:
+  grep -n 'acceptedAnswer \\[' {filename}.ttl
+
+Any match is a contract violation — replace the blank node with a named IRI before proceeding.
+
+Also check:
+  grep -n 'schema:step \\[' {filename}.ttl
+  grep -n 'schema:hasPart \\[' {filename}.ttl
+
+These patterns indicate other blank nodes that may need named IRIs."""@en .
+
+:step4 a schema:HowToStep ;
+    schema:position 4 ;
+    schema:name "Record of violation that triggered this gate"@en ;
+    schema:text """On 2026-06-23, all 10 schema:Answer entities in youid-self-sovereign-identity-claude_sonnet_4_6-1.ttl were generated as blank nodes. The rule was implied by SKILL.md lines 43, 175, and checklist item 1141 (resolver URL requirement) but had no named gate in preferences.ttl. The violation was caught by the user during review and corrected manually. This step closes that gap by making the prohibition an explicit, named, pre-build blocker."""@en .
+
+:incidentRecord a schema:Thing ;
+    schema:name "Blank node FAQ answers — youid infographic"@en ;
+    schema:description "All 10 schema:Answer entities in youid-self-sovereign-identity-claude_sonnet_4_6-1.ttl were blank nodes. Corrected to :Answer1–:Answer10 with schema:isPartOf back-links. Root cause: rule existed in SKILL.md prose only, not as a named preferences.ttl gate."@en ;
+    schema:dateModified "2026-06-23T00:00:00Z"^^xsd:dateTime .

--- a/agent-rdf-memory/howto/rdf-residence-vs-birthplace.ttl
+++ b/agent-rdf-memory/howto/rdf-residence-vs-birthplace.ttl
@@ -1,0 +1,47 @@
+@prefix : <#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix onto: <http://www.openlinksw.com/ontology/> .
+
+: a schema:CreativeWork ;
+    schema:about :residenceVsBirthplaceRule .
+
+:residenceVsBirthplaceRule a schema:HowTo ;
+    schema:name "Correctly encode residence vs birthplace in RDF-Turtle"@en ;
+    schema:dateCreated "2026-06-23T00:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-23T00:00:00Z"^^xsd:dateTime ;
+    schema:description "Rule for distinguishing schema:homeLocation (residence) from schema:birthPlace (place of birth) when generating RDF about Kingsley Uyi Idehen."@en ;
+    schema:step :step1, :step2, :step3 .
+
+:step1 a schema:HowToStep ;
+    schema:position 1 ;
+    schema:name "Identify the source of location data"@en ;
+    schema:text """Location data for Kingsley can come from multiple sources:
+- LinkedIn profile city field → this is RESIDENCE (schema:homeLocation)
+- X.509 certificate Distinguished Name L= field → this is Locality = RESIDENCE
+- Social profile location field → this is RESIDENCE
+None of these are birth records. Do not use any of these as schema:birthPlace."""@en .
+
+:step2 a schema:HowToStep ;
+    schema:position 2 ;
+    schema:name "Apply the correct predicate"@en ;
+    schema:text """Correct mapping:
+- Newton, Massachusetts → schema:homeLocation (place of current residence)
+- schema:birthPlace → only used if the user explicitly states a birth city
+
+The error pattern to avoid:
+  <https://www.linkedin.com/in/kidehen#this> schema:birthPlace :newtonMassachusetts .  # WRONG
+
+Correct form:
+  <https://www.linkedin.com/in/kidehen#this> schema:homeLocation :newtonMassachusetts .  # CORRECT"""@en .
+
+:step3 a schema:HowToStep ;
+    schema:position 3 ;
+    schema:name "Note on X.509 Locality field"@en ;
+    schema:text """In X.509 Distinguished Names, the L= component stands for Locality Name — the city or town where the certificate holder RESIDES, not where they were born. When sponging or parsing oplcert:subject/issuer strings, map L= to schema:addressLocality or schema:homeLocation, never to schema:birthPlace."""@en .
+
+:errorRecord a schema:Thing ;
+    schema:name "Birthplace mix-up — Newton, Massachusetts"@en ;
+    schema:description "In china-super-app-us-super-agent-big-pickle-3.ttl, schema:birthPlace was incorrectly used for :newtonMassachusetts on Kingsley's person entity. Corrected to schema:homeLocation on 2026-06-23."@en ;
+    schema:dateModified "2026-06-23T00:00:00Z"^^xsd:dateTime .

--- a/agent-rdf-memory/preferences.ttl
+++ b/agent-rdf-memory/preferences.ttl
@@ -1690,3 +1690,65 @@ See howto/uriburner-oauth-authcode-flow.ttl for the full step-by-step with curl 
 :topicOAuthAuthCodeFlow a schema:Thing ;
     schema:name "URIBurner OAuth Authorization Code Flow"@en ;
     schema:description "OAuth2 Authorization Code grant flow with dynamic client registration and local redirect server for accessing URIBurner DAV resources. Token issuer must match resource server (linkeddata.uriburner.com), not my.openlinksw.com."@en .
+
+# ── Step 62: schema:homeLocation vs schema:birthPlace ─────────────────────────
+
+:step-residenceVsBirthplace a schema:HowToStep ;
+    schema:position 62 ;
+    schema:name "Use schema:homeLocation for residence, not schema:birthPlace"@en ;
+    schema:text """Newton, Massachusetts is Kingsley Uyi Idehen's place of RESIDENCE, not birthplace.
+
+**Rule:** When encoding a person's location in RDF-Turtle:
+- `schema:homeLocation` — city/town/place where the person currently resides
+- `schema:birthPlace` — the place where the person was BORN (a different fact)
+
+**The error that occurred:** In china-super-app-us-super-agent-big-pickle-3.ttl, the triple
+    <https://www.linkedin.com/in/kidehen#this> schema:birthPlace :newtonMassachusetts
+was generated incorrectly. Newton, Massachusetts (LinkedIn profile location) is where Kingsley resides, not where he was born. Corrected to schema:homeLocation.
+
+**How to apply:** Whenever encoding a location for Kingsley from LinkedIn data, social profiles, or X.509 certificate Locality (L=) fields, use schema:homeLocation. Only use schema:birthPlace if the actual birth city is known and explicitly stated as such by the user.
+
+**Related:** X.509 DN field L= (Locality Name) = place of residence, NOT birthplace. See howto/rdf-residence-vs-birthplace.ttl."""@en ;
+    onto:hasTrigger onto:triggerPreferencesUpdate ;
+    rdfs:seeAlso <howto/rdf-residence-vs-birthplace.ttl> .
+
+# ── Step 63: No blank nodes for resolver-addressable entities ─────────────────
+
+:step-noBlankNodesForResolverEntities a schema:HowToStep ;
+    schema:position 63 ;
+    schema:name "Prohibit blank nodes for any entity that requires a resolver URL"@en ;
+    schema:text """**PRE-BUILD GATE — check before writing any RDF.**
+
+Blank nodes (`[...]` or `_:b`) have no stable IRI. Any entity that will be (a) hyperlinked in HTML via the resolver pattern, (b) referenced in a SPARQL query result, or (c) described as a first-class knowledge graph entity MUST use a named IRI — never a blank node.
+
+**Entities that MUST have named IRIs (non-exhaustive):**
+- `schema:Answer` — every FAQ answer (e.g., `:Answer1`, `:Answer2`, …)
+- `schema:HowToStep` — every HowTo step
+- `schema:DefinedTerm` — every glossary term
+- `schema:Question` — every FAQ question
+- `schema:Quotation` — every quote entity
+- Any custom ontology class instance used as a subject in the graph
+
+**Correct pattern for FAQ answers:**
+```turtle
+:FAQ1 a schema:Question ;
+    schema:acceptedAnswer :Answer1 .
+
+:Answer1 a schema:Answer ;
+    schema:text "..."@en ;
+    schema:isPartOf :FAQ1 .
+```
+
+**Wrong — blank node, no resolver URL possible:**
+```turtle
+:FAQ1 schema:acceptedAnswer [
+    a schema:Answer ;
+    schema:text "..."@en
+] .
+```
+
+**Why this gate exists:** In the youid-self-sovereign-identity infographic (2026-06-23), all 10 `schema:Answer` entities were generated as blank nodes despite the resolver-URL requirement being stated in the skill contract. The rule was implied by SKILL.md prose but had no named gate in preferences.ttl — so it was silently skipped. This step makes it an explicit pre-build blocker.
+
+**How to apply:** Before writing the FAQ section of any companion TTL, verify every `schema:acceptedAnswer` value is a named IRI. grep for `acceptedAnswer [` — if any match exists, it is a contract violation. Fix before proceeding."""@en ;
+    onto:hasTrigger onto:triggerSkillInvocation, onto:triggerPreferencesUpdate ;
+    rdfs:seeAlso <howto/no-blank-nodes-resolver-entities.ttl> .


### PR DESCRIPTION
## Summary

- **Step 62 — `schema:homeLocation` vs `schema:birthPlace`**: Newton, Massachusetts is Kingsley's place of residence, not birthplace. LinkedIn profile location and X.509 DN `L=` (Locality Name) fields must map to `schema:homeLocation`. Corrects an error in `china-super-app-us-super-agent-big-pickle-3.ttl` where `schema:birthPlace` was used instead.

- **Step 63 — No blank nodes for resolver-addressable entities**: Explicit pre-build gate prohibiting blank nodes (`[...]` or `_:b`) for `schema:Answer`, `schema:HowToStep`, `schema:DefinedTerm`, `schema:Question`, `schema:Quotation`, and all custom class instances that require resolver URLs or SPARQL addressability. Includes a mechanical grep check: `grep -n 'acceptedAnswer \[' *.ttl` — any match is a blocker. Triggered by a violation in the YouID infographic companion TTL where all 10 `schema:Answer` entities were blank nodes; the rule existed in SKILL.md prose (lines 43, 175, checklist item 1141) but had no named gate in `preferences.ttl`.

## Files changed

- `agent-rdf-memory/preferences.ttl` — Steps 62 and 63 added
- `agent-rdf-memory/howto/rdf-residence-vs-birthplace.ttl` — new companion howto
- `agent-rdf-memory/howto/no-blank-nodes-resolver-entities.ttl` — new companion howto with incident record

## Test plan

- [ ] Verify `preferences.ttl` parses as valid Turtle
- [ ] Confirm Step 62 (`schema:position 62`) and Step 63 (`schema:position 63`) are present
- [ ] Confirm both howto files exist and are valid Turtle
- [ ] Confirm no regression in existing steps (positions 1–61 unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)