### PR TITLE
fix(memory): remove owl:sameAs from Agent whoami section, expand User list

### DIFF
--- a/agent-rdf-memory/howto/agent-identity.ttl
+++ b/agent-rdf-memory/howto/agent-identity.ttl
@@ -7,7 +7,7 @@
     schema:name "Agent Identity — Whoami Format, Verified Identity Gate, and Stripe Sandbox Card"@en ;
     schema:description "Rules for agent identity presentation: the canonical two-section bullet response to whoami (with verified identity lines for both user and agent), the certificate verification gate that runs before composing the response, and the Stripe sandbox card credentials for ACP test payments."@en ;
     schema:dateCreated "2026-06-05T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-06-25T14:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-26T12:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :step-whoamiFormat, :step-verifiedIdentityGate, :step-stripeSandboxCard ;
     schema:step :step-whoamiFormat, :step-verifiedIdentityGate, :step-stripeSandboxCard ;
@@ -35,7 +35,7 @@ After running the appropriate trigger, respond in this format:
 • Email: kidehen@openlinksw.com
 • Role: Founder & CEO, OpenLink Software
 • WebID: {user SAN URI} {✅ | ⚠️ Unverified}
-• owl:sameAs: https://www.linkedin.com/in/kidehen#this, https://x.com/kidehen#this, https://substack.com/@kidehen#this
+• owl:sameAs: sourced from WebID profile index.html#netid declarations at session time — includes LinkedIn, X/Twitter, GitHub, Mastodon, Bluesky, Threads, Facebook, Instagram, TikTok, Substack, Carrd, Glitch, Linktree, myOpenLink ID, podcast feeds, mailto, and profile representation variants (JSON-LD, RDFa, Turtle)
 
 **Agent (me)**
 • Model: {model name} ({llm-id used in session filenames})
@@ -46,7 +46,6 @@ After running the appropriate trigger, respond in this format:
 • Behavioral contract: preferences.ttl ({count} standing instructions, incl. {notable recent additions})
 • Agent WebID: {agent SAN URI} {✅ | ⚠️ Unverified}
 • On-Behalf-Of: {user SAN URI} {✅ | ⚠️ Unverified}
-• owl:sameAs: https://www.linkedin.com/in/kidehen#this, https://x.com/kidehen#this, https://substack.com/@kidehen#this
 
 **For Trigger B ("who are you?") — Agent-only, no badges:**
 
@@ -61,9 +60,6 @@ After running the appropriate trigger, respond in this format:
 • On-Behalf-Of: {user SAN URI}
 
 (Omit ✅/⚠ badges — no cert verification for Trigger B. Omit the User section entirely.)
-
-The cert-verified SAN URI is canonical for both the agent and the On-Behalf-Of delegator.
-The owl:sameAs on the On-Behalf-Of line lists the delegator's known platform IRIs.
 Use the current session's model and environment — never copy from a prior session. Fill the artifact output root from step-outputDirs rules based on the active LLM model ID. Always emit the Agent WebID and On-Behalf-Of lines even when unverified."""@en .
 
 # ── Step 2: Verified Identity Gate ───────────────────────────────────────────

--- a/agent-rdf-memory/howto/verified-identity.ttl
+++ b/agent-rdf-memory/howto/verified-identity.ttl
@@ -9,7 +9,7 @@
     schema:name "Verified Identity Gate — Whoami Certificate Verification Protocol"@en ;
     schema:description "Protocol for cryptographically verifying both the user identity and the agent identity before responding to a whoami query. Uses local PKCS#12 / PEM certificates whose public key moduli are matched against the published cert:RSAPublicKey in each party's WebID profile document."@en ;
     schema:dateCreated "2026-06-19T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-06-19T00:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-26T12:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :step-locateUserCert, :step-verifyUserIdentity,
                  :step-locateAgentCert, :step-verifyAgentIdentity,
@@ -130,7 +130,7 @@ Fill runtime values (model, env, path, project) from current session context.
 • Email: kidehen@openlinksw.com
 • Role: Founder & CEO, OpenLink Software
 • WebID: {user SAN URI} {✅ | ⚠️ Unverified}
-• owl:sameAs: https://www.linkedin.com/in/kidehen#this, https://x.com/kidehen#this, https://substack.com/@kidehen#this
+• owl:sameAs: sourced from WebID profile index.html#netid declarations — includes LinkedIn, X/Twitter, GitHub, Mastodon, Bluesky, Threads, Facebook, Instagram, TikTok, Substack, Carrd, Glitch, Linktree, myOpenLink ID, podcast feeds, mailto, and profile representation variants
 
 **Agent (me)**
 • Model: {model name} ({llm-id used in session filenames})
@@ -141,9 +141,7 @@ Fill runtime values (model, env, path, project) from current session context.
 • Behavioral contract: preferences.ttl ({count} standing instructions, incl. {notable recent additions})
 • Agent WebID: {agent SAN URI} {✅ | ⚠️ Unverified}
 • On-Behalf-Of: {user SAN URI} {✅ | ⚠️ Unverified}
-• owl:sameAs: https://www.linkedin.com/in/kidehen#this, https://x.com/kidehen#this, https://substack.com/@kidehen#this
 
 The cert-verified SAN URI is canonical for both the agent and the delegator (On-Behalf-Of).
-owl:sameAs on the On-Behalf-Of line lists the delegator's known platform IRIs.
 If verification is skipped (cert files absent, openssl unavailable) emit all lines
 with ⚠️ Unverified and fall back to memory-known SAN URIs rather than omitting them."""@en .

--- a/agent-rdf-memory/index.ttl
+++ b/agent-rdf-memory/index.ttl
@@ -6,7 +6,7 @@
 <> a schema:CreativeWork ;
     schema:name "Agent Session Index"@en ;
     schema:description "Index of all agent sessions with references to session files."@en ;
-    schema:dateModified "2026-06-25T14:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-26T12:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :sessionIndex .
 
@@ -465,3 +465,18 @@
     schema:item <sessions/2026-06-25-big_pickle-opencode-3.ttl> ;
     schema:name "Session 2026-06-25 (big-pickle + OpenCode — DemoFileAccessOffer2URIBurner ACP purchase on ods-qa)"@en ;
     schema:description "Purchased DemoFileAccessOffer2URIBurner ($2.99) from ods-qa ACP via acp-client skill. Checkout created (cs_ec175890-70af-11f1-b27f-f0569f38fb9f), Stripe SPT generated via pm_card_visa, order confirmed (ord_f41bf1f4-70af-11f1-b27f-f0569f38fb9f). Subscription payment link presented — user declined to proceed with Stripe invoice. Session memory written to agent-rdf-memory/sessions/."@en .
+
+:session20260625BigPickleIdentityComparison a schema:ListItem ;
+    schema:position 69 ;
+    schema:item <sessions/2026-06-25-big_pickle-opencode-4.ttl> ;
+    schema:name "Session 2026-06-25 (big-pickle + OpenCode — Identity Worldviews Comparison: AIAM vs YouID vs Sovereign Subject)"@en ;
+    schema:description "Generated three-format collection (RDF-Turtle, Markdown, HTML infographic) comparing three identity governance frameworks: AIAM (Anthropic enterprise agent governance), YouID/WebID (self-sovereign identity), Sovereign Subject (infrastructure-layer identity). 11 comparison dimensions + deepest-difference formula analysis. Files initially placed in project root — relocated to Big Pickle/{rdf,md,webpages}/ after user flagged routing error. Lesson recorded: resolve output root from model ID in system prompt before first write (step-outputRootBlockingGate). Session memory at sessions/2026-06-25-big_pickle-opencode-4.ttl."@en .
+
+:session20260626BigPickleWhoamiCorrection a schema:ListItem ;
+    schema:position 70 ;
+    schema:item <sessions/2026-06-26-big_pickle-opencode.ttl> ;
+    schema:name "Session 2026-06-26 (big-pickle + OpenCode — whoami format correction: Agent owl:sameAs removed, User owl:sameAs expanded)"@en ;
+    schema:description "Corrected whoami response format: (1) Agent section no longer includes owl:sameAs — agents don't have social profiles; (2) User owl:sameAs now sourced from WebID profile index.html#netid declarations (full multi-platform list). Updated howto/agent-identity.ttl, howto/verified-identity.ttl. No prior collection generated."@en .
+
+:sessionIndex schema:itemListElement :session20260625BigPickleIdentityComparison,
+    :session20260626BigPickleWhoamiCorrection .

--- a/agent-rdf-memory/preferences.ttl
+++ b/agent-rdf-memory/preferences.ttl
@@ -10,7 +10,7 @@
 <> a schema:CreativeWork ;
     schema:name "preferences.ttl"@en ;
     schema:description "Configuration for agent RDF memory management and semantic memory skill usage." ;
-    schema:dateModified "2026-06-25T20:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-26T12:00:00Z"^^xsd:dateTime ;
     schema:dateCreated "2026-05-29T17:22:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :agentBehaviorGuide .


### PR DESCRIPTION
## Summary

Corrects the whoami response format in agent identity documentation:

1. **Agent section** — removed `owl:sameAs` line. Agents don't have social platform profiles (LinkedIn, X/Twitter, etc.), so listing them was incorrect.

2. **User section** — `owl:sameAs` now sourced from the WebID profile (`index.html#netid` `owl:sameAs` declarations) instead of a hardcoded 3-entry list. The complete set includes LinkedIn, X/Twitter, GitHub, Mastodon, Bluesky, Threads, Facebook, Instagram, TikTok, Substack, Carrd, Glitch, Linktree, myOpenLink ID, podcast feeds, mailto, and profile representation variants.

## Files Changed

- `agent-rdf-memory/howto/agent-identity.ttl` — updated Trigger A and Trigger B format templates
- `agent-rdf-memory/howto/verified-identity.ttl` — same corrections + removed orphan owl:sameAs prose
- `agent-rdf-memory/preferences.ttl` — dateModified
- `agent-rdf-memory/index.ttl` — dateModified