### PR TITLE
feat(memory+youid): whoami owl:sameAs hyperlinks, WebID verification service gate, GLM path

### DIFF
--- a/agent-rdf-memory/core.ttl
+++ b/agent-rdf-memory/core.ttl
@@ -8,7 +8,7 @@
 <> a schema:CreativeWork ;
     schema:name "Agent RDF Memory Core"@en ;
     schema:description "Core ontology and user identity for the agent RDF memory system."@en ;
-    schema:dateModified "2026-06-03T00:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-26T12:30:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :agentMemory .
 
@@ -101,3 +101,9 @@
     schema:description "Generated artifacts (RDF, MD, HTML) from Grok 4.3 sessions operating in Full Contract Mode go to /Users/kidehen/Documents/LLMs/Grok/ with subfolders rdf/, md/, webpages/."@en ;
     schema:value "/Users/kidehen/Documents/LLMs/Grok/" ;
     schema:dateCreated "2026-05-30"^^xsd:date .
+
+:glmOutputPath a schema:PropertyValue ;
+    schema:name "GLM output path"@en ;
+    schema:description "Generated artifacts (RDF, MD, HTML) from GLM sessions (GLM-5.1, GLM-5.2, and later GLM variants) go to /Users/kidehen/Documents/LLMs/glm/ with subfolders rdf/, md/, webpages/. Lowercase glm/ is the canonical directory name — not uppercase GLM/."@en ;
+    schema:value "/Users/kidehen/Documents/LLMs/glm/" ;
+    schema:dateCreated "2026-06-26"^^xsd:date .

--- a/agent-rdf-memory/howto/agent-identity.ttl
+++ b/agent-rdf-memory/howto/agent-identity.ttl
@@ -7,7 +7,7 @@
     schema:name "Agent Identity — Whoami Format, Verified Identity Gate, and Stripe Sandbox Card"@en ;
     schema:description "Rules for agent identity presentation: the canonical two-section bullet response to whoami (with verified identity lines for both user and agent), the certificate verification gate that runs before composing the response, and the Stripe sandbox card credentials for ACP test payments."@en ;
     schema:dateCreated "2026-06-05T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-06-25T14:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-26T12:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :step-whoamiFormat, :step-verifiedIdentityGate, :step-stripeSandboxCard ;
     schema:step :step-whoamiFormat, :step-verifiedIdentityGate, :step-stripeSandboxCard ;
@@ -35,7 +35,7 @@ After running the appropriate trigger, respond in this format:
 • Email: kidehen@openlinksw.com
 • Role: Founder & CEO, OpenLink Software
 • WebID: {user SAN URI} {✅ | ⚠️ Unverified}
-• owl:sameAs: https://www.linkedin.com/in/kidehen#this, https://x.com/kidehen#this, https://substack.com/@kidehen#this
+• owl:sameAs: sourced from WebID profile index.html#netid declarations at session time — includes LinkedIn, X/Twitter, GitHub, Mastodon, Bluesky, Threads, Facebook, Instagram, TikTok, Substack, Carrd, Glitch, Linktree, myOpenLink ID, podcast feeds, mailto, and profile representation variants (JSON-LD, RDFa, Turtle)
 
 **Agent (me)**
 • Model: {model name} ({llm-id used in session filenames})
@@ -46,7 +46,6 @@ After running the appropriate trigger, respond in this format:
 • Behavioral contract: preferences.ttl ({count} standing instructions, incl. {notable recent additions})
 • Agent WebID: {agent SAN URI} {✅ | ⚠️ Unverified}
 • On-Behalf-Of: {user SAN URI} {✅ | ⚠️ Unverified}
-• owl:sameAs: https://www.linkedin.com/in/kidehen#this, https://x.com/kidehen#this, https://substack.com/@kidehen#this
 
 **For Trigger B ("who are you?") — Agent-only, no badges:**
 
@@ -61,9 +60,6 @@ After running the appropriate trigger, respond in this format:
 • On-Behalf-Of: {user SAN URI}
 
 (Omit ✅/⚠ badges — no cert verification for Trigger B. Omit the User section entirely.)
-
-The cert-verified SAN URI is canonical for both the agent and the On-Behalf-Of delegator.
-The owl:sameAs on the On-Behalf-Of line lists the delegator's known platform IRIs.
 Use the current session's model and environment — never copy from a prior session. Fill the artifact output root from step-outputDirs rules based on the active LLM model ID. Always emit the Agent WebID and On-Behalf-Of lines even when unverified."""@en .
 
 # ── Step 2: Verified Identity Gate ───────────────────────────────────────────

--- a/agent-rdf-memory/howto/agent-identity.ttl
+++ b/agent-rdf-memory/howto/agent-identity.ttl
@@ -7,7 +7,7 @@
     schema:name "Agent Identity — Whoami Format, Verified Identity Gate, and Stripe Sandbox Card"@en ;
     schema:description "Rules for agent identity presentation: the canonical two-section bullet response to whoami (with verified identity lines for both user and agent), the certificate verification gate that runs before composing the response, and the Stripe sandbox card credentials for ACP test payments."@en ;
     schema:dateCreated "2026-06-05T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-06-26T12:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-26T14:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :step-whoamiFormat, :step-verifiedIdentityGate, :step-stripeSandboxCard ;
     schema:step :step-whoamiFormat, :step-verifiedIdentityGate, :step-stripeSandboxCard ;
@@ -35,7 +35,9 @@ After running the appropriate trigger, respond in this format:
 • Email: kidehen@openlinksw.com
 • Role: Founder & CEO, OpenLink Software
 • WebID: {user SAN URI} {✅ | ⚠️ Unverified}
-• owl:sameAs: sourced from WebID profile index.html#netid declarations at session time — includes LinkedIn, X/Twitter, GitHub, Mastodon, Bluesky, Threads, Facebook, Instagram, TikTok, Substack, Carrd, Glitch, Linktree, myOpenLink ID, podcast feeds, mailto, and profile representation variants (JSON-LD, RDFa, Turtle)
+• owl:sameAs: grep <link rel="me"> from {user WebID index.html path} and emit each as [Title](URL). Example output:
+  [LinkedIn](https://www.linkedin.com/in/kidehen#this) · [X](https://x.com/kidehen) · [Substack](https://substack.com/@kidehen) · [Mastodon](https://mastodon.social/@kidehen) · [Bluesky](https://bsky.app/profile/kidehen.bsky.social) · [Threads](https://www.threads.net/@kidehen) · [GitHub](https://github.com/kidehen) · [Linktree](https://linktr.ee/kidehen) · [ID.MyOpenLink.NET](https://id.myopenlink.net/~KingsleyUyiIdehen/Public/) · [Carrd](https://kidehen.carrd.co/) · [Glitch](https://glitch.com/~kidehen) · [Facebook](https://facebook.com/kidehen) · [Instagram](https://www.instagram.com/kidehen) · [TikTok](https://www.tiktok.com/@kidehen) · [RSS](https://www.openlinksw.com/data/podcasts/?a=rss) · [Atom](https://www.openlinksw.com/data/podcasts/?a=atom) · [Email](mailto:kidehen@openlinksw.com)
+  Never substitute prose platform-category descriptions for the actual hyperlinked URIs.
 
 **Agent (me)**
 • Model: {model name} ({llm-id used in session filenames})

--- a/agent-rdf-memory/howto/artifact-routing.ttl
+++ b/agent-rdf-memory/howto/artifact-routing.ttl
@@ -7,7 +7,7 @@
     schema:name "Artifact Routing — Output Directories and Terminology"@en ;
     schema:description "Rules for routing generated artifacts (RDF, HTML, Markdown) to the correct model-specific output directories, plus the meshup vs mashup terminology rule."@en ;
     schema:dateCreated "2026-06-05T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-26T12:30:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :step-outputDirs, :step-gpt5ChatCodexOutputDirs,
         :step-mashupVsMeshup, :step-defaultOutputRoot, :step-modelOverEnvironment ;
@@ -20,7 +20,7 @@
 :step-outputDirs a schema:HowToStep ;
     schema:position "1"^^xsd:integer ;
     schema:name "Route artifacts to model-specific output directories under the canonical LLM root"@en ;
-    schema:text """CANONICAL LLM ROOT: /Users/kidehen/Documents/LLMs/ — all generated artifacts are written beneath this root, and all local RDF searches (step-kgQueryMode) scan beneath this same root. This symmetry is intentional: the write path and the read path share one root, so any artifact written in a generation workflow is automatically discoverable in a subsequent query workflow. Model-specific subdirectories: DeepSeek V4 Pro → /Users/kidehen/Documents/LLMs/DeepSeek/{rdf,md,webpages}/. Claude Sonnet/Opus → /Users/kidehen/Documents/LLMs/Claude Generated/{RDF,md,webpages}/. MiniMax → /Users/kidehen/Documents/LLMs/MiniMax Generated/{rdf,md,webpages}/. GPT-5 Chat in Codex Desktop → /Users/kidehen/Documents/LLMs/GPT5-Chat-Generated/{rdf,md,webpages}/. Kimi → /Users/kidehen/Documents/LLMs/kimi/{rdf,md,webpages}/. Grok → /Users/kidehen/Documents/LLMs/Grok/{rdf,md,webpages}/. Determine the output root from the active LLM model ID before writing any file. Do not use kg-output/, the repo root, or a generator work folder as the final artifact destination. Identify the active LLM from the system prompt model identifier — never infer it from session file names, surrounding conversation context, or memory entries."""@en .
+    schema:text """CANONICAL LLM ROOT: /Users/kidehen/Documents/LLMs/ — all generated artifacts are written beneath this root, and all local RDF searches (step-kgQueryMode) scan beneath this same root. This symmetry is intentional: the write path and the read path share one root, so any artifact written in a generation workflow is automatically discoverable in a subsequent query workflow. Model-specific subdirectories: DeepSeek V4 Pro → /Users/kidehen/Documents/LLMs/DeepSeek/{rdf,md,webpages}/. Claude Sonnet/Opus → /Users/kidehen/Documents/LLMs/Claude Generated/{RDF,md,webpages}/. MiniMax → /Users/kidehen/Documents/LLMs/MiniMax Generated/{rdf,md,webpages}/. GPT-5 Chat in Codex Desktop → /Users/kidehen/Documents/LLMs/GPT5-Chat-Generated/{rdf,md,webpages}/. Kimi → /Users/kidehen/Documents/LLMs/kimi/{rdf,md,webpages}/. Grok → /Users/kidehen/Documents/LLMs/Grok/{rdf,md,webpages}/. GLM (GLM-5.1, GLM-5.2, and later GLM variants) → /Users/kidehen/Documents/LLMs/glm/{rdf,md,webpages}/ — lowercase glm/, NOT uppercase GLM/. Determine the output root from the active LLM model ID before writing any file. Do not use kg-output/, the repo root, or a generator work folder as the final artifact destination. Identify the active LLM from the system prompt model identifier — never infer it from session file names, surrounding conversation context, or memory entries."""@en .
 
 # ── Step 2: GPT-5 Chat Codex Output Dirs ─────────────────────────────────────
 

--- a/agent-rdf-memory/howto/reuse-proven-patterns.ttl
+++ b/agent-rdf-memory/howto/reuse-proven-patterns.ttl
@@ -1,0 +1,40 @@
+@prefix : <#> .
+@prefix schema: <http://schema.org/> .
+@prefix onto: <http://example.org/ontology/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+: a schema:CreativeWork ;
+    schema:about :reuseProvenPatternsProtocol ;
+    schema:name "Proven HTML Pattern Reuse Protocol"@en ;
+    schema:description "Protocol for retrieving and reusing proven HTML interactive patterns from prior infographic output before writing new infographics."@en ;
+    schema:dateCreated "2026-06-26T18:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-26T18:00:00Z"^^xsd:dateTime .
+
+:reuseProvenPatternsProtocol a schema:HowTo ;
+    schema:name "How to reuse proven HTML patterns from prior infographics"@en ;
+    schema:description "Before generating any new HTML infographic, query agent-rdf-memory for prior working output files from the same LLM+agent combination. Identify which patterns were used in the most recent working output for each interactive element — FAQ accordion, glossary layout, nav panel, theme toggle, KG Explorer, sparql-explorer — and reuse those DOM structures, CSS classes, and JS functions. Do not default to untested alternative layouts."@en .
+
+:step1 a schema:HowToStep ;
+    schema:position 1 ;
+    schema:name "Query memory for prior infographic files"@en ;
+    schema:text "Query index.ttl and session files in agent-rdf-memory/sessions/ for infographic HTML output files from the same LLM+agent, filtered by 'rdf-infographic-skill' or 'kg-generator' in the provenance chain. Identify the most recent working output that was delivered to the user."@en .
+
+:step2 a schema:HowToStep ;
+    schema:position 2 ;
+    schema:name "Inventory interactive patterns in prior output"@en ;
+    schema:text "Read the identified HTML file and catalog each interactive section: FAQ accordion structure (class names, toggle mechanism, expand/collapse CSS), glossary layout (grid vs flex vs wrapping rows), nav panel (glassmorphism, header-bar, collapsible body), theme toggle (position, styling, JS), KG Explorer (render pattern, lazy-init, drag behavior), and sparql-explorer (footer section, query display, href encoding)."@en .
+
+:step3 a schema:HowToStep ;
+    schema:position 3 ;
+    schema:name "Reuse — never rewrite"@en ;
+    schema:text "Copy the proven DOM structure, CSS, and JS for each interactive element from the prior working output into the new file. Adapt entity-specific content and color scheme but preserve the interaction model, class names, and layout approach. The FAQ accordion pattern (.faq-item > .faq-q onclick toggle via parentElement.classList.toggle('open') > .faq-a max-height expand) from satyas-convenient-truth and startups-2030 infographics is the canonical pattern — never use grid-row or flat-list FAQ layouts."@en .
+
+:step4 a schema:HowToStep ;
+    schema:position 4 ;
+    schema:name "Verify pattern fidelity in new output"@en ;
+    schema:text "After generating the new HTML, grep for the canonical pattern signatures to confirm fidelity: grep the .faq-class names, the onclick='this.parentElement.classList.toggle' pattern for accordion, the glossary-row-wrapping layout, the nav header-bar with grab-indicator, and the theme toggle pill with data-label. If any signature is missing, revert to the prior working pattern before delivery."@en .
+
+:incidentNote a schema:Thing ;
+    schema:name "Incident: Grid-row FAQ layout used in aiam-vs-youid-comparison (2026-06-26)"@en ;
+    schema:description "When generating the aiam-vs-youid-comparison HTML infographic, the FAQ section was implemented as a flat grid-row layout instead of the established accordion pattern from satyas-convenient-truth and startups-2030. The user rejected this approach, noting that the preference to reuse proven patterns should have been retrieved from memory automatically. The HTML was subsequently reverted to the canonical accordion pattern. Root cause: preferences.ttl did not yet include a step mandating pattern reuse from prior working outputs."@en .

--- a/agent-rdf-memory/howto/study-prior-patterns.ttl
+++ b/agent-rdf-memory/howto/study-prior-patterns.ttl
@@ -1,0 +1,40 @@
+@prefix : <#> .
+@prefix schema: <http://schema.org/> .
+@prefix onto: <http://example.org/ontology/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+: a schema:CreativeWork ;
+    schema:about :studyPriorPatternsProtocol ;
+    schema:name "Study Prior Patterns Protocol"@en ;
+    schema:description "Protocol for studying proven HTML interactive patterns from prior infographic output as input to execution plan construction."@en ;
+    schema:dateCreated "2026-06-26T18:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-26T18:00:00Z"^^xsd:dateTime .
+
+:studyPriorPatternsProtocol a schema:HowTo ;
+    schema:name "How to study prior patterns when constructing execution plans"@en ;
+    schema:description "Before constructing an execution plan for a new HTML infographic, query agent-rdf-memory for prior working output files from the same LLM+agent combination. Study which patterns were used for each interactive element — FAQ accordion, glossary layout, nav panel, theme toggle, KG Explorer, sparql-explorer. Then construct a plan that balances study of what worked before against what the operator's actual prompt requests. The operator's request is authoritative; prior patterns inform but do not override it."@en .
+
+:step1 a schema:HowToStep ;
+    schema:position 1 ;
+    schema:name "Query memory for prior infographic files"@en ;
+    schema:text "Query index.ttl and session files in agent-rdf-memory/sessions/ for infographic HTML output files from the same LLM+agent, filtered by 'rdf-infographic-skill' or 'kg-generator' in the provenance chain. Identify the most recent working output that was delivered to the user."@en .
+
+:step2 a schema:HowToStep ;
+    schema:position 2 ;
+    schema:name "Catalog interactive patterns as study input"@en ;
+    schema:text "Read the identified HTML file and catalog each interactive section: FAQ accordion structure (class names, toggle mechanism, expand/collapse CSS), glossary layout (grid vs flex vs wrapping rows), nav panel (glassmorphism, header-bar, collapsible body), theme toggle (position, styling, JS), KG Explorer (render pattern, lazy-init, drag behavior), and sparql-explorer (footer section, query display, href encoding). Note what worked well and what caused issues."@en .
+
+:step3 a schema:HowToStep ;
+    schema:position 3 ;
+    schema:name "Construct execution plan from operator request + study"@en ;
+    schema:text "Construct the execution plan with the operator's prompt as the primary driver. Use the studied patterns as reference material — strong signals for what works in this repo, but not mandates. If the operator asks for something different from prior patterns, follow the operator. If the operator doesn't specify layout details, the studied patterns become the default because they are proven to work."@en .
+
+:step4 a schema:HowToStep ;
+    schema:position 4 ;
+    schema:name "Validate plan against operator intent"@en ;
+    schema:text "Before executing, verify the plan matches what the operator actually asked for. If the plan overrides a studied pattern, confirm it's because the operator's request demands it — not because of an arbitrary design choice. If the operator rejects an approach, pivot by revisiting the studied patterns as alternatives."@en .
+
+:incidentNote a schema:Thing ;
+    schema:name "Incident: Grid-row FAQ layout in aiam-vs-youid-comparison (2026-06-26)"@en ;
+    schema:description "When generating the aiam-vs-youid-comparison HTML infographic, the FAQ section was implemented as a flat grid-row layout — an untested alternative — instead of the established accordion pattern from satyas-convenient-truth and startups-2030. The user rejected this approach. Root cause: the prior patterns were not studied before constructing the execution plan, and the alternative was not checked against what the operator's request would reasonably accept."@en .

--- a/agent-rdf-memory/howto/verified-identity.ttl
+++ b/agent-rdf-memory/howto/verified-identity.ttl
@@ -9,7 +9,7 @@
     schema:name "Verified Identity Gate — Whoami Certificate Verification Protocol"@en ;
     schema:description "Protocol for cryptographically verifying both the user identity and the agent identity before responding to a whoami query. Uses local PKCS#12 / PEM certificates whose public key moduli are matched against the published cert:RSAPublicKey in each party's WebID profile document."@en ;
     schema:dateCreated "2026-06-19T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-06-26T12:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-26T14:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :step-locateUserCert, :step-verifyUserIdentity,
                  :step-locateAgentCert, :step-verifyAgentIdentity,
@@ -130,7 +130,7 @@ Fill runtime values (model, env, path, project) from current session context.
 • Email: kidehen@openlinksw.com
 • Role: Founder & CEO, OpenLink Software
 • WebID: {user SAN URI} {✅ | ⚠️ Unverified}
-• owl:sameAs: sourced from WebID profile index.html#netid declarations — includes LinkedIn, X/Twitter, GitHub, Mastodon, Bluesky, Threads, Facebook, Instagram, TikTok, Substack, Carrd, Glitch, Linktree, myOpenLink ID, podcast feeds, mailto, and profile representation variants
+• owl:sameAs: grep <link rel="me"> from user's WebID index.html and emit each as [Title](URL) — never prose platform-category descriptions
 
 **Agent (me)**
 • Model: {model name} ({llm-id used in session filenames})

--- a/agent-rdf-memory/howto/verified-identity.ttl
+++ b/agent-rdf-memory/howto/verified-identity.ttl
@@ -9,7 +9,7 @@
     schema:name "Verified Identity Gate — Whoami Certificate Verification Protocol"@en ;
     schema:description "Protocol for cryptographically verifying both the user identity and the agent identity before responding to a whoami query. Uses local PKCS#12 / PEM certificates whose public key moduli are matched against the published cert:RSAPublicKey in each party's WebID profile document."@en ;
     schema:dateCreated "2026-06-19T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-06-19T00:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-26T12:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :step-locateUserCert, :step-verifyUserIdentity,
                  :step-locateAgentCert, :step-verifyAgentIdentity,
@@ -130,7 +130,7 @@ Fill runtime values (model, env, path, project) from current session context.
 • Email: kidehen@openlinksw.com
 • Role: Founder & CEO, OpenLink Software
 • WebID: {user SAN URI} {✅ | ⚠️ Unverified}
-• owl:sameAs: https://www.linkedin.com/in/kidehen#this, https://x.com/kidehen#this, https://substack.com/@kidehen#this
+• owl:sameAs: sourced from WebID profile index.html#netid declarations — includes LinkedIn, X/Twitter, GitHub, Mastodon, Bluesky, Threads, Facebook, Instagram, TikTok, Substack, Carrd, Glitch, Linktree, myOpenLink ID, podcast feeds, mailto, and profile representation variants
 
 **Agent (me)**
 • Model: {model name} ({llm-id used in session filenames})
@@ -141,9 +141,7 @@ Fill runtime values (model, env, path, project) from current session context.
 • Behavioral contract: preferences.ttl ({count} standing instructions, incl. {notable recent additions})
 • Agent WebID: {agent SAN URI} {✅ | ⚠️ Unverified}
 • On-Behalf-Of: {user SAN URI} {✅ | ⚠️ Unverified}
-• owl:sameAs: https://www.linkedin.com/in/kidehen#this, https://x.com/kidehen#this, https://substack.com/@kidehen#this
 
 The cert-verified SAN URI is canonical for both the agent and the delegator (On-Behalf-Of).
-owl:sameAs on the On-Behalf-Of line lists the delegator's known platform IRIs.
 If verification is skipped (cert files absent, openssl unavailable) emit all lines
 with ⚠️ Unverified and fall back to memory-known SAN URIs rather than omitting them."""@en .

--- a/agent-rdf-memory/howto/webid-verification-services.ttl
+++ b/agent-rdf-memory/howto/webid-verification-services.ttl
@@ -1,0 +1,48 @@
+@prefix : <#> .
+@prefix schema: <http://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<> a schema:HowTo ;
+    schema:name "WebID/NetID Verification Service Selection — Elicit Before mTLS Verification"@en ;
+    schema:description "Rules for handling WebID/NetID verification requests. Lists known mTLS verification services and mandates user elicitation before selecting one, since the list is open and will grow over time."@en ;
+    schema:dateCreated "2026-06-26T12:50:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-26T12:50:00Z"^^xsd:dateTime ;
+    schema:author <https://linkedin.com/in/kidehen#this> ;
+    schema:about :step-webidVerificationServiceSelection, :topicWebidVerificationServices ;
+    schema:step :step-webidVerificationServiceSelection ;
+    rdfs:seeAlso <../preferences.ttl> .
+
+# ── Step 1: Elicit Verification Service Selection ────────────────────────────
+
+:step-webidVerificationServiceSelection a schema:HowToStep ;
+    schema:position "1"^^xsd:integer ;
+    schema:name "Elicit WebID/NetID verification service selection before mTLS verification"@en ;
+    schema:text """When the user asks to verify a WebID or NetID via a remote verification service, ALWAYS elicit which service to use before issuing the mTLS curl. Do not default to a single service. Present the known services list (below) and let the user choose. If the user names a service explicitly in their prompt, honor that choice without re-eliciting (same principle as skill protocol routing).
+
+KNOWN SERVICES (open list — more will be added over time):
+  1. https://netid-qa.openlinksw.com:9443/webid/  — NetID QA, mTLS on port 9443, supports WebID+TLS and NetID+TLS, accepts URI schemes: acct, http(s), ldap, mailto, bitcoin, ethereum. Returns HTML with NetID, timestamp, sha1 digest, emoji.
+  2. https://ods-qa.openlinksw.com/webid/         — ODS QA instance.
+  3. https://linkeddata.uriburner.com/webid/      — URIBurner (production, public).
+  4. https://demo.openlinksw.com/webid/           — OpenLink demo instance.
+
+ELICITATION FORMAT:
+  Ask the user which service to use, presenting the numbered list above. If the user has already named a service in their prompt (e.g., 'verify using https://netid-qa.openlinksw.com:9443/webid/'), skip elicitation and use the named service.
+
+EXECUTION (per service):
+  - All listed services use mTLS (client certificate authentication).
+  - Extract a temporary combined PEM (cert + private key) from the user's cert.p12 using the passphrase (per :step-curlAuth and :step-secretEchoRedaction — never echo the passphrase).
+  - curl -sS -L --cert {tmpPEM} '{serviceURL}?go=Verify'
+  - The service extracts the SAN URI from the presented X.509 certificate and returns the verified NetID, timestamp, sha1 digest, and emoji.
+  - Shred the temp PEM immediately after use.
+
+VERIFICATION GATE INTERACTION:
+  This step complements :step-verifiedWhoami (position 60) and :step-webidTlsVerification (position 23.1). Those gates verify the local cert modulus against profile.ttl cert:modulus. This step performs REMOTE verification by a trusted OpenLink verification service. Both are valid; the user may request either or both.
+
+OPEN LIST POLICY:
+  The known services list is intentionally open. When a new OpenLink verification service comes online (or a third-party service is trusted by the user), add it to the list in this file. Do not treat the list as closed or exhaustive."""@en ;
+    rdfs:seeAlso <../preferences.ttl> .
+
+:topicWebidVerificationServices a schema:Thing ;
+    schema:name "WebID/NetID Verification Service Selection"@en ;
+    schema:description "Rules for eliciting and executing WebID/NetID verification against OpenLink's mTLS verification services. Known services: netid-qa.openlinksw.com:9443/webid/, ods-qa.openlinksw.com/webid/, linkeddata.uriburner.com/webid/, demo.openlinksw.com/webid/. List is open and extensible. Selection is always elicited unless the user names a service in their prompt."@en .

--- a/agent-rdf-memory/index.ttl
+++ b/agent-rdf-memory/index.ttl
@@ -6,7 +6,7 @@
 <> a schema:CreativeWork ;
     schema:name "Agent Session Index"@en ;
     schema:description "Index of all agent sessions with references to session files."@en ;
-    schema:dateModified "2026-06-26T12:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-26T17:00:51Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :sessionIndex .
 
@@ -479,4 +479,23 @@
     schema:description "Corrected whoami response format: (1) Agent section no longer includes owl:sameAs — agents don't have social profiles; (2) User owl:sameAs now sourced from WebID profile index.html#netid declarations (full multi-platform list). Updated howto/agent-identity.ttl, howto/verified-identity.ttl. No prior collection generated."@en .
 
 :sessionIndex schema:itemListElement :session20260625BigPickleIdentityComparison,
-    :session20260626BigPickleWhoamiCorrection .
+    :session20260626BigPickleWhoamiCorrection,
+    :session20260626Glm52OpenCodeWhoami .
+
+:prefWebidVerificationServices a schema:ListItem ;
+    schema:position 71 ;
+    schema:name "Step 82 — WebID/NetID verification service selection (elicit before mTLS)"@en ;
+    schema:description """New preference: when the user asks to verify a WebID or NetID via a remote service, elicit which service to use from the known open list. Known services: (1) https://netid-qa.openlinksw.com:9443/webid/ — mTLS on port 9443, supports WebID+TLS and NetID+TLS, accepts acct/http(s)/ldap/mailto/bitcoin/ethereum URI schemes, returns NetID+timestamp+sha1+emoji; (2) https://ods-qa.openlinksw.com/webid/; (3) https://linkeddata.uriburner.com/webid/; (4) https://demo.openlinksw.com/webid/. List is open and extensible — new services added over time. If the user names a service in their prompt, honor it without re-eliciting. Companion howto: howto/webid-verification-services.ttl. Complements :step-verifiedWhoami (pos 60) and :step-webidTlsVerification (pos 23.1) which perform LOCAL modulus verification."""@en ;
+    schema:about <preferences.ttl#step-webidVerificationServiceSelection> .
+
+:session20260626Glm52OpenCodeWhoami a schema:ListItem ;
+    schema:position 71 ;
+    schema:item <sessions/2026-06-26-glm_5_2-opencode.ttl> ;
+    schema:name "Session 2026-06-26 (GLM-5.2 + OpenCode — whoami with verified identity gate + GLM output path registration, first GLM-5.2 session)"@en ;
+    schema:description "First session with GLM-5.2 in OpenCode. User issued 'whoami?' then 'According to prefs.' Ran verified identity gate per :step-verifiedWhoami (pos 60) and :step-whoamiFormat (pos 23): extracted SAN URIs and moduli from both cert.pem files via openssl, compared against cert:modulus in profile.ttl for each bundle. Both matched (user C719...C07, agent DA2B...D17B). Emitted full two-section whoami response with verified badges. User then approved registering GLM as a canonical output path using lowercase glm/. Updated core.ttl (new :glmOutputPath PropertyValue), howto/artifact-routing.ttl (step-outputDirs schema:text now lists GLM with lowercase path and the NOT-uppercase note), and scripts/fill_core_template.{py,ts} (both had uppercase GLM/ — corrected to lowercase glm/). Created /Users/kidehen/Documents/LLMs/glm/rdf/ and /webpages/ subfolders alongside existing md/."@en .
+
+:session20260626Gpt5ChatCodex a schema:ListItem ;
+    schema:position 999 ;
+    schema:item <sessions/2026-06-26-gpt5_chat-codex.ttl> ;
+    schema:name "Session 2026-06-26 (GPT-5 Chat Codex — Virtuoso 08.03.3335 KG Explorer theme/toggle fix)"@en ;
+    schema:description "Regenerated canonical Virtuoso 08.03.3335 RDF/HTML artifacts after fixing KG Explorer dark-mode hyperlink colors and Firefox-safe dark/light toggle behavior; validated RDF parse, syntax, and static theme contract checks."@en .

--- a/agent-rdf-memory/index.ttl
+++ b/agent-rdf-memory/index.ttl
@@ -6,7 +6,7 @@
 <> a schema:CreativeWork ;
     schema:name "Agent Session Index"@en ;
     schema:description "Index of all agent sessions with references to session files."@en ;
-    schema:dateModified "2026-06-25T14:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-26T12:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :sessionIndex .
 
@@ -465,3 +465,18 @@
     schema:item <sessions/2026-06-25-big_pickle-opencode-3.ttl> ;
     schema:name "Session 2026-06-25 (big-pickle + OpenCode — DemoFileAccessOffer2URIBurner ACP purchase on ods-qa)"@en ;
     schema:description "Purchased DemoFileAccessOffer2URIBurner ($2.99) from ods-qa ACP via acp-client skill. Checkout created (cs_ec175890-70af-11f1-b27f-f0569f38fb9f), Stripe SPT generated via pm_card_visa, order confirmed (ord_f41bf1f4-70af-11f1-b27f-f0569f38fb9f). Subscription payment link presented — user declined to proceed with Stripe invoice. Session memory written to agent-rdf-memory/sessions/."@en .
+
+:session20260625BigPickleIdentityComparison a schema:ListItem ;
+    schema:position 69 ;
+    schema:item <sessions/2026-06-25-big_pickle-opencode-4.ttl> ;
+    schema:name "Session 2026-06-25 (big-pickle + OpenCode — Identity Worldviews Comparison: AIAM vs YouID vs Sovereign Subject)"@en ;
+    schema:description "Generated three-format collection (RDF-Turtle, Markdown, HTML infographic) comparing three identity governance frameworks: AIAM (Anthropic enterprise agent governance), YouID/WebID (self-sovereign identity), Sovereign Subject (infrastructure-layer identity). 11 comparison dimensions + deepest-difference formula analysis. Files initially placed in project root — relocated to Big Pickle/{rdf,md,webpages}/ after user flagged routing error. Lesson recorded: resolve output root from model ID in system prompt before first write (step-outputRootBlockingGate). Session memory at sessions/2026-06-25-big_pickle-opencode-4.ttl."@en .
+
+:session20260626BigPickleWhoamiCorrection a schema:ListItem ;
+    schema:position 70 ;
+    schema:item <sessions/2026-06-26-big_pickle-opencode.ttl> ;
+    schema:name "Session 2026-06-26 (big-pickle + OpenCode — whoami format correction: Agent owl:sameAs removed, User owl:sameAs expanded)"@en ;
+    schema:description "Corrected whoami response format: (1) Agent section no longer includes owl:sameAs — agents don't have social profiles; (2) User owl:sameAs now sourced from WebID profile index.html#netid declarations (full multi-platform list). Updated howto/agent-identity.ttl, howto/verified-identity.ttl. No prior collection generated."@en .
+
+:sessionIndex schema:itemListElement :session20260625BigPickleIdentityComparison,
+    :session20260626BigPickleWhoamiCorrection .

--- a/agent-rdf-memory/preferences.ttl
+++ b/agent-rdf-memory/preferences.ttl
@@ -10,7 +10,7 @@
 <> a schema:CreativeWork ;
     schema:name "preferences.ttl"@en ;
     schema:description "Configuration for agent RDF memory management and semantic memory skill usage." ;
-    schema:dateModified "2026-06-26T12:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-26T12:50:00Z"^^xsd:dateTime ;
     schema:dateCreated "2026-05-29T17:22:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :agentBehaviorGuide .
@@ -28,6 +28,7 @@
     schema:name "Agent Standing Instructions"@en ;
     schema:description "Procedural rules the agent must follow in every session. Encoded as structured RDF so rules are queryable, resolvable, and harder to overlook than flat prose alone."@en ;
     schema:about :topicApprovalWorkflow, :topicArtifactRouting, :topicModelIdentityPreflight,
+        :topicWhoamiSameAsHyperlinks,
         :topicSkillComposition,         :topicEntityResolution, :topicCanonicalEntityIriDenotation,
         :topicEntityIriDenotationMechanics,
         :topicMemoryManagement, :topicVersionControl,
@@ -50,8 +51,10 @@
         :topicYouidValidationGate,
         :topicOAuthAuthCodeFlow,
         :topicD3Loading,
-        :topicSecretEchoRedaction ;
+        :topicSecretEchoRedaction,
+        :topicWebidVerificationServices ;
     schema:step :step-approval, :step-outputDirs, :step-gpt5ChatCodexOutputDirs, :step-mashupVsMeshup, :step-modelIdentityPreflight, :step-skillChain,
+        :step-whoamiSameAsHyperlinks,
         :step-kgQueryMode,
         :step-entityDenotation, :step-memoryProtocol,
         :step-gitWorkflow, :step-attribution, :step-zipRepackage,
@@ -77,7 +80,8 @@
         :step-youidValidationGate,
         :step-uriburnerOAuthAuthCodeFlow,
         :step-staticD3Load, :step-singleRender,
-        :step-secretEchoRedaction .
+        :step-secretEchoRedaction,
+        :step-webidVerificationServiceSelection .
 
 # ── Step 1: Seek Approval ────────────────────────────────────────────────────
 
@@ -1123,3 +1127,43 @@
     schema:text "New HowToStep entries in preferences.ttl are limited to schema:name, a one-sentence schema:text, onto:hasTrigger, and rdfs:seeAlso; all rationale, code, gates, and incident notes go in the companion howto/*.ttl file."@en ;
     onto:hasTrigger onto:triggerPreferencesUpdate ;
     rdfs:seeAlso <howto/memory-protocol-gate.ttl> .
+
+# ── Step 81: Study proven patterns from prior work when constructing execution plans ──
+
+:step-studyPriorPatterns a schema:HowToStep ;
+    schema:position 81 ;
+    schema:name "Study proven patterns from prior output as input to execution plan construction, in line with operator request"@en ;
+    schema:text "Before constructing an execution plan for a new HTML infographic, study proven interactive patterns and structural choices from prior working outputs under this repo. Use the study to inform the plan — but the plan must ultimately reflect what the operator's prompt actually asks for, not blindly reproduce prior patterns."@en ;
+    onto:hasTrigger onto:triggerSkillInvocation, onto:triggerPreferencesUpdate ;
+    rdfs:seeAlso <howto/study-prior-patterns.ttl> .
+
+:topicStudyPriorPatterns a schema:Thing ;
+    schema:name "Study Prior Patterns, Don't Mandate Reuse"@en ;
+    schema:description "The FAQ accordion pattern (.faq-item > .faq-q onclick toggle > .faq-a max-height expand) from prior documents (satyas-convenient-truth, startups-2030) is a strong signal for what works in this repo — study it, use it to inform plan construction, but let the operator's actual request determine the final approach."@en .
+
+# ── Step 82: WebID/NetID Verification Service Selection ──────────────────────
+
+:step-webidVerificationServiceSelection a schema:HowToStep ;
+    schema:position 82 ;
+    schema:name "Elicit WebID/NetID verification service selection before mTLS verification"@en ;
+    schema:text "When the user asks to verify a WebID or NetID via a remote service, elicit which service to use from the known open list (netid-qa.openlinksw.com:9443/webid/, ods-qa.openlinksw.com/webid/, linkeddata.uriburner.com/webid/, demo.openlinksw.com/webid/, and others added over time); if the user names a service in their prompt, honor it without re-eliciting."@en ;
+    onto:hasTrigger onto:triggerPreferencesUpdate, onto:triggerSkillInvocation ;
+    rdfs:seeAlso <howto/webid-verification-services.ttl> .
+
+:topicWebidVerificationServices a schema:Thing ;
+    schema:name "WebID/NetID Verification Service Selection"@en ;
+    schema:description "Rules for eliciting and executing WebID/NetID verification against OpenLink's mTLS verification services. Known services: netid-qa.openlinksw.com:9443/webid/, ods-qa.openlinksw.com/webid/, linkeddata.uriburner.com/webid/, demo.openlinksw.com/webid/. List is open and extensible. Selection is always elicited unless the user names a service in their prompt."@en ;
+    rdfs:seeAlso <howto/webid-verification-services.ttl> .
+
+# ── Step 83: whoami owl:sameAs as hyperlinks ──────────────────────────────────
+
+:step-whoamiSameAsHyperlinks a schema:HowToStep ;
+    schema:position 83 ;
+    schema:name "Emit owl:sameAs values in whoami as Markdown hyperlinks sourced from the user's WebID index.html rel=me links"@en ;
+    schema:text "Before emitting the whoami User section, grep the user's WebID index.html for <link rel='me'> entries and emit each as a Markdown hyperlink [Title](URL) — never as prose platform categories."@en ;
+    onto:hasTrigger onto:triggerWhoamiQuery ;
+    rdfs:seeAlso <howto/agent-identity.ttl> .
+
+:topicWhoamiSameAsHyperlinks a schema:Thing ;
+    schema:name "whoami owl:sameAs as Markdown hyperlinks"@en ;
+    schema:description "The owl:sameAs bullet in the whoami User section must list each platform identity as a Markdown hyperlink [Title](URL), sourced at runtime by grepping <link rel='me'> entries from the user's WebID index.html. Prose descriptions of platform categories are not acceptable."@en .

--- a/agent-rdf-memory/preferences.ttl
+++ b/agent-rdf-memory/preferences.ttl
@@ -10,7 +10,7 @@
 <> a schema:CreativeWork ;
     schema:name "preferences.ttl"@en ;
     schema:description "Configuration for agent RDF memory management and semantic memory skill usage." ;
-    schema:dateModified "2026-06-25T20:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-26T12:00:00Z"^^xsd:dateTime ;
     schema:dateCreated "2026-05-29T17:22:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :agentBehaviorGuide .

--- a/agent-rdf-memory/scripts/fill_core_template.py
+++ b/agent-rdf-memory/scripts/fill_core_template.py
@@ -67,7 +67,7 @@ _MODEL_OUTPUT_ROOTS: dict[str, str] = {
     "gpt5":             "/Users/kidehen/Documents/LLMs/GPT5-Chat-Generated/",
     "gpt5_chat":        "/Users/kidehen/Documents/LLMs/GPT5-Chat-Generated/",
     "qwen":             "/Users/kidehen/Documents/LLMs/Alibaba Qwen/",
-    "glm":              "/Users/kidehen/Documents/LLMs/GLM/",
+    "glm":              "/Users/kidehen/Documents/LLMs/glm/",
     "big_pickle":       "/Users/kidehen/Documents/LLMs/Big Pickle/",
 }
 

--- a/agent-rdf-memory/scripts/fill_core_template.ts
+++ b/agent-rdf-memory/scripts/fill_core_template.ts
@@ -28,7 +28,7 @@ const MODEL_OUTPUT_ROOTS: Record<string, string> = {
   gpt5:            "/Users/kidehen/Documents/LLMs/GPT5-Chat-Generated/",
   gpt5_chat:       "/Users/kidehen/Documents/LLMs/GPT5-Chat-Generated/",
   qwen:            "/Users/kidehen/Documents/LLMs/Alibaba Qwen/",
-  glm:             "/Users/kidehen/Documents/LLMs/GLM/",
+  glm:             "/Users/kidehen/Documents/LLMs/glm/",
   big_pickle:      "/Users/kidehen/Documents/LLMs/Big Pickle/",
 };
 


### PR DESCRIPTION
## Summary

- **Step 83 — whoami owl:sameAs as hyperlinks**: `owl:sameAs` bullet in the `whoami` User section now greps `<link rel="me">` entries from the user's WebID `index.html` at runtime and emits each as a Markdown hyperlink `[Title](URL)` — prose platform-category descriptions are no longer acceptable.
- **Step 82 — WebID/NetID verification service gate**: before running mTLS verification, elicit the service from a known open list (`netid-qa.openlinksw.com:9443/webid/`, `ods-qa.openlinksw.com/webid/`, `linkeddata.uriburner.com/webid/`, `demo.openlinksw.com/webid/`); if the user names a service in their prompt, honour it without re-eliciting.
- **GLM output path**: registered lowercase `glm/` as the canonical output path for GLM-5.1/5.2 sessions; corrected `fill_core_template.{py,ts}` from `GLM/` → `glm/`.
- **New howto files**: `webid-verification-services.ttl`, `study-prior-patterns.ttl`, `reuse-proven-patterns.ttl`.
- **Format spec alignment**: `howto/agent-identity.ttl` and `howto/verified-identity.ttl` updated to reflect the new hyperlink rule.

## Test plan

- [ ] Run `whoami?` — confirm `owl:sameAs` line emits `[LinkedIn](…) · [X](…) · …` hyperlinks, not prose
- [ ] Run WebID verification against `https://netid-qa.openlinksw.com:9443/webid/` — confirm mTLS succeeds and returns NetID + sha1 + emoji
- [ ] Confirm `fill_core_template.py` and `.ts` route GLM sessions to `/Users/kidehen/Documents/LLMs/glm/`
- [ ] Verify preferences.ttl parses as valid Turtle: `python3 -c "import rdflib; rdflib.Graph().parse('agent-rdf-memory/preferences.ttl', format='turtle'); print('OK')"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)