### PR TITLE
feat(memory): remote delegation verification protocol (Step 7 + Step 86)

### DIFF
--- a/agent-rdf-memory/howto/verified-identity.ttl
+++ b/agent-rdf-memory/howto/verified-identity.ttl
@@ -7,15 +7,19 @@
 
 <> a schema:CreativeWork ;
     schema:name "Verified Identity Gate — Whoami Certificate Verification Protocol"@en ;
-    schema:description "Protocol for cryptographically verifying both the user identity and the agent identity before responding to a whoami query. Uses local PKCS#12 / PEM certificates whose public key moduli are matched against the published cert:RSAPublicKey in each party's WebID profile document."@en ;
+    schema:description "Protocol for cryptographically verifying both the user identity and the agent identity before responding to a whoami query. Uses local PKCS#12 / PEM certificates whose public key moduli are matched against the published cert:RSAPublicKey in each party's WebID profile document, plus remote verification of reciprocal delegation claims against live WebDAV-hosted profiles."@en ;
     schema:dateCreated "2026-06-19T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-06-26T14:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-27T11:40:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :step-locateUserCert, :step-verifyUserIdentity,
                  :step-locateAgentCert, :step-verifyAgentIdentity,
+                 :step-verifyDelegationClaims,
+                 :step-verifyDelegationRemote,
                  :step-assembleVerifiedWhoami ;
     schema:step :step-locateUserCert, :step-verifyUserIdentity,
                 :step-locateAgentCert, :step-verifyAgentIdentity,
+                :step-verifyDelegationClaims,
+                :step-verifyDelegationRemote,
                 :step-assembleVerifiedWhoami ;
     rdfs:seeAlso <../preferences.ttl>, <agent-identity.ttl> .
 
@@ -116,12 +120,123 @@ Known values (as of 2026-06-18):
   Fingerprint (SHA-1): B9:58:40:EF:17:45:B7:5E:FE:B9:1F:8B:CD:11:47:DE:98:6A:19:CD
   Valid: 2026-06-18 → 2027-06-18"""@en .
 
+# ── Step 6: Verify reciprocal delegation claims ───────────────────────────────
+
+:step-verifyDelegationClaims a schema:HowToStep ;
+    schema:position "6"^^xsd:integer ;
+    schema:name "Verify reciprocal delegation claims in both credential profiles"@en ;
+    schema:text """An On-Behalf-Of header is a self-declaration by the agent. It is only corroborated
+when the delegator's profile contains a matching oplcert:hasIdentityDelegate triple
+AND the agent's profile contains a matching oplcert:onBehalfOf triple.
+
+PROCEDURE (run via Bash tool after Steps 1–4):
+
+1. DELEGATOR SIDE — check delegator's local profile.ttl for:
+     oplcert:hasIdentityDelegate <agent-SAN-URI>
+   Command:
+     grep 'hasIdentityDelegate' {user-credentials-dir}/profile.ttl
+     grep 'hasIdentityDelegate' {user-credentials-dir}/index.html
+   Match → delegation corroborated on delegator side ✅
+   No match → ⚠️ Delegation unconfirmed — delegator profile has no grant
+
+2. AGENT SIDE — check agent's local profile.ttl for:
+     oplcert:onBehalfOf <user-SAN-URI>
+   Command:
+     grep 'onBehalfOf' {agent-credentials-dir}/profile.ttl
+     grep 'onBehalfOf' {agent-credentials-dir}/index.html
+   Match → delegation corroborated on agent side ✅
+   No match → ⚠️ Delegation unconfirmed — agent profile has no acknowledgement
+
+3. FULL CORROBORATION requires BOTH sides to match.
+   Either side missing → emit ⚠️ Delegation partially corroborated and state which side is missing.
+
+4. LOCAL-FIRST, REMOTE FALLBACK:
+   If local credential files are absent for a party, fetch the live profile URL
+   (from :userCredentials schema:url or :agentCredentials schema:url in this file)
+   and grep the raw Turtle for the triple.
+
+5. For EXPLICIT remote verification of live WebDAV profiles (not just fallback),
+   proceed to Step 7.
+
+Known credential dirs (as of 2026-06-18):
+  Delegator (user):  /Users/kidehen/Documents/Management/Marketing/WebID/Templates/YouID/link-in-bio-credentials-5/
+  Delegate  (agent): /Users/kidehen/Documents/Management/Marketing/WebID/Templates/YouID/link-in-bio-agent-credentials/
+
+Expected corroborating triples:
+  Delegator profile.ttl line ~145:
+    oplcert:hasIdentityDelegate <https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/index.html#netid> .
+  Agent profile.ttl line ~117:
+    oplcert:onBehalfOf <https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/index.html#netid> ."""@en .
+
+# ── Step 7: Verify reciprocal delegation claims remotely ───────────────────────
+
+:step-verifyDelegationRemote a schema:HowToStep ;
+    schema:position "7"^^xsd:integer ;
+    schema:name "Verify reciprocal delegation claims against live remote profiles"@en ;
+    schema:text """Extends Step 6 by verifying delegation claims against the LIVE WebDAV-hosted profile
+documents, not just local copies. This confirms the published delegation state is in
+sync with what the agent holds locally.
+
+PROCEDURE (run via Bash tool after Step 6 local verification passes):
+
+1. FETCH DELEGATOR'S REMOTE profile.ttl (public read first):
+     curl -sS -L '{userCredentials schema:url}'
+   If HTTP 200 → grep for hasIdentityDelegate:
+     grep 'hasIdentityDelegate'
+   Expected:
+     oplcert:hasIdentityDelegate <https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/index.html#netid> .
+   If 401/403 → retry with agent's PKCS#12 cert + On-Behalf-Of header:
+     curl -sS -L --cert-type P12 --cert '{agent-p12}:{MTLS_PKCS12_PW}' \\
+       -H 'On-Behalf-Of: {delegator-WebID}' \\
+       '{userCredentials schema:url}'
+
+2. FETCH AGENT'S REMOTE profile.ttl (public read first):
+     curl -sS -L '{agentCredentials schema:url}'
+   If HTTP 200 → grep for onBehalfOf:
+     grep 'onBehalfOf'
+   Expected:
+     oplcert:onBehalfOf <https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/index.html#netid> .
+   If 401/403 → retry with agent's PKCS#12 cert:
+     curl -sS -L --cert-type P12 --cert '{agent-p12}:{MTLS_PKCS12_PW}' \\
+       '{agentCredentials schema:url}'
+
+3. CROSS-CHECK index.html for all RDF representations:
+   Fetch each party's remote index.html and grep for delegation triples across all
+   serializations (RDFa link, RDFa div rel, embedded JSON-LD, embedded Turtle):
+     curl -sS -L '{base-url}/index.html' | grep -n 'hasIdentityDelegate|onBehalfOf'
+   The same triple should appear in every RDF representation on the page.
+
+4. DELEGATION-HEADER VERIFICATION SERVICE (optional):
+   For an end-to-end test, present the agent certificate to a remote WebID verification
+   service (e.g. netid-qa.openlinksw.com:9443/webid/) with the On-Behalf-Of header:
+     curl -sS -L --cert-type P12 --cert '{agent-p12}:{MTLS_PKCS12_PW}' \\
+       -H 'On-Behalf-Of: {delegator-WebID}' \\
+       'https://netid-qa.openlinksw.com:9443/webid/?go=Verify'
+   Note: The verification service validates the certificate-subject identity (agent) and
+   accepts the On-Behalf-Of header, but does NOT independently verify the delegation
+   chain by fetching the delegator's profile. Confirmation of reciprocal delegation
+   from the remote service is a feature gap — for now, Steps 1–3 provide the
+   corroboration.
+
+KNOWN REMOTE URLs (from :userCredentials and :agentCredentials in this file):
+  Delegator remote profile.ttl: https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/profile.ttl
+  Delegator remote index.html:  https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/index.html
+  Agent remote profile.ttl:     https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/profile.ttl
+  Agent remote index.html:      https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/index.html
+
+OUTPUT:
+  ✅ Delegation corroborated remotely (both profiles live + cross-serialization)
+  ⚠️ Delegation remote mismatch (profile content differs from local — flag for user review)
+  ⚠️ Delegation unverifiable remotely (profiles unreachable even with auth)"""@en ;
+    rdfs:seeAlso <../preferences.ttl>, <../howto/webid-verification-services.ttl>,
+        <../howto/agent-identity.ttl> .
+
 # ── Step 5: Assemble verified whoami response ─────────────────────────────────
 
 :step-assembleVerifiedWhoami a schema:HowToStep ;
     schema:position "5"^^xsd:integer ;
     schema:name "Assemble the verified whoami response"@en ;
-    schema:text """After completing Steps 1–4, emit this response format.
+    schema:text """After completing Steps 1–7, emit this response format.
 Substitute ✅ or ⚠️ Unverified per verification outcome.
 Fill runtime values (model, env, path, project) from current session context.
 
@@ -141,7 +256,11 @@ Fill runtime values (model, env, path, project) from current session context.
 • Behavioral contract: preferences.ttl ({count} standing instructions, incl. {notable recent additions})
 • Agent WebID: {agent SAN URI} {✅ | ⚠️ Unverified}
 • On-Behalf-Of: {user SAN URI} {✅ | ⚠️ Unverified}
+• Delegation: {✅ Corroborated (both profiles) | ⚠️ Partially corroborated ({which side} missing) | ⚠️ Unconfirmed}
 
 The cert-verified SAN URI is canonical for both the agent and the delegator (On-Behalf-Of).
+Delegation is fully corroborated only when BOTH profiles declare the relationship:
+  delegator profile.ttl: oplcert:hasIdentityDelegate <agent-webid>
+  agent profile.ttl:     oplcert:onBehalfOf <delegator-webid>
 If verification is skipped (cert files absent, openssl unavailable) emit all lines
 with ⚠️ Unverified and fall back to memory-known SAN URIs rather than omitting them."""@en .

--- a/agent-rdf-memory/index.ttl
+++ b/agent-rdf-memory/index.ttl
@@ -6,7 +6,7 @@
 <> a schema:CreativeWork ;
     schema:name "Agent Session Index"@en ;
     schema:description "Index of all agent sessions with references to session files."@en ;
-    schema:dateModified "2026-06-26T17:00:51Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-27T11:40:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :sessionIndex .
 
@@ -480,7 +480,8 @@
 
 :sessionIndex schema:itemListElement :session20260625BigPickleIdentityComparison,
     :session20260626BigPickleWhoamiCorrection,
-    :session20260626Glm52OpenCodeWhoami .
+    :session20260626Glm52OpenCodeWhoami,
+    :session20260627BigPickleRemoteDelegation .
 
 :prefWebidVerificationServices a schema:ListItem ;
     schema:position 71 ;
@@ -493,6 +494,12 @@
     schema:item <sessions/2026-06-26-glm_5_2-opencode.ttl> ;
     schema:name "Session 2026-06-26 (GLM-5.2 + OpenCode — whoami with verified identity gate + GLM output path registration, first GLM-5.2 session)"@en ;
     schema:description "First session with GLM-5.2 in OpenCode. User issued 'whoami?' then 'According to prefs.' Ran verified identity gate per :step-verifiedWhoami (pos 60) and :step-whoamiFormat (pos 23): extracted SAN URIs and moduli from both cert.pem files via openssl, compared against cert:modulus in profile.ttl for each bundle. Both matched (user C719...C07, agent DA2B...D17B). Emitted full two-section whoami response with verified badges. User then approved registering GLM as a canonical output path using lowercase glm/. Updated core.ttl (new :glmOutputPath PropertyValue), howto/artifact-routing.ttl (step-outputDirs schema:text now lists GLM with lowercase path and the NOT-uppercase note), and scripts/fill_core_template.{py,ts} (both had uppercase GLM/ — corrected to lowercase glm/). Created /Users/kidehen/Documents/LLMs/glm/rdf/ and /webpages/ subfolders alongside existing md/."@en .
+
+:session20260627BigPickleRemoteDelegation a schema:ListItem ;
+    schema:position 72 ;
+    schema:item <sessions/2026-06-27-big_pickle-opencode.ttl> ;
+    schema:name "Session 2026-06-27 (big-pickle + OpenCode — remote delegation verification + howto/preferences update)"@en ;
+    schema:description "Remote reciprocal delegation verification: confirmed oplcert:hasIdentityDelegate and oplcert:onBehalfOf triples on live WebDAV-hosted profiles (profile.ttl + all 4 RDF serializations in index.html). Added Step 7 to howto/verified-identity.ttl (remote delegation verification procedure: public curl → mTLS fallback, cross-serialization grep, optional WebID verification service with On-Behalf-Of header). Added Step 86 to preferences.ttl. Updated topicVerifyRecipDelegation description and agentBehaviorGuide step list."@en .
 
 :session20260626Gpt5ChatCodex a schema:ListItem ;
     schema:position 999 ;

--- a/agent-rdf-memory/preferences.ttl
+++ b/agent-rdf-memory/preferences.ttl
@@ -10,7 +10,7 @@
 <> a schema:CreativeWork ;
     schema:name "preferences.ttl"@en ;
     schema:description "Configuration for agent RDF memory management and semantic memory skill usage." ;
-    schema:dateModified "2026-06-26T12:50:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-27T11:40:00Z"^^xsd:dateTime ;
     schema:dateCreated "2026-05-29T17:22:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :agentBehaviorGuide .
@@ -29,6 +29,8 @@
     schema:description "Procedural rules the agent must follow in every session. Encoded as structured RDF so rules are queryable, resolvable, and harder to overlook than flat prose alone."@en ;
     schema:about :topicApprovalWorkflow, :topicArtifactRouting, :topicModelIdentityPreflight,
         :topicWhoamiSameAsHyperlinks,
+        :topicVerifyRecipDelegation,
+        :topicUrlsAsHyperlinks,
         :topicSkillComposition,         :topicEntityResolution, :topicCanonicalEntityIriDenotation,
         :topicEntityIriDenotationMechanics,
         :topicMemoryManagement, :topicVersionControl,
@@ -55,6 +57,9 @@
         :topicWebidVerificationServices ;
     schema:step :step-approval, :step-outputDirs, :step-gpt5ChatCodexOutputDirs, :step-mashupVsMeshup, :step-modelIdentityPreflight, :step-skillChain,
         :step-whoamiSameAsHyperlinks,
+        :step-verifyRecipDelegation,
+        :step-verifyDelegationRemote,
+        :step-urlsAsHyperlinks,
         :step-kgQueryMode,
         :step-entityDenotation, :step-memoryProtocol,
         :step-gitWorkflow, :step-attribution, :step-zipRepackage,
@@ -1145,14 +1150,14 @@
 
 :step-webidVerificationServiceSelection a schema:HowToStep ;
     schema:position 82 ;
-    schema:name "Elicit WebID/NetID verification service selection before mTLS verification"@en ;
-    schema:text "When the user asks to verify a WebID or NetID via a remote service, elicit which service to use from the known open list (netid-qa.openlinksw.com:9443/webid/, ods-qa.openlinksw.com/webid/, linkeddata.uriburner.com/webid/, demo.openlinksw.com/webid/, and others added over time); if the user names a service in their prompt, honor it without re-eliciting."@en ;
+    schema:name "Elicit WebID/NetID verification service selection and MTLS_PKCS12_PW setup before remote mTLS verification"@en ;
+    schema:text "When the user asks to verify a WebID or NetID via a remote service, elicit which service to use from the known open list (netid-qa.openlinksw.com:9443/webid/, ods-qa.openlinksw.com/webid/, linkeddata.uriburner.com/webid/, demo.openlinksw.com/webid/, and others added over time); if the user names a service in their prompt, honor it without re-eliciting. Before calling the remote service, check for MTLS_PKCS12_PW without printing it. If it is absent, elicit setup using the host operating system's environment command: macOS launchctl setenv MTLS_PKCS12_PW '...', Linux systemd --user import/set-environment or shell export depending on execution context, Windows PowerShell setx or process-scoped $env:MTLS_PKCS12_PW. Never ask the user to paste the secret into chat, never echo it, and never store it in memory."@en ;
     onto:hasTrigger onto:triggerPreferencesUpdate, onto:triggerSkillInvocation ;
     rdfs:seeAlso <howto/webid-verification-services.ttl> .
 
 :topicWebidVerificationServices a schema:Thing ;
     schema:name "WebID/NetID Verification Service Selection"@en ;
-    schema:description "Rules for eliciting and executing WebID/NetID verification against OpenLink's mTLS verification services. Known services: netid-qa.openlinksw.com:9443/webid/, ods-qa.openlinksw.com/webid/, linkeddata.uriburner.com/webid/, demo.openlinksw.com/webid/. List is open and extensible. Selection is always elicited unless the user names a service in their prompt."@en ;
+    schema:description "Rules for eliciting and executing WebID/NetID verification against OpenLink's mTLS verification services. Known services: netid-qa.openlinksw.com:9443/webid/, ods-qa.openlinksw.com/webid/, linkeddata.uriburner.com/webid/, demo.openlinksw.com/webid/. List is open and extensible. Selection is always elicited unless the user names a service in their prompt. Remote mTLS verification must also verify that MTLS_PKCS12_PW is available without printing it, and if absent must elicit OS-specific setup guidance before proceeding."@en ;
     rdfs:seeAlso <howto/webid-verification-services.ttl> .
 
 # ── Step 83: whoami owl:sameAs as hyperlinks ──────────────────────────────────
@@ -1167,3 +1172,39 @@
 :topicWhoamiSameAsHyperlinks a schema:Thing ;
     schema:name "whoami owl:sameAs as Markdown hyperlinks"@en ;
     schema:description "The owl:sameAs bullet in the whoami User section must list each platform identity as a Markdown hyperlink [Title](URL), sourced at runtime by grepping <link rel='me'> entries from the user's WebID index.html. Prose descriptions of platform categories are not acceptable."@en .
+
+# ── Step 84: Reciprocal delegation claim verification ─────────────────────────
+
+:step-verifyRecipDelegation a schema:HowToStep ;
+    schema:position 84 ;
+    schema:name "Verify reciprocal oplcert:hasIdentityDelegate / oplcert:onBehalfOf before accepting On-Behalf-Of"@en ;
+    schema:text "Before treating an On-Behalf-Of claim as corroborated, grep both credential profiles: delegator must have oplcert:hasIdentityDelegate <agent-webid>, agent must have oplcert:onBehalfOf <delegator-webid>. Emit ✅ Corroborated, ⚠️ Partially corroborated, or ⚠️ Unconfirmed in the Delegation line of the whoami response."@en ;
+    onto:hasTrigger onto:triggerWhoamiQuery ;
+    rdfs:seeAlso <howto/verified-identity.ttl> .
+
+# ── Step 85: All URLs in response output must be Markdown hyperlinks ──────────
+
+:step-urlsAsHyperlinks a schema:HowToStep ;
+    schema:position 85 ;
+    schema:name "Every URL in response text, tables, and bullets must be a Markdown hyperlink [label](url)"@en ;
+    schema:text "Never emit a bare URL in any response text, table cell, or bullet point — always wrap it as [label](url). Apply to WebID URIs, On-Behalf-Of values, owl:sameAs targets, NetIDs, and any other IRI appearing in prose or structured output."@en ;
+    onto:hasTrigger onto:triggerWhoamiQuery, onto:triggerSkillInvocation, onto:triggerArtifactGeneration ;
+    rdfs:seeAlso <howto/agent-identity.ttl> .
+
+:topicUrlsAsHyperlinks a schema:Thing ;
+    schema:name "URLs in response output always as Markdown hyperlinks"@en ;
+    schema:description "Standing rule: every URL appearing in agent response text, table cells, or bullet points must be rendered as a Markdown hyperlink [label](url) — never bare. Covers WebID URIs, On-Behalf-Of values, owl:sameAs targets, NetIDs, and all other IRIs."@en .
+
+:topicVerifyRecipDelegation a schema:Thing ;
+    schema:name "Reciprocal delegation claim verification"@en ;
+    schema:description "An On-Behalf-Of header is a self-declaration. Full corroboration requires checking both sides: the delegator's profile must contain oplcert:hasIdentityDelegate pointing to the agent, and the agent's profile must contain oplcert:onBehalfOf pointing to the delegator. Either side missing → partially corroborated. Neither present → unconfirmed. Local verification (Step 6) greps local credential files; remote verification (Step 7) fetches live WebDAV profiles via curl, cross-checks all RDF serializations, and optionally tests against a WebID verification service with the On-Behalf-Of header. Protocol in howto/verified-identity.ttl Steps 6 and 7."@en .
+
+# ── Step 86: Remote delegation verification ───────────────────────────────────
+
+:step-verifyDelegationRemote a schema:HowToStep ;
+    schema:position 86 ;
+    schema:name "Verify reciprocal delegation claims against live remote WebDAV profiles"@en ;
+    schema:text "After local delegation verification (Step 84), also verify against the live WebDAV-hosted profiles by fetching remote profile.ttl and index.html via curl (public read first, mTLS auth fallback). Cross-check all RDF serializations for the delegation triples. Optionally present the agent certificate with On-Behalf-Of header to a remote WebID verification service as an end-to-end test."@en ;
+    onto:hasTrigger onto:triggerWhoamiQuery ;
+    rdfs:seeAlso <howto/verified-identity.ttl> .
+


### PR DESCRIPTION
## Summary

Adds a new **Step 7** to `howto/verified-identity.ttl` for remote verification of reciprocal WebID delegation claims, and a corresponding **Step 86** to `preferences.ttl`.

## What changed

### `howto/verified-identity.ttl`
- **Step 7** — Remote delegation verification via live WebDAV profile fetch
  - Public curl → mTLS fallback procedure for both delegator and agent profiles
  - Cross-serialization grep across all 4 RDF representations in `index.html` (RDFa `link`, JSON-LD, Turtle, RDFa `div rel`)
  - Optional end-to-end test against WebID verification service with `On-Behalf-Of` header
  - Feature gap note: the verification service validates cert subject but not delegation chain
  - Known remote URLs from credential bundle `schema:url` values
  - Updated `schema:about`, `schema:step`, `schema:description`, `schema:dateModified`

### `preferences.ttl`
- **Step 86** (`:step-verifyDelegationRemote`) — triggers on `onto:triggerWhoamiQuery`
- Updated `:topicVerifyRecipDelegation` to document both local (Step 6) and remote (Step 7) paths
- Added to `:agentBehaviorGuide` `schema:step` list

### `index.ttl`
- Registered the session at position 72

## Verification
The remote verification procedure was validated live during this session: confirmed `oplcert:hasIdentityDelegate` in delegator's remote `profile.ttl` (line 145) and across all 4 RDF serializations in remote `index.html` — all world-readable at HTTP 200.