### PR TITLE
feat(memory): include cert details in User and Agent whoami sections

### DIFF
--- a/agent-rdf-memory/howto/agent-identity.ttl
+++ b/agent-rdf-memory/howto/agent-identity.ttl
@@ -7,7 +7,7 @@
     schema:name "Agent Identity — Whoami Format, Verified Identity Gate, and Stripe Sandbox Card"@en ;
     schema:description "Rules for agent identity presentation: the canonical two-section bullet response to whoami (with verified identity lines for both user and agent), the certificate verification gate that runs before composing the response, and the Stripe sandbox card credentials for ACP test payments."@en ;
     schema:dateCreated "2026-06-05T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-06-26T14:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-30T12:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :step-whoamiFormat, :step-verifiedIdentityGate, :step-stripeSandboxCard ;
     schema:step :step-whoamiFormat, :step-verifiedIdentityGate, :step-stripeSandboxCard ;
@@ -35,6 +35,7 @@ After running the appropriate trigger, respond in this format:
 • Email: kidehen@openlinksw.com
 • Role: Founder & CEO, OpenLink Software
 • WebID: {user SAN URI} {✅ | ⚠️ Unverified}
+• User cert: {subject} · {SHA-256 fingerprint} · {validFrom → validTo} · modulus {✅ match | ⚠️ mismatch} with profile.ttl (omitted if no local credential files found)
 • owl:sameAs: grep <link rel="me"> from {user WebID index.html path} and emit each as [Title](URL). Example output:
   [LinkedIn](https://www.linkedin.com/in/kidehen#this) · [X](https://x.com/kidehen) · [Substack](https://substack.com/@kidehen) · [Mastodon](https://mastodon.social/@kidehen) · [Bluesky](https://bsky.app/profile/kidehen.bsky.social) · [Threads](https://www.threads.net/@kidehen) · [GitHub](https://github.com/kidehen) · [Linktree](https://linktr.ee/kidehen) · [ID.MyOpenLink.NET](https://id.myopenlink.net/~KingsleyUyiIdehen/Public/) · [Carrd](https://kidehen.carrd.co/) · [Glitch](https://glitch.com/~kidehen) · [Facebook](https://facebook.com/kidehen) · [Instagram](https://www.instagram.com/kidehen) · [TikTok](https://www.tiktok.com/@kidehen) · [RSS](https://www.openlinksw.com/data/podcasts/?a=rss) · [Atom](https://www.openlinksw.com/data/podcasts/?a=atom) · [Email](mailto:kidehen@openlinksw.com)
   Never substitute prose platform-category descriptions for the actual hyperlinked URIs.
@@ -47,7 +48,9 @@ After running the appropriate trigger, respond in this format:
 • Memory store: {absolute path to agent-rdf-memory/}
 • Behavioral contract: preferences.ttl ({count} standing instructions, incl. {notable recent additions})
 • Agent WebID: {agent SAN URI} {✅ | ⚠️ Unverified}
+• Agent cert: {subject} · {SHA-256 fingerprint} · {validFrom → validTo} · modulus {✅ match | ⚠️ mismatch} with profile.ttl
 • On-Behalf-Of: {user SAN URI} {✅ | ⚠️ Unverified}
+• Delegation: {✅ Corroborated (both profiles) | ⚠️ Partially corroborated ({which side} missing) | ⚠️ Unconfirmed}
 
 **For Trigger B ("who are you?") — Agent-only, no badges:**
 
@@ -59,6 +62,7 @@ After running the appropriate trigger, respond in this format:
 • Memory store: {absolute path to agent-rdf-memory/}
 • Behavioral contract: preferences.ttl ({count} standing instructions, incl. {notable recent additions})
 • Agent WebID: {agent SAN URI}
+• Agent cert: {subject} · {SHA-256 fingerprint} · {validFrom → validTo} (omitted if no local credential files found)
 • On-Behalf-Of: {user SAN URI}
 
 (Omit ✅/⚠ badges — no cert verification for Trigger B. Omit the User section entirely.)

--- a/agent-rdf-memory/howto/verified-identity.ttl
+++ b/agent-rdf-memory/howto/verified-identity.ttl
@@ -9,7 +9,7 @@
     schema:name "Verified Identity Gate — Whoami Certificate Verification Protocol"@en ;
     schema:description "Protocol for cryptographically verifying both the user identity and the agent identity before responding to a whoami query. Uses local PKCS#12 / PEM certificates whose public key moduli are matched against the published cert:RSAPublicKey in each party's WebID profile document, plus remote verification of reciprocal delegation claims against live WebDAV-hosted profiles."@en ;
     schema:dateCreated "2026-06-19T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-06-27T11:40:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-27T12:40:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :step-locateUserCert, :step-verifyUserIdentity,
                  :step-locateAgentCert, :step-verifyAgentIdentity,
@@ -208,10 +208,10 @@ PROCEDURE (run via Bash tool after Step 6 local verification passes):
 
 4. DELEGATION-HEADER VERIFICATION SERVICE (optional):
    For an end-to-end test, present the agent certificate to a remote WebID verification
-   service (e.g. netid-qa.openlinksw.com:9443/webid/) with the On-Behalf-Of header:
-     curl -sS -L --cert-type P12 --cert '{agent-p12}:{MTLS_PKCS12_PW}' \\
-       -H 'On-Behalf-Of: {delegator-WebID}' \\
-       'https://netid-qa.openlinksw.com:9443/webid/?go=Verify'
+    service (e.g. ods-qa.openlinksw.com:5443/webid/) with the On-Behalf-Of header:
+      curl -sS -L --cert-type P12 --cert '{agent-p12}:{MTLS_PKCS12_PW}' \
+        -H 'On-Behalf-Of: {delegator-WebID}' \
+        'https://ods-qa.openlinksw.com:5443/webid/?go=Verify'
    Note: The verification service validates the certificate-subject identity (agent) and
    accepts the On-Behalf-Of header, but does NOT independently verify the delegation
    chain by fetching the delegator's profile. Confirmation of reciprocal delegation

--- a/agent-rdf-memory/howto/webid-verification-services.ttl
+++ b/agent-rdf-memory/howto/webid-verification-services.ttl
@@ -5,9 +5,9 @@
 
 <> a schema:HowTo ;
     schema:name "WebID/NetID Verification Service Selection — Elicit Before mTLS Verification"@en ;
-    schema:description "Rules for handling WebID/NetID verification requests. Lists known mTLS verification services and mandates user elicitation before selecting one, since the list is open and will grow over time."@en ;
+    schema:description "Rules for handling WebID/NetID verification requests. Lists known mTLS verification services, mandates user elicitation before selecting one, and requires secret-safe MTLS_PKCS12_PW setup before remote mTLS verification."@en ;
     schema:dateCreated "2026-06-26T12:50:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-06-26T12:50:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-27T12:40:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :step-webidVerificationServiceSelection, :topicWebidVerificationServices ;
     schema:step :step-webidVerificationServiceSelection ;
@@ -17,24 +17,55 @@
 
 :step-webidVerificationServiceSelection a schema:HowToStep ;
     schema:position "1"^^xsd:integer ;
-    schema:name "Elicit WebID/NetID verification service selection before mTLS verification"@en ;
+    schema:name "Elicit WebID/NetID verification service selection and MTLS_PKCS12_PW setup before mTLS verification"@en ;
     schema:text """When the user asks to verify a WebID or NetID via a remote verification service, ALWAYS elicit which service to use before issuing the mTLS curl. Do not default to a single service. Present the known services list (below) and let the user choose. If the user names a service explicitly in their prompt, honor that choice without re-eliciting (same principle as skill protocol routing).
 
 KNOWN SERVICES (open list — more will be added over time):
-  1. https://netid-qa.openlinksw.com:9443/webid/  — NetID QA, mTLS on port 9443, supports WebID+TLS and NetID+TLS, accepts URI schemes: acct, http(s), ldap, mailto, bitcoin, ethereum. Returns HTML with NetID, timestamp, sha1 digest, emoji.
-  2. https://ods-qa.openlinksw.com/webid/         — ODS QA instance.
-  3. https://linkeddata.uriburner.com/webid/      — URIBurner (production, public).
-  4. https://demo.openlinksw.com/webid/           — OpenLink demo instance.
+   1. https://ods-qa.openlinksw.com:5443/webid/   — ODS QA, mTLS on port 5443, supports WebID+TLS and NetID+TLS, accepts URI schemes: acct, http(s), ldap, mailto, bitcoin, ethereum. Returns HTML with NetID, timestamp, sha1 digest, emoji.
+   2. https://linkeddata.uriburner.com/webid/      — URIBurner (production, public).
+   3. https://demo.openlinksw.com/webid/           — OpenLink demo instance.
 
 ELICITATION FORMAT:
-  Ask the user which service to use, presenting the numbered list above. If the user has already named a service in their prompt (e.g., 'verify using https://netid-qa.openlinksw.com:9443/webid/'), skip elicitation and use the named service.
+  Ask the user which service to use, presenting the numbered list above. If the user has already named a service in their prompt (e.g., 'verify using https://ods-qa.openlinksw.com:5443/webid/'), skip elicitation and use the named service.
+
+PKCS#12 PASSWORD ENVIRONMENT GATE:
+  Before calling any remote WebID/NetID verification service, check for MTLS_PKCS12_PW without printing the value:
+    - First check the current process environment.
+    - If macOS, also check launchd with: launchctl getenv MTLS_PKCS12_PW
+    - Treat MTLS_PKCS12_PWD as a legacy alias only when a skill or existing environment already uses it; prefer MTLS_PKCS12_PW for this remote verification workflow.
+
+  If MTLS_PKCS12_PW is absent, elicit secret setup using the host operating system. Never ask the user to paste the password into chat. Provide the command appropriate to the runtime OS:
+    - macOS GUI / launchd-launched agents:
+        launchctl setenv MTLS_PKCS12_PW 'your-password'
+      Then ask the user to restart the agent process if the current process still cannot see the variable.
+
+    - Linux shell-launched session:
+        export MTLS_PKCS12_PW='your-password'
+      Run the agent from that same shell, or otherwise inject the variable into the service manager that launches it.
+
+    - Linux systemd user service:
+        systemctl --user set-environment MTLS_PKCS12_PW='your-password'
+      Restart the relevant user service/session before retrying.
+
+    - Windows PowerShell, current process only:
+        $env:MTLS_PKCS12_PW = 'your-password'
+      Start the agent from that PowerShell session.
+
+    - Windows persistent user environment:
+        setx MTLS_PKCS12_PW 'your-password'
+      Restart the agent process before retrying.
+
+  After setup, validate the PKCS#12 bundle with openssl using the variable, redirecting certificate-validation output as needed so the password is never echoed. Report only presence/validation status, not the value.
 
 EXECUTION (per service):
   - All listed services use mTLS (client certificate authentication).
-  - Extract a temporary combined PEM (cert + private key) from the user's cert.p12 using the passphrase (per :step-curlAuth and :step-secretEchoRedaction — never echo the passphrase).
-  - curl -sS -L --cert {tmpPEM} '{serviceURL}?go=Verify'
+  - Prefer direct curl PKCS#12 usage when supported:
+      curl -sS -L --cert-type P12 --cert '{cert.p12}:<value from MTLS_PKCS12_PW>' '{serviceURL}?go=Verify'
+    The secret must be supplied from the environment inside the shell process, never interpolated into logs or response text.
+  - If the platform curl cannot use PKCS#12 directly, extract a temporary combined PEM (cert + private key) from the user's cert.p12 using MTLS_PKCS12_PW (per :step-curlAuth and :step-secretEchoRedaction — never echo the passphrase).
+  - If a temp PEM is created, use: curl -sS -L --cert {tmpPEM} '{serviceURL}?go=Verify'
   - The service extracts the SAN URI from the presented X.509 certificate and returns the verified NetID, timestamp, sha1 digest, and emoji.
-  - Shred the temp PEM immediately after use.
+  - Shred/remove the temp PEM immediately after use.
 
 VERIFICATION GATE INTERACTION:
   This step complements :step-verifiedWhoami (position 60) and :step-webidTlsVerification (position 23.1). Those gates verify the local cert modulus against profile.ttl cert:modulus. This step performs REMOTE verification by a trusted OpenLink verification service. Both are valid; the user may request either or both.
@@ -45,4 +76,4 @@ OPEN LIST POLICY:
 
 :topicWebidVerificationServices a schema:Thing ;
     schema:name "WebID/NetID Verification Service Selection"@en ;
-    schema:description "Rules for eliciting and executing WebID/NetID verification against OpenLink's mTLS verification services. Known services: netid-qa.openlinksw.com:9443/webid/, ods-qa.openlinksw.com/webid/, linkeddata.uriburner.com/webid/, demo.openlinksw.com/webid/. List is open and extensible. Selection is always elicited unless the user names a service in their prompt."@en .
+    schema:description "Rules for eliciting and executing WebID/NetID verification against OpenLink's mTLS verification services. Known services: ods-qa.openlinksw.com:5443/webid/, linkeddata.uriburner.com/webid/, demo.openlinksw.com/webid/. List is open and extensible. Selection is always elicited unless the user names a service in their prompt. Before remote mTLS verification, MTLS_PKCS12_PW must be checked without printing it; if absent, setup must be elicited with the command appropriate to the host operating system."@en .

--- a/agent-rdf-memory/index.ttl
+++ b/agent-rdf-memory/index.ttl
@@ -6,7 +6,7 @@
 <> a schema:CreativeWork ;
     schema:name "Agent Session Index"@en ;
     schema:description "Index of all agent sessions with references to session files."@en ;
-    schema:dateModified "2026-06-27T11:40:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-28T21:49:21Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :sessionIndex .
 
@@ -506,3 +506,18 @@
     schema:item <sessions/2026-06-26-gpt5_chat-codex.ttl> ;
     schema:name "Session 2026-06-26 (GPT-5 Chat Codex — Virtuoso 08.03.3335 KG Explorer theme/toggle fix)"@en ;
     schema:description "Regenerated canonical Virtuoso 08.03.3335 RDF/HTML artifacts after fixing KG Explorer dark-mode hyperlink colors and Firefox-safe dark/light toggle behavior; validated RDF parse, syntax, and static theme contract checks."@en .
+
+:session20260628Gpt5ChatCodexTrillionaires a schema:ListItem ;
+    schema:position 1000 ;
+    schema:item <sessions/2026-06-28-gpt5_chat-codex.ttl> ;
+    schema:name "Session 2026-06-28 (GPT-5 Chat Codex — Project Syndicate trillionaires thesis RDF/HTML collection)"@en ;
+    schema:description "Generated RDF-Turtle and HTML collection from Nabil Ahmed's Project Syndicate commentary 'How Trillionaires Are Really Made'. Artifacts written to GPT5-Chat-Generated/rdf and webpages; generator under showcases/how-trillionaires-are-really-made; validation passed for Turtle parse, harness contract, generator syntax, kgData orphan audit, inline JS syntax, and HTML link behavior."@en .
+
+:session20260630BigPickleAgentCredsWhoami a schema:ListItem ;
+    schema:position 1001 ;
+    schema:item <sessions/2026-06-30-big_pickle-opencode.ttl> ;
+    schema:name "Session 2026-06-30 (big-pickle + OpenCode — Agent verifiable credentials in whoami output)"@en ;
+    schema:description "User ruled that if Agent verifiable credentials exist, they must appear in the Agent section of whoami output (cert subject, SHA-256 fingerprint, validity, modulus match status). Updated howto/agent-identity.ttl templates (Trigger A & B) and preferences.ttl dateModified."@en .
+
+:sessionIndex schema:itemListElement :session20260630BigPickleAgentCredsWhoami,
+    :session20260628Gpt5ChatCodexTrillionaires .

--- a/agent-rdf-memory/preferences.ttl
+++ b/agent-rdf-memory/preferences.ttl
@@ -10,7 +10,7 @@
 <> a schema:CreativeWork ;
     schema:name "preferences.ttl"@en ;
     schema:description "Configuration for agent RDF memory management and semantic memory skill usage." ;
-    schema:dateModified "2026-06-27T11:40:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-06-30T12:00:00Z"^^xsd:dateTime ;
     schema:dateCreated "2026-05-29T17:22:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :agentBehaviorGuide .
@@ -54,7 +54,9 @@
         :topicOAuthAuthCodeFlow,
         :topicD3Loading,
         :topicSecretEchoRedaction,
-        :topicWebidVerificationServices ;
+        :topicWebidVerificationServices ,
+        :topicWebidVerificationTable ,
+        :topicDelegationInsertGate ;
     schema:step :step-approval, :step-outputDirs, :step-gpt5ChatCodexOutputDirs, :step-mashupVsMeshup, :step-modelIdentityPreflight, :step-skillChain,
         :step-whoamiSameAsHyperlinks,
         :step-verifyRecipDelegation,
@@ -86,7 +88,9 @@
         :step-uriburnerOAuthAuthCodeFlow,
         :step-staticD3Load, :step-singleRender,
         :step-secretEchoRedaction,
-        :step-webidVerificationServiceSelection .
+        :step-webidVerificationServiceSelection ,
+        :step-webidVerificationTable ,
+        :step-delegationInsertGate .
 
 # ── Step 1: Seek Approval ────────────────────────────────────────────────────
 
@@ -1207,4 +1211,66 @@
     schema:text "After local delegation verification (Step 84), also verify against the live WebDAV-hosted profiles by fetching remote profile.ttl and index.html via curl (public read first, mTLS auth fallback). Cross-check all RDF serializations for the delegation triples. Optionally present the agent certificate with On-Behalf-Of header to a remote WebID verification service as an end-to-end test."@en ;
     onto:hasTrigger onto:triggerWhoamiQuery ;
     rdfs:seeAlso <howto/verified-identity.ttl> .
+
+# ── Step 87: Identity Verification Table Pattern ──────────────────────────────
+
+:topicWebidVerificationTable a schema:Thing ;
+    schema:name "Identity Verification Table Pattern"@en ;
+    schema:description "Structured verification table pattern for WebID/NetID identity validation. Covers: (1) Agent cert SHA-1 fingerprint extraction from PKCS#12, (2) base verification against remote ODS webid_verify.vsp, (3) On-Behalf-Of verification with delegator WebID header, (4) cross-check of delegator profile for oplcert:hasIdentityDelegate, (5) cross-check of agent profile for oplcert:onBehalfOf across all RDF serializations (TTL, JSON-LD, HTML RDFa), (6) modulus consistency check between cert and profile documents, (7) results emitted as a verification table with rows for each check and ✅/⚠️ status columns."@en .
+
+:step-webidVerificationTable a schema:HowToStep ;
+    schema:position 87 ;
+    schema:name "Run identity verification table: cert extraction → base OBO → delegation cross-check → modulus consistency → emit table"@en ;
+    schema:text "When verifying WebID/NetID identity, follow the structured table pattern: extract SHA-1 fingerprint from PKCS#12 cert, run base and OBO verification against remote service, cross-check reciprocal delegation claims on both sides across all RDF serializations, compare cert modulus with profile documents, and emit results as a verification table."@en ;
+    onto:hasTrigger onto:triggerWhoamiQuery, onto:triggerPreferencesUpdate ;
+    rdfs:seeAlso <howto/webid-verification-table.ttl> .
+
+# ── Step 88: Preferences Presentation Format ──────────────────────────────────
+
+:topicPreferencesPresentationFormat a schema:Thing ;
+    schema:name "Preferences Presentation Format"@en ;
+    schema:description "When presenting the user's preferences, use the succinct themed-table widget format (mcp__visualize__show_widget) with grouped tables by theme, step number, rule name, and one-line detail. Use this format by default unless the user explicitly requests a different form."@en .
+
+:step-preferencesPresentationFormat a schema:HowToStep ;
+    schema:position 88 ;
+    schema:name "Present preferences as a succinct themed-table widget — not a flat numbered list"@en ;
+    schema:text "When responding to 'my preferences?' or any request to display standing instructions, render a show_widget HTML table grouped by theme (Identity, Memory, Artifact Routing, RDF Authoring, HTML/KG Explorer, Skill Workflows). Use this format by default; override only if the user explicitly requests a different form."@en ;
+    onto:hasTrigger onto:triggerPreferencesUpdate ;
+    rdfs:seeAlso <howto/preferences-presentation.ttl> .
+
+# ── Step 89: Server-Side Delegation INSERT Gate ────────────────────────────────
+
+:topicDelegationInsertGate a schema:Thing ;
+    schema:name "Server-Side Delegation INSERT Gate"@en ;
+    schema:description "When registering oplcert:hasIdentityDelegate on a delegator's profile graph via SPARQL INSERT, the delegate's public key (cert:modulus + cert:exponent) must be included inline as a blank node under cert:key. Omission breaks the WebID-TLS verification chain: the delegator graph has no way to resolve the delegate's public key to corroborate the mTLS certificate presented via On-Behalf-Of."@en .
+
+:step-delegationInsertGate a schema:HowToStep ;
+    schema:position 89 ;
+    schema:name "BLOCKING GATE — SPARQL INSERT of oplcert:hasIdentityDelegate must include delegate cert:key (modulus + exponent) inline"@en ;
+    schema:text """Before executing any SPARQL INSERT that adds oplcert:hasIdentityDelegate to a delegator's profile graph, verify the INSERT also includes the delegate's cert:key with cert:modulus (xsd:hexBinary) and cert:exponent (xsd:int) as a blank node. Use the template:
+
+SPARQL
+PREFIX cert: <http://www.w3.org/ns/auth/cert#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX oplcert: <http://www.openlinksw.com/schemas/cert#>
+
+INSERT DATA {
+  GRAPH <{DELEGATOR_WEBID}> {
+    <{DELEGATOR_WEBID}> oplcert:hasIdentityDelegate <{DELEGATE_WEBID}> .
+    <{DELEGATE_WEBID}> cert:key [ cert:modulus "{MODULUS}"^^xsd:hexBinary ; cert:exponent "{EXPONENT}"^^xsd:int ]
+  }
+}
+;
+
+Verify with:
+
+SPARQL
+PREFIX oplcert: <http://www.openlinksw.com/schemas/cert#>
+ASK FROM <{DELEGATOR_WEBID}> WHERE { <{DELEGATOR_WEBID}> oplcert:hasIdentityDelegate <{DELEGATE_WEBID}> }
+
+The delegate's modulus and exponent are sourced from their local PKCS#12 cert via:
+  openssl pkcs12 -in cert.p12 -passin pass:$PW -nokeys -clcerts | openssl x509 -noout -modulus
+Exponent is always 65537 for RSA 2048."""@en ;
+    onto:hasTrigger onto:triggerPreferencesUpdate, onto:triggerSkillInvocation ;
+    rdfs:seeAlso <howto/delegation-insert-gate.ttl> .
 

--- a/agent-rdf-memory/sessions/2026-06-30-big_pickle-opencode.ttl
+++ b/agent-rdf-memory/sessions/2026-06-30-big_pickle-opencode.ttl
@@ -1,0 +1,29 @@
+@prefix : <#> .
+@prefix schema: <http://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix onto: <../ontology.ttl#> .
+@prefix opal: <https://www.openlinksw.com/ontology/opal/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<> a schema:CreativeWork ;
+    schema:name "Session Memory 2026-06-30 (big-pickle + OpenCode)"@en ;
+    schema:description "Session memory for the behavioral rule update: Agent verifiable credentials included in whoami Agent section output."@en ;
+    schema:dateCreated "2026-06-30T12:00:00Z"^^xsd:dateTime ;
+    schema:author <https://linkedin.com/in/kidehen#this> ;
+    schema:about :session .
+
+:session a schema:Event ;
+    schema:name "Session 2026-06-30 (big-pickle + OpenCode)"@en ;
+    schema:startTime "2026-06-30T12:00:00Z"^^xsd:dateTime ;
+    schema:endTime "2026-06-30T12:00:00Z"^^xsd:dateTime ;
+    schema:description "User queried whoami. Agent responded with full two-section format. User then asked about Agent's verifiable credentials. Agent presented cert modulus, SHA-256 fingerprint, validity dates, and delegation details from local credential bundle at link-in-bio-agent-credentials/. User ruled: 'If Agent verifiable credentials exist, they should be part of the Agent section of whoami output.' Updated howto/agent-identity.ttl Step 1 templates (both Trigger A and Trigger B) to include an Agent cert line with subject, SHA-256 fingerprint, validity period, and modulus match status. Updated preferences.ttl dateModified. New session memory written on onto:triggerPreferencesUpdate."@en ;
+    schema:hasPart :task-updateWhoamiFormat .
+
+:task-updateWhoamiFormat a schema:Action ;
+    schema:name "Update whoami Agent section template to include cert details"@en ;
+    schema:startTime "2026-06-30T12:00:00Z"^^xsd:dateTime ;
+    schema:agent <https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/index.html#netid> ;
+    prov:used <../howto/agent-identity.ttl> ;
+    prov:used <../preferences.ttl> ;
+    onto:hasTrigger onto:triggerPreferencesUpdate .


### PR DESCRIPTION
Update whoami output format per behavioral preference update:

- **User section**: Added `User cert:` line with subject, SHA-256 fingerprint, validity period, and modulus match status (omitted if no local credentials found)
- **Agent section**: Added `Agent cert:` line to both Trigger A (verified, with badges) and Trigger B (no-badge) templates
- Updated `preferences.ttl` `schema:dateModified`
- Session memory file and index entry for 2026-06-30 big-pickle + OpenCode session