### PR TITLE
refactor(preferences): hub-and-spoke model + OWL property characterization + youid enhancements

### DIFF
--- a/agent-rdf-memory/README.md
+++ b/agent-rdf-memory/README.md
@@ -1,0 +1,98 @@
+# Agent RDF Memory
+
+Queryable behavioral contract for AI agents, encoded as RDF-Turtle. All standing instructions live here — never in the platform's flat markdown memory store.
+
+## Folder structure
+
+```
+agent-rdf-memory/
+├── README.md              ← this file
+├── core.ttl               ← user identity, agent identity template, output paths
+├── preferences.ttl        ← hub: 9 sub-HowTos, 105 HowToStep definitions
+├── ontology.ttl           ← custom vocabulary (triggers, prompt types)
+├── index.ttl              ← session index (one schema:ListItem per session)
+├── howto/                 ← companion specification files (one per sub-HowTo)
+│   ├── agent-identity.ttl
+│   ├── artifact-routing.ttl
+│   ├── canonical-entity-iri-denotation.ttl
+│   ├── …                  ← (40+ files, see § Sub-HowTo map below)
+│   └── youid-validation-gates.ttl
+├── sessions/              ← episodic memory (YYYY-MM-DD-{llm}-{env}.ttl)
+├── projects/              ← project-specific knowledge
+├── entities/              ← people, tools, preferences
+└── scripts/               ← validation & utility scripts
+```
+
+## Retrieval protocol (mandatory)
+
+Before any task, the agent must:
+
+1. List `agent-rdf-memory/` and all subfolders
+2. Read `core.ttl`
+3. Read `preferences.ttl`
+4. Read `index.ttl`
+5. Follow `index.ttl` references to relevant `sessions/` or `projects/` files
+
+See `howto/session-governance.ttl` for the full protocol.
+
+## Preferences structure
+
+`preferences.ttl` is a **hub-and-spoke** model:
+
+```
+:agentBehaviorGuide (hub)
+├── schema:about    → 9 topic entities (conceptual grouping)
+└── schema:hasPart  → 9 sub-HowTos (each owns its own schema:step list)
+```
+
+Each sub-HowTo has `rdfs:seeAlso` links to companion `howto/*.ttl` files that contain the full specification text. Steps in `preferences.ttl` are sparse pointers (name + one-sentence `schema:text` + `rdfs:seeAlso`). All rationale, code, gates, and incident notes live in the howto files.
+
+## Sub-HowTo map
+
+| # | Sub-HowTo | Steps | Primary howto files |
+|---|-----------|-------|---------------------|
+| 1 | `:howto-identity-webid` | 14 | agent-identity, verified-identity, youid-delegation, webid-verification-services, webid-verification-table, delegation-insert-gate, youid-validation-gates |
+| 2 | `:howto-memory-management` | 16 | session-governance, memory-protocol-gate, token-optimized-session-handoff, sparql-memory-loading, no-unauthorized-deletion, no-memory-md-write |
+| 3 | `:howto-artifact-routing` | 7 | artifact-routing, remote-webdav-upload |
+| 4 | `:howto-rdf-authoring` | 19 | canonical-entity-iri-denotation, entity-iri-denotation-mechanics, canonical-iri-compliance-gate, entity-type-gate, external-iri-verification, entity-link-placement, concept-entity-hyperlinking, faq-entity-iri-gate, sparql-absolute-prefix-iri, entity-href-companion-ttl, owl-sameas-vs-skos-related, entity-lookup-disambiguation, rdf-residence-vs-birthplace, no-blank-nodes-resolver-entities, rdf-document-authoring |
+| 5 | `:howto-html-kg-explorer` | 38 | infographic-authoring, kg-explorer-ui-patterns, kg-explorer-d3-patterns, kg-explorer-reuse-first, harness-contract-compliance, rdf-infographic-compliance-gate, rdf-infographic-gated-workflow, footer-sparql-explorer-gate, sparql-html-escape-gate, study-prior-patterns, kg-curation-attribution, ui-ux-expert-persona |
+| 6 | `:howto-ontology-generation` | 2 | ontology-cross-reference-gate, owl-property-characterization, ontology-discovery |
+| 7 | `:howto-skill-workflows` | 6 | skill-invocation, opal-session-vocabulary, uriburner-oauth-authcode-flow |
+| 8 | `:howto-virtuoso-sparql` | 2 | virtuoso-sparql-formats, virtuoso-workbench-query-dedup |
+| 9 | `:howto-terminology` | 1 | artifact-routing, rdf-document-authoring |
+
+**Total: 105 steps across 9 themes.**
+
+## Querying preferences
+
+### SPARQL (if loaded into a triplestore)
+
+```sparql
+# All steps for a specific domain
+SELECT ?step ?pos ?name WHERE {
+    :howto-rdf-authoring schema:step ?step .
+    ?step schema:position ?pos ; schema:name ?name .
+} ORDER BY ?pos
+```
+
+### File-based (grep)
+
+```bash
+# Find which sub-HowTo owns a step
+grep -l "schema:step.*step-whoamiFormat" agent-rdf-memory/preferences.ttl
+# → :howto-identity-webid
+```
+
+## Adding a new rule
+
+1. Decide which sub-HowTo it belongs to (or create a new one if none fit)
+2. Add a `schema:HowToStep` entry to `preferences.ttl`
+3. Add the step to the sub-HowTo's `schema:step` list
+4. Write the full specification to the companion `howto/<topic>.ttl`
+5. If creating a new sub-HowTo: add it to `:agentBehaviorGuide` `schema:hasPart`, add a topic entity, and update this README
+
+## Related
+
+- `CLAUDE.md` / `AGENT.md` — prose reference (authoritative upon conflict: `preferences.ttl` wins)
+- `SESSION-START-HOOK.md` — runtime injection mechanism for session initialization
+- `scripts/validate-memory-protocol.py` — post-session audit gate

--- a/agent-rdf-memory/index.ttl
+++ b/agent-rdf-memory/index.ttl
@@ -6,7 +6,7 @@
 <> a schema:CreativeWork ;
     schema:name "Agent Session Index"@en ;
     schema:description "Index of all agent sessions with references to session files."@en ;
-    schema:dateModified "2026-07-01T12:27:02Z"^^xsd:dateTime ;
+    schema:dateModified "2026-07-01T20:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :sessionIndex .
 
@@ -536,4 +536,11 @@
     schema:name "Session 2026-07-01 (GPT-5 Chat Codex — AI Absorption Problem RDF and HTML Collection)"@en ;
     schema:description "Generated RDF-Turtle and HTML collection about Stuart Winter-Tear's The AI Absorption Problem with referenced Microsoft, Stanford, Anthropic briefing, and Unhyped Advisory source treatment. Artifacts written to GPT5-Chat-Generated/rdf and webpages; generator under showcases/ai-absorption-problem; validation passed."@en .
 
-:sessionIndex schema:itemListElement :session20260701Gpt5ChatCodexAiAbsorption .
+:session20260701ClaudeSonnet46ContextEngineering a schema:ListItem ;
+    schema:position 1004 ;
+    schema:item <sessions/2026-07-01-claude_sonnet_4_6-claude_code.ttl> ;
+    schema:name "Session 2026-07-01 (Claude Sonnet 4.6 + Claude Code — AI Agent Memory Context Engineering Collection)"@en ;
+    schema:description "Generated TTL (491 triples, 0 blank nodes), MD, and HTML collection on AI agent memory as context engineering, synthesising ByteByteGo and agent-rdf-memory sources. Added Comparative Analysis section (9-dimension ByteByteGo vs agent-rdf-memory table). Fixed TTL structural gaps (DefinedTermSet, inDefinedTermSet, FAQPage, schema:hasPart wiring). Fixed pre-existing Turtle_(syntax) unescaped-parens bug. HTML harness: 21 failures → 0 (kgData pure JSON, d3@7 CDN, Section navigation aria-label, settings-panel id, pred-anchor class, data-resolver-href, resolverHref click handler, 8-label attribution footer, Named graph + text/x-html-nice-turtle guidance). Preferences Step 88 encoded: preferences displayed as themed-table widget by default."@en .
+
+:sessionIndex schema:itemListElement :session20260701Gpt5ChatCodexAiAbsorption ,
+    :session20260701ClaudeSonnet46ContextEngineering .

--- a/agent-rdf-memory/preferences.ttl
+++ b/agent-rdf-memory/preferences.ttl
@@ -27,74 +27,223 @@
 :agentBehaviorGuide a schema:HowTo ;
     schema:name "Agent Standing Instructions"@en ;
     schema:description "Procedural rules the agent must follow in every session. Encoded as structured RDF so rules are queryable, resolvable, and harder to overlook than flat prose alone."@en ;
-    schema:about :topicApprovalWorkflow, :topicArtifactRouting, :topicModelIdentityPreflight,
-        :topicWhoamiSameAsHyperlinks,
-        :topicVerifyRecipDelegation,
-        :topicUrlsAsHyperlinks,
-        :topicSkillComposition,         :topicEntityResolution, :topicCanonicalEntityIriDenotation,
-        :topicEntityIriDenotationMechanics,
-        :topicMemoryManagement, :topicVersionControl,
-        :topicAttributionStyling, :topicPackaging,
-        :topicThemeImplementation, :topicGraphVisualization,
-        :topicContractValidation, :topicNoFabricatedUrls, :topicCurlAuth,
-        :topicStripeSandboxCard, :topicWhoamiFormat, :topicSecretRedaction,
-        :topicPromptRecording, :topicSemanticFidelity,
-        :topicKGExplorerReuseFirst, :topicOntologyDiscovery, :topicRetrievalToolOrder,
-        :topicVirtuosoSparqlFormats, :topicEntityTypeGate, :topicExternalIriVerification,
-        :topicEntityLinkPlacement, :topicCanonicalIriCompliance,
-        :topicConceptEntityHyperlinking, :topicModelOverEnvironment,
-        :topicNoBlankNodes,
-        :topicRemoteWebdavUpload, :topicMemoryProtocolGate,
-        :topicTokenOptimizedSessionHandoff, :topicOntologyCrossReference,
-        :topicNoUnauthorizedDeletion,
-        :topicNoMemoryMdWrite,
-        :topicEntityLookupDisambiguation,
-        :topicSparqlHtmlEscape,
-        :topicYouidValidationGate,
-        :topicOAuthAuthCodeFlow,
-        :topicD3Loading,
-        :topicSecretEchoRedaction,
-        :topicWebidVerificationServices ,
-        :topicWebidVerificationTable ,
-        :topicDelegationInsertGate ,
-        :topicOboHeaderFormat ,
-        :topicOwlPropertyCharacterization ;
-    schema:step :step-approval, :step-outputDirs, :step-gpt5ChatCodexOutputDirs, :step-mashupVsMeshup, :step-modelIdentityPreflight, :step-skillChain,
-        :step-whoamiSameAsHyperlinks,
-        :step-verifyRecipDelegation,
-        :step-verifyDelegationRemote,
-        :step-urlsAsHyperlinks,
-        :step-kgQueryMode,
-        :step-entityDenotation, :step-memoryProtocol,
-        :step-gitWorkflow, :step-attribution, :step-zipRepackage,
-        :step-darkModeCSS, :step-kgExplorerReuse, :step-templateSelection,
-        :step-kgNavPlacement, :step-kgNavCollapsed, :step-kgControlsMasterClose,
-        :step-kgNoOrphans, :step-kgToolbarGroups, :step-kgSettingsPanel,
-        :step-harnessIds, :step-footerLabels, :step-sparqlFormat,
-        :step-complianceBug, :step-simulationLifecycle,
-        :step-clickGuard, :step-kgDataRegex,
-        :step-documentEntity, :step-noFabricatedUrls, :step-curlAuth,
-        :step-stripeSandboxCard, :step-whoamiFormat, :step-secretRedaction,
-        :step-promptRecording, :step-retrievalToolOrder,
-        :step-defaultOutputRoot, :step-modelOverEnvironment, :step-virtuosoSparqlFormats, :step-entityTypeGate,
-        :step-externalIriVerification, :step-entityLinkPlacement,
-        :step-canonicalIriCompliance, :step-conceptEntityHyperlinking,
-        :step-noBlankNodes,
-        :step-remoteWebdavUpload, :step-memoryProtocolGate,
-        :step-tokenOptimizedSessionHandoff, :step-ontologyCrossReference,
-        :step-noUnauthorizedDeletion,
-        :step-noMemoryMdWrite,
-        :step-entityLookupDisambiguation,
-        :step-sparqlHtmlEscape,
-        :step-youidValidationGate,
-        :step-uriburnerOAuthAuthCodeFlow,
-        :step-staticD3Load, :step-singleRender,
-        :step-secretEchoRedaction,
-        :step-webidVerificationServiceSelection ,
-        :step-webidVerificationTable ,
-        :step-delegationInsertGate ,
-        :step-oboHeaderFormat ,
+    schema:about :topic-identity-webid, :topic-memory-management, :topic-artifact-routing,
+        :topic-rdf-authoring, :topic-html-kg-explorer, :topic-ontology-generation,
+        :topic-skill-workflows, :topic-virtuoso-sparql, :topic-terminology ;
+    schema:hasPart :howto-identity-webid,
+        :howto-memory-management,
+        :howto-artifact-routing,
+        :howto-rdf-authoring,
+        :howto-html-kg-explorer,
+        :howto-ontology-generation,
+        :howto-skill-workflows,
+        :howto-virtuoso-sparql,
+        :howto-terminology .
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ── Topic Entities (simplified — one per sub-HowTo) ──────────────────────
+# ═══════════════════════════════════════════════════════════════════════════
+
+:topic-identity-webid a schema:Thing ;
+    schema:name "Identity, WebID & Delegation"@en ;
+    schema:description "Agent identity format, whoami triggers, WebID-TLS verification, reciprocal delegation, On-Behalf-Of, and YouID validation."@en .
+
+:topic-memory-management a schema:Thing ;
+    schema:name "Memory Management & Session Governance"@en ;
+    schema:description "Agent RDF memory protocol, prompt recording, secret redaction, SPARQL-based loading, and token-optimized handoffs."@en .
+
+:topic-artifact-routing a schema:Thing ;
+    schema:name "Artifact Output Routing"@en ;
+    schema:description "Model-specific output directories, model identity pre-flight gate, and remote WebDAV upload."@en .
+
+:topic-rdf-authoring a schema:Thing ;
+    schema:name "RDF Authoring & Entity Resolution"@en ;
+    schema:description "Entity IRI denotation, canonical IRI compliance, entity type gates, concept hyperlinking, and blank node prohibitions."@en .
+
+:topic-html-kg-explorer a schema:Thing ;
+    schema:name "HTML Infographic & KG Explorer"@en ;
+    schema:description "Infographic authoring, D3.js KG Explorer patterns, harness contract compliance, SPARQL workbench, and UI patterns."@en .
+
+:topic-ontology-generation a schema:Thing ;
+    schema:name "Ontology Generation"@en ;
+    schema:description "Cross-reference gate, OWL property characterization, and shared ontology discovery."@en .
+
+:topic-skill-workflows a schema:Thing ;
+    schema:name "Skill Chain & Workflows"@en ;
+    schema:description "kg-generator → rdf-infographic-skill chain, KG query modes, ZIP repackaging, and OPAL session vocabulary."@en .
+
+:topic-virtuoso-sparql a schema:Thing ;
+    schema:name "Virtuoso & SPARQL"@en ;
+    schema:description "Virtuoso SPARQL URL format parameters and workbench query deduplication rules."@en .
+
+:topic-terminology a schema:Thing ;
+    schema:name "Terminology & Conventions"@en ;
+    schema:description "Mashup vs meshup and other terminological conventions."@en .
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ── Sub-HowTo Entities ──────────────────────────────────────────────────
+# ═══════════════════════════════════════════════════════════════════════════
+
+# ── 1. Identity, WebID & Delegation ────────────────────────────────────────
+
+:howto-identity-webid a schema:HowTo ;
+    schema:name "Identity, WebID & Delegation"@en ;
+    schema:description "Agent identity format, whoami triggers, WebID-TLS verification, reciprocal delegation (local+remote), On-Behalf-Of header format, WebID verification services, and YouID validation gates."@en ;
+    rdfs:seeAlso <howto/agent-identity.ttl>,
+        <howto/verified-identity.ttl>,
+        <howto/youid-delegation.ttl>,
+        <howto/webid-verification-services.ttl>,
+        <howto/webid-verification-table.ttl>,
+        <howto/delegation-insert-gate.ttl>,
+        <howto/youid-validation-gates.ttl> ;
+    schema:step :step-whoamiFormat, :step-webidTlsVerification, :step-verifiedWhoami,
+        :step-whoamiSameAsHyperlinks, :step-urlsAsHyperlinks, :step-stripeSandboxCard,
+        :step-verifyRecipDelegation, :step-verifyDelegationRemote,
+        :step-webidVerificationServiceSelection, :step-webidVerificationTable,
+        :step-delegationLocalFiles, :step-delegationInsertGate,
+        :step-oboHeaderFormat, :step-youidValidationGate .
+
+# ── 2. Memory Management & Session Governance ──────────────────────────────
+
+:howto-memory-management a schema:HowTo ;
+    schema:name "Memory Management & Session Governance"@en ;
+    schema:description "Agent RDF memory protocol, session file naming, prompt recording, secret redaction, SPARQL-based memory loading, token-optimized handoffs, and no-unauthorized-deletion rules."@en ;
+    rdfs:seeAlso <howto/session-governance.ttl>,
+        <howto/memory-protocol-gate.ttl>,
+        <howto/token-optimized-session-handoff.ttl>,
+        <howto/sparql-memory-loading.ttl>,
+        <howto/no-unauthorized-deletion.ttl>,
+        <howto/no-memory-md-write.ttl> ;
+    schema:step :step-approval, :step-memoryProtocol, :step-gitWorkflow,
+        :step-noFabricatedUrls, :step-curlAuth, :step-secretRedaction,
+        :step-promptRecording, :step-memoryProtocolGate,
+        :step-tokenOptimizedSessionHandoff, :step-soleMemoryIndex,
+        :step-sparqlMemoryLoading, :step-noUnauthorizedDeletion,
+        :step-noMemoryMdWrite, :step-preferencesSparse, :step-secretEchoRedaction,
+        :step-preferencesPresentationFormat .
+
+# ── 3. Artifact Output Routing ──────────────────────────────────────────────
+
+:howto-artifact-routing a schema:HowTo ;
+    schema:name "Artifact Output Routing"@en ;
+    schema:description "Model-specific output directory routing, model identity pre-flight gate, model-over-environment tiebreaker, artifact placement elicitation, and remote WebDAV upload."@en ;
+    rdfs:seeAlso <howto/artifact-routing.ttl>,
+        <howto/remote-webdav-upload.ttl> ;
+    schema:step :step-outputDirs, :step-gpt5ChatCodexOutputDirs,
+        :step-modelIdentityPreflight, :step-defaultOutputRoot,
+        :step-modelOverEnvironment, :step-artifactPlacement,
+        :step-remoteWebdavUpload .
+
+# ── 4. RDF Authoring & Entity Resolution ────────────────────────────────────
+
+:howto-rdf-authoring a schema:HowTo ;
+    schema:name "RDF Authoring & Entity Resolution"@en ;
+    schema:description "Entity IRI denotation, canonical IRI compliance, external IRI verification, entity type gates, concept hyperlinking, FAQ entity IRI pre-build gate, DBpedia canonical subjects, blank node prohibitions, and language tagging."@en ;
+    rdfs:seeAlso <howto/canonical-entity-iri-denotation.ttl>,
+        <howto/entity-iri-denotation-mechanics.ttl>,
+        <howto/canonical-iri-compliance-gate.ttl>,
+        <howto/entity-type-gate.ttl>,
+        <howto/external-iri-verification.ttl>,
+        <howto/entity-link-placement.ttl>,
+        <howto/concept-entity-hyperlinking.ttl>,
+        <howto/faq-entity-iri-gate.ttl>,
+        <howto/sparql-absolute-prefix-iri.ttl>,
+        <howto/entity-href-companion-ttl.ttl>,
+        <howto/owl-sameas-vs-skos-related.ttl>,
+        <howto/entity-lookup-disambiguation.ttl>,
+        <howto/rdf-residence-vs-birthplace.ttl>,
+        <howto/no-blank-nodes-resolver-entities.ttl>,
+        <howto/rdf-document-authoring.ttl> ;
+    schema:step :step-entityDenotation, :step-documentEntity, :step-documentAbout,
+        :step-entityTypeGate, :step-externalIriVerification,
+        :step-entityLinkPlacement, :step-canonicalIriCompliance,
+        :step-conceptEntityHyperlinking, :step-noBlankNodes,
+        :step-faqEntityIriGate, :step-schemaAuthorOverFoafMaker,
+        :step-entityHrefCompanionTTL, :step-sparqlAbsolutePrefixIRI,
+        :step-owlSameAsVsSkosRelated, :step-entityLookupDisambiguation,
+        :step-residenceVsBirthplace, :step-noBlankNodesForResolverEntities,
+        :step-dbpediaCanonicalSubject, :step-terminologySemanticWeb .
+
+# ── 5. HTML Infographic & KG Explorer ───────────────────────────────────────
+
+:howto-html-kg-explorer a schema:HowTo ;
+    schema:name "HTML Infographic & KG Explorer"@en ;
+    schema:description "Infographic authoring, D3.js KG Explorer patterns (simulation lifecycle, click guard, sticky drag, lazy init, single render, static D3 load), UI patterns (nav placement/collapse, controls, orphans, toolbar, settings), harness contract compliance, SPARQL workbench, footer gates, heading fragment IDs, theme toggle, and IIFE scoping."@en ;
+    rdfs:seeAlso <howto/infographic-authoring.ttl>,
+        <howto/kg-explorer-ui-patterns.ttl>,
+        <howto/kg-explorer-d3-patterns.ttl>,
+        <howto/kg-explorer-reuse-first.ttl>,
+        <howto/harness-contract-compliance.ttl>,
+        <howto/rdf-infographic-compliance-gate.ttl>,
+        <howto/rdf-infographic-gated-workflow.ttl>,
+        <howto/footer-sparql-explorer-gate.ttl>,
+        <howto/sparql-html-escape-gate.ttl>,
+        <howto/study-prior-patterns.ttl>,
+        <howto/kg-curation-attribution.ttl>,
+        <howto/ui-ux-expert-persona.ttl> ;
+    schema:step :step-attribution, :step-darkModeCSS, :step-kgExplorerReuse,
+        :step-templateSelection, :step-kgNavPlacement, :step-kgNavCollapsed,
+        :step-kgControlsMasterClose, :step-kgNoOrphans, :step-kgToolbarGroups,
+        :step-kgSettingsPanel, :step-harnessIds, :step-footerLabels,
+        :step-sparqlFormat, :step-complianceBug, :step-simulationLifecycle,
+        :step-clickGuard, :step-kgDataRegex, :step-rdfInfographicGateEnforcement,
+        :step-rdfInfographicGatedWorkflow, :step-sparqlHtmlEscape,
+        :step-reuseWorkingKG, :step-kgDragSticky, :step-iifeGlobalScope,
+        :step-sparqlBtnFooterAnchor, :step-themeToggleInNavHeader,
+        :step-headingFragmentIds, :step-staticD3Load, :step-singleRender,
+        :step-kgLazyInit, :step-studyPriorPatterns, :step-kgCurationAttribution,
+        :step-uiUxExpertPersona, :step-faqQuestionTextHyperlink,
+        :step-sparqlWorkbenchPlacement, :step-sparqlBtnMandatory,
+        :step-sparqlExplorerVisibleText, :step-footerTextAlignCascade,
+        :step-staleWorkbenchCleanup .
+
+# ── 6. Ontology Generation ──────────────────────────────────────────────────
+
+:howto-ontology-generation a schema:HowTo ;
+    schema:name "Ontology Generation"@en ;
+    schema:description "Cross-reference gate for custom ontology terms, OWL property characterization from nine semantic categories, and shared ontology discovery via prefix.cc before inventing new predicates."@en ;
+    rdfs:seeAlso <howto/ontology-cross-reference-gate.ttl>,
+        <howto/owl-property-characterization.ttl>,
+        <howto/ontology-discovery.ttl> ;
+    schema:step :step-ontologyCrossReference,
         :step-owlPropertyCharacterization .
+
+# ── 7. Skill Chain & Workflows ──────────────────────────────────────────────
+
+:howto-skill-workflows a schema:HowTo ;
+    schema:name "Skill Chain & Workflows"@en ;
+    schema:description "kg-generator → rdf-infographic-skill chain, KG query modes, ZIP repackaging, content retrieval tool order, OPAL session vocabulary, and URIBurner OAuth authorization code flow."@en ;
+    rdfs:seeAlso <howto/skill-invocation.ttl>,
+        <howto/opal-session-vocabulary.ttl>,
+        <howto/uriburner-oauth-authcode-flow.ttl> ;
+    schema:step :step-skillChain, :step-kgQueryMode, :step-zipRepackage,
+        :step-retrievalToolOrder, :step-opalSessionVocabulary,
+        :step-uriburnerOAuthAuthCodeFlow .
+
+# ── 8. Virtuoso & SPARQL ────────────────────────────────────────────────────
+
+:howto-virtuoso-sparql a schema:HowTo ;
+    schema:name "Virtuoso & SPARQL"@en ;
+    schema:description "Virtuoso SPARQL URL format parameters by query type, workbench query deduplication via named graphs, and SPARQL absolute PREFIX IRI rules."@en ;
+    rdfs:seeAlso <howto/virtuoso-sparql-formats.ttl>,
+        <howto/virtuoso-workbench-query-dedup.ttl> ;
+    schema:step :step-virtuosoSparqlFormats,
+        :step-virtuosoWorkbenchQueryDedup .
+
+# ── 9. Terminology & Conventions ────────────────────────────────────────────
+
+:howto-terminology a schema:HowTo ;
+    schema:name "Terminology & Conventions"@en ;
+    schema:description "Mashup vs meshup terminology and other terminological conventions."@en ;
+    rdfs:seeAlso <howto/artifact-routing.ttl>,
+        <howto/rdf-document-authoring.ttl> ;
+    schema:step :step-mashupVsMeshup .
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ── Step Definitions (referenced by sub-HowTos above) ────────────────────
+# ═══════════════════════════════════════════════════════════════════════════
+
+# ── Identity, WebID & Delegation ────────────────────────────────────────────
 
 # ── Step 1: Seek Approval ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

### preferences.ttl restructured: 91 flat steps → 9 themed sub-HowTos

The monolithic `:agentBehaviorGuide` with 91 flat `schema:step` entries is replaced by a hub-and-spoke model:

```
:agentBehaviorGuide (hub)
├── schema:about    → 9 simplified topic entities
└── schema:hasPart  → 9 sub-HowTos (each owns its schema:step list)
```

| # | Sub-HowTo | Steps |
|---|-----------|-------|
| 1 | Identity, WebID & Delegation | 14 |
| 2 | Memory Management & Session Governance | 16 |
| 3 | Artifact Output Routing | 7 |
| 4 | RDF Authoring & Entity Resolution | 19 |
| 5 | HTML Infographic & KG Explorer | 38 |
| 6 | Ontology Generation | 2 |
| 7 | Skill Chain & Workflows | 6 |
| 8 | Virtuoso & SPARQL | 2 |
| 9 | Terminology & Conventions | 1 |

All 105 steps preserved and linked. Zero orphans. Each sub-HowTo carries `rdfs:seeAlso` to its companion `howto/*.ttl` files.

### New: Step 91 — OWL Property Characterization Gate
Custom `owl:ObjectProperty` definitions must carry applicable OWL constructs from nine semantic categories (Typing, Hierarchy, Symmetry, Reflexivity, Cardinality, Propagation, Identity/Direction, Composition, Class-based Constraints). Classification/status properties default to `owl:FunctionalProperty + owl:AsymmetricProperty + owl:IrreflexiveProperty`.

### New: agent-rdf-memory/README.md
Documents folder structure, retrieval protocol, hub-and-spoke model, sub-HowTo map, querying examples, and procedure for adding new rules.

### New howto files
- `howto/owl-property-characterization.ttl` — 6-step OWL characterization guide
- `howto/delegation-insert-gate.ttl` — Step 89: SPARQL INSERT gate for delegation
- `howto/webid-verification-table.ttl` — Step 87: identity verification table pattern
- `howto/preferences-presentation.ttl` — Step 88: themed-table widget format

### Skill updates
- `youid/`: SKILL.md enhancements + README
- `acp-client/`: SKILL.md update

🤖 Generated with [Claude Code](https://claude.com/claude-code)