### PR TITLE
feat: Add infographic-describer skill for bulk RDF-Turtle generation

### DIFF
--- a/infographic-describer/SKILL.md
+++ b/infographic-describer/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: infographic-describer
+description: Generate RDF-Turtle descriptions (schema:ImageObject, schema:VideoObject, schema:WebPage) for infographic files in a WebDAV directory, using SHACL shapes as the property contract. Trigger when: user asks to describe infographics, generate metadata for a DAV directory, create RDF descriptions for image/video collections, or apply a SHACL shape to bulk-describe files. Handles content negotiation (HTML describe pages vs SPARQL DESCRIBE), filename-derived metadata, thumbnail URL detection, and category inference.
+---
+
+# Infographic Describer
+
+Generate RDF-Turtle descriptions for files in a WebDAV-hosted directory using a SHACL shape as the property contract.
+
+## Workflow
+
+### Step 1: Discover Files
+
+List the target WebDAV directory to enumerate files:
+
+```bash
+curl -sL "https://www.openlinksw.com/data/{directory}/" | python3 -c "
+import sys, re
+html = sys.stdin.read()
+files = re.findall(r'title=\"File - ([^\"]+)\"', html)
+for f in files:
+    print(f)
+"
+```
+
+Classify by extension: `.png` → `schema:ImageObject`, `.mp4` → `schema:VideoObject`, `.html` → `schema:WebPage`.
+
+### Step 2: Probe Describe Endpoint
+
+Check which files have existing RDF data in the triplestore. Use the SPARQL DESCRIBE endpoint:
+
+```python
+import urllib.parse, urllib.request
+
+iri = f'https://www.openlinksw.com/DAV/www2.openlinksw.com/data/{directory}/{stem}.{ext}'
+query = f'DESCRIBE <{iri}>'
+url = 'http://www.openlinksw.com/sparql?query=' + urllib.parse.quote(query) + '&output=text%2Fn3'
+
+req = urllib.request.Request(url, headers={'Accept': 'text/n3, */*'})
+resp = urllib.request.urlopen(req, timeout=30)
+data = resp.read().decode()
+has_data = 'Empty' not in data and len(data.strip()) > 50
+```
+
+### Step 3: Probe Thumbnails
+
+Check for thumbnails using the content-explorer pattern:
+
+```
+https://www.openlinksw.com/data/content-explorer/thumbnails/{category}-{stem}.avif
+```
+
+Where `{category}` is the directory name (e.g., `infographics`). Probe with HTTP HEAD:
+
+```bash
+curl -sL -o /dev/null -w "%{http_code}" "$url"
+```
+
+Only files with `200` have thumbnails.
+
+### Step 4: Generate Descriptions
+
+For each file, construct RDF triples using the SHACL shape properties:
+
+| Property | Source | Fallback |
+|----------|--------|----------|
+| `rdf:type` | File extension | `schema:CreativeWork` |
+| `schema:name` | Filename stem (underscores/hyphens → spaces) | — |
+| `schema:description` | Derived from name or describe page | `"Infographic: {name}"` |
+| `schema:encodingFormat` | Content type from listing | Map extension to MIME |
+| `schema:contentUrl` | Full DAV URL | — |
+| `schema:thumbnailUrl` | Probe result (only if 200) | Omit |
+| `schema:category` | Directory-based category IRI | Default to `#Infographic` |
+| `wdrs:describedby` | Constructed describe endpoint URL | — |
+| `schema:dateCreated` | Describe page (if available) | Omit |
+| `schema:dateModified` | Describe page (if available) | Omit |
+
+**Entity IRI pattern**: `{contentUrl}#this`
+
+**Category IRIs** (content-explorer-metadata.ttl):
+- `#Infographic` — default for `/data/infographics/`
+- `#Guide` — filenames containing "guide"
+- `#Demo` — filenames containing "demo"
+- `#Survey` — filenames containing "survey"
+
+**Encoding format mapping**:
+- `.png` → `image/png`
+- `.jpg`/`.jpeg` → `image/jpeg`
+- `.mp4` → `video/mp4`
+- `.html` → `text/html`
+
+### Step 5: Generate Turtle
+
+Use this template structure:
+
+```turtle
+@prefix schema: <http://schema.org/> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix wdrs:   <http://www.w3.org/2007/05/powder-s#> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
+
+<{contentUrl}#this>
+    a {schemaType} ;
+    schema:name "{name}" ;
+    schema:description "{description}" ;
+    schema:encodingFormat "{mimeType}" ;
+    schema:contentUrl <{contentUrl}> ;
+    schema:category <{categoryIri}> ;
+    wdrs:describedby <{describeUrl}> .
+```
+
+Add `schema:thumbnailUrl` only if the probe returned 200.
+
+### Step 6: Validate
+
+Validate the generated Turtle:
+
+```python
+from rdflib import Graph
+g = Graph()
+g.parse('output.ttl', format='turtle')
+print(f'{len(g)} triples, {len(set(g.subjects()))} entities')
+```
+
+### Step 7: Save
+
+Save to the user-designated output path. Default:
+- Shapes: `/Users/kidehen/Documents/RDF_DATA/shacl-shapes/`
+- Descriptions: same directory as the shapes
+
+## SHACL Shape Conventions
+
+When generating or updating SHACL shapes to match describe output:
+
+- Use `sh:minCount 0` for properties that may not exist for all files (`thumbnailUrl`, `dateCreated`, `dateModified`)
+- Use `sh:minCount 1` for always-present properties (`name`, `contentUrl`, `encodingFormat`, `type`)
+- Use `sh:hasValue` for fixed values (e.g., `encodingFormat = "image/png"`)
+- Use `sh:targetClass` to match the schema type
+
+## Notes
+
+- The `/describe` endpoint requires a POST with `h=1` to bypass the confirmation dialog
+- Most files in a DAV directory will have sparse or no RDF data — filename-derived metadata is the norm
+- Thumbnails are rare — only files processed by the content-explorer system have them
+- The SPARQL DESCRIBE endpoint (without CBD mode) returns more data than CBD mode for these resources

--- a/infographic-describer/agents/openai.yaml
+++ b/infographic-describer/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Infographic Describer"
+  short_description: "Help with Infographic Describer tasks"

--- a/infographic-describer/references/shacl-templates.md
+++ b/infographic-describer/references/shacl-templates.md
@@ -1,0 +1,84 @@
+# SHACL Shape Templates for Infographic Entities
+
+## ImageObject Shape (PNG files)
+
+```turtle
+@prefix sh:    <http://www.w3.org/ns/shacl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix wdrs:  <http://www.w3.org/2007/05/powder-s#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+
+<#InfographicImageShape>
+    a sh:NodeShape ;
+    sh:targetClass schema:ImageObject ;
+    sh:property [
+        sh:path rdf:type ;
+        sh:hasValue schema:ImageObject ;
+        sh:minCount 1 ; sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path schema:name ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ; sh:maxCount 1 ; sh:minLength 1 ;
+    ] ;
+    sh:property [
+        sh:path schema:description ;
+        sh:datatype xsd:string ;
+        sh:minCount 1 ; sh:maxCount 1 ; sh:minLength 1 ;
+    ] ;
+    sh:property [
+        sh:path schema:encodingFormat ;
+        sh:datatype xsd:string ;
+        sh:hasValue "image/png" ;
+        sh:minCount 1 ; sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path schema:contentUrl ;
+        sh:class rdf:Resource ;
+        sh:minCount 1 ; sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path schema:thumbnailUrl ;
+        sh:class rdf:Resource ;
+        sh:minCount 0 ; sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path schema:category ;
+        sh:minCount 1 ;
+    ] ;
+    sh:property [
+        sh:path schema:dateCreated ;
+        sh:datatype xsd:dateTime ;
+        sh:minCount 0 ; sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path schema:dateModified ;
+        sh:datatype xsd:dateTime ;
+        sh:minCount 0 ; sh:maxCount 1 ;
+    ] ;
+    sh:property [
+        sh:path wdrs:describedby ;
+        sh:minCount 1 ;
+    ] .
+```
+
+## VideoObject Shape (MP4 files)
+
+Same structure but with:
+- `sh:targetClass schema:VideoObject`
+- `sh:hasValue schema:VideoObject` for rdf:type
+- `sh:hasValue "video/mp4"` for encodingFormat
+
+## WebPage Shape (HTML files)
+
+Same structure but with:
+- `sh:targetClass schema:WebPage`
+- `sh:hasValue schema:WebPage` for rdf:type
+- `sh:hasValue "text/html"` for encodingFormat
+
+## Notes
+
+- `thumbnailUrl`, `dateCreated`, `dateModified` use `sh:minCount 0` because most files lack these
+- `category` uses `sh:minCount 1` — at minimum the directory-based default category applies
+- `wdrs:describedby` uses `sh:minCount 1` — the describe endpoint URL is always constructible

--- a/infographic-describer/scripts/describe-infographics.py
+++ b/infographic-describer/scripts/describe-infographics.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Generate RDF-Turtle descriptions for files in a WebDAV directory."""
+
+import argparse
+import json
+import re
+import sys
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+
+# Category IRIs for content-explorer-metadata.ttl
+CATEGORY_IRIS = {
+    "infographic": "https://www.openlinksw.com/DAV/www2.openlinksw.com/data/content-explorer/ttl/content-explorer-metadata.ttl#Infographic",
+    "guide": "https://www.openlinksw.com/DAV/www2.openlinksw.com/data/content-explorer/ttl/content-explorer-metadata.ttl#Guide",
+    "demo": "https://www.openlinksw.com/DAV/www2.openlinksw.com/data/content-explorer/ttl/content-explorer-metadata.ttl#Demo",
+    "survey": "https://www.openlinksw.com/DAV/www2.openlinksw.com/data/content-explorer/ttl/content-explorer-metadata.ttl#Survey",
+}
+
+# MIME type mapping
+MIME_TYPES = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "mp4": "video/mp4",
+    "html": "text/html",
+}
+
+# Schema type mapping
+SCHEMA_TYPES = {
+    "png": "schema:ImageObject",
+    "jpg": "schema:ImageObject",
+    "jpeg": "schema:ImageObject",
+    "mp4": "schema:VideoObject",
+    "html": "schema:WebPage",
+}
+
+
+def stem_to_name(stem):
+    """Convert filename stem to human-readable name."""
+    name = stem.replace("_", " ").replace("-", " ")
+    name = re.sub(r"\s+", " ", name).strip()
+    return name
+
+
+def detect_categories(stem):
+    """Detect categories from filename patterns."""
+    lower = stem.lower()
+    cats = []
+    for keyword, iri in CATEGORY_IRIS.items():
+        if keyword in lower:
+            cats.append(iri)
+    if not cats:
+        cats.append(CATEGORY_IRIS["infographic"])
+    return cats
+
+
+def list_directory(base_url):
+    """List files in a WebDAV directory."""
+    req = urllib.request.Request(base_url, headers={"User-Agent": "Mozilla/5.0"})
+    resp = urllib.request.urlopen(req, timeout=30)
+    html = resp.read().decode()
+    files = re.findall(r'title="File - ([^"]+)"', html)
+    return files
+
+
+def check_describe(stem, ext, dav_prefix):
+    """Check if a file has describe data in the triplestore."""
+    iri = f"{dav_prefix}/{stem}.{ext}"
+    query = f"DESCRIBE <{iri}>"
+    url = "http://www.openlinksw.com/sparql?query=" + urllib.parse.quote(query) + "&output=text%2Fn3"
+
+    req = urllib.request.Request(url, headers={"Accept": "text/n3, */*", "User-Agent": "Mozilla/5.0"})
+    resp = urllib.request.urlopen(req, timeout=30)
+    data = resp.read().decode()
+    return "Empty" not in data and len(data.strip()) > 50
+
+
+def check_thumbnail(stem, category_dir):
+    """Check if a thumbnail exists for the file."""
+    url = f"https://www.openlinksw.com/data/content-explorer/thumbnails/{category_dir}-{stem}.avif"
+    try:
+        req = urllib.request.Request(url, method="HEAD", headers={"User-Agent": "Mozilla/5.0"})
+        resp = urllib.request.urlopen(req, timeout=10)
+        return resp.status == 200
+    except Exception:
+        return False
+
+
+def generate_turtle(entries, dav_prefix):
+    """Generate Turtle from entries."""
+    lines = [
+        "@prefix schema: <http://schema.org/> .",
+        "@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .",
+        "@prefix wdrs:   <http://www.w3.org/2007/05/powder-s#> .",
+        "@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .",
+        "",
+    ]
+
+    for entry in entries:
+        stem = entry["stem"]
+        ext = entry["ext"]
+        content_url = entry["content_url"]
+        schema_type = SCHEMA_TYPES.get(ext, "schema:CreativeWork")
+        mime_type = MIME_TYPES.get(ext, "application/octet-stream")
+        name = entry["name"]
+        description = entry["description"]
+        categories = entry["categories"]
+        thumbnail = entry.get("thumbnail_url")
+
+        escaped_name = name.replace("\\", "\\\\").replace('"', '\\"')
+        escaped_desc = description.replace("\\", "\\\\").replace('"', '\\"')
+
+        lines.append(f"<{content_url}#this>")
+        lines.append(f"    a {schema_type} ;")
+        lines.append(f'    schema:name "{escaped_name}" ;')
+        lines.append(f'    schema:description "{escaped_desc}" ;')
+        lines.append(f'    schema:encodingFormat "{mime_type}" ;')
+        lines.append(f"    schema:contentUrl <{content_url}> ;")
+
+        if thumbnail:
+            lines.append(f"    schema:thumbnailUrl <{thumbnail}> ;")
+
+        cat_triples = " ,\n        ".join(f"<{c}>" for c in categories)
+        lines.append(f"    schema:category {cat_triples} ;")
+
+        encoded_iri = urllib.parse.quote(content_url, safe="")
+        describe_url = f"https://www.openlinksw.com/describe/?url={encoded_iri}"
+        lines.append(f"    wdrs:describedby <{describe_url}> .")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate RDF-Turtle descriptions for WebDAV directory files")
+    parser.add_argument("--directory", required=True, help="WebDAV directory path (e.g., infographics)")
+    parser.add_argument("--dav-prefix", default="https://www.openlinksw.com/DAV/www2.openlinksw.com/data", help="DAV base prefix")
+    parser.add_argument("--output", help="Output file path")
+    parser.add_argument("--category-dir", help="Thumbnail category directory name (default: same as --directory)")
+    parser.add_argument("--skip-thumbnails", action="store_true", help="Skip thumbnail probing")
+    parser.add_argument("--skip-describe", action="store_true", help="Skip describe endpoint probing")
+    parser.add_argument("--delay", type=float, default=0.3, help="Delay between requests (seconds)")
+    args = parser.parse_args()
+
+    category_dir = args.category_dir or args.directory
+    base_url = f"https://www.openlinksw.com/data/{args.directory}/"
+    dav_prefix = f"{args.dav_prefix}/{args.directory}"
+
+    print(f"Listing {base_url}...")
+    files = list_directory(base_url)
+    print(f"Found {len(files)} files")
+
+    entries = []
+    for i, filename in enumerate(files):
+        stem, ext = filename.rsplit(".", 1) if "." in filename else (filename, "")
+        content_url = f"{dav_prefix}/{filename}"
+        name = stem_to_name(stem)
+        categories = detect_categories(stem)
+
+        entry = {
+            "stem": stem,
+            "ext": ext,
+            "filename": filename,
+            "content_url": content_url,
+            "name": name,
+            "description": f"Infographic: {name}",
+            "categories": categories,
+        }
+
+        if not args.skip_thumbnails and ext in ("png", "jpg", "jpeg"):
+            if check_thumbnail(stem, category_dir):
+                entry["thumbnail_url"] = f"https://www.openlinksw.com/data/content-explorer/thumbnails/{category_dir}-{stem}.avif"
+                print(f"  [{i+1}/{len(files)}] {filename}: has thumbnail")
+            else:
+                print(f"  [{i+1}/{len(files)}] {filename}: no thumbnail")
+        else:
+            print(f"  [{i+1}/{len(files)}] {filename}")
+
+        entries.append(entry)
+        if (i + 1) % 10 == 0:
+            time.sleep(args.delay)
+
+    turtle = generate_turtle(entries, dav_prefix)
+
+    output_path = args.output or f"/Users/kidehen/Documents/RDF_DATA/shacl-shapes/{args.directory}-descriptions.ttl"
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        f.write(turtle)
+
+    # Validate
+    try:
+        from rdflib import Graph
+        g = Graph()
+        g.parse(output_path, format="turtle")
+        print(f"\nValid Turtle: {len(g)} triples, {len(set(g.subjects()))} entities")
+    except ImportError:
+        print(f"\nSaved {len(entries)} descriptions to {output_path}")
+
+    print(f"Output: {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a new  skill that generates RDF-Turtle descriptions for files in WebDAV-hosted directories using SHACL shapes as the property contract.

## What's Included

- **SKILL.md**: 7-step workflow (discover → probe describe → probe thumbnails → generate → validate)
- **scripts/describe-infographics.py**: Bulk description generator with thumbnail detection and category inference
- **references/shacl-templates.md**: SHACL shape templates for ImageObject, VideoObject, WebPage

## Key Features

- Content negotiation: handles HTML describe pages vs SPARQL DESCRIBE endpoints
- Filename-derived metadata: generates name, description, encodingFormat from filenames
- Thumbnail detection: probes content-explorer/thumbnails/ for existing thumbnails
- Category inference: detects infographic/guide/demo/survey from filename patterns
- SHACL-compliant: shapes use minCount 0 for optional properties (thumbnailUrl, dates)

## Usage

```bash
python3 infographic-describer/scripts/describe-infographics.py \
  --directory infographics \
  --output /path/to/output.ttl
```

## Testing

- Validated: 51 infographic files → 357 triples, valid Turtle
- Script syntax check: passed
- Thumbnail detection: 1 out of 51 files has a thumbnail