### PR TITLE
feat(memory+dwingler): endpoint-first SPARQL override, new standing instructions, remote SPARQL routing

### DIFF
--- a/agent-rdf-memory/howto/artifact-routing.ttl
+++ b/agent-rdf-memory/howto/artifact-routing.ttl
@@ -7,14 +7,16 @@
     schema:name "Artifact Routing — Output Directories and Terminology"@en ;
     schema:description "Rules for routing generated artifacts (RDF, HTML, Markdown) to the correct model-specific output directories, preserving active model identity, and applying the meshup vs mashup terminology rule."@en ;
     schema:dateCreated "2026-06-05T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-07-06T19:25:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-07-17T18:44:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :step-outputDirs, :step-gpt5ChatCodexOutputDirs,
         :step-mashupVsMeshup, :step-defaultOutputRoot, :step-modelOverEnvironment,
-        :step-noPromptModelOverride, :step-savedPromptsFolder ;
+        :step-noPromptModelOverride, :step-savedPromptsFolder, :step-vspsFolder,
+        :step-screencastDistributionArtifacts ;
     schema:step :step-outputDirs, :step-gpt5ChatCodexOutputDirs,
         :step-mashupVsMeshup, :step-defaultOutputRoot, :step-modelOverEnvironment,
-        :step-noPromptModelOverride, :step-savedPromptsFolder ;
+        :step-noPromptModelOverride, :step-savedPromptsFolder, :step-vspsFolder,
+        :step-screencastDistributionArtifacts ;
     rdfs:seeAlso <../preferences.ttl> .
 
 # ── Step 1: Output Directory Routing ─────────────────────────────────────────
@@ -75,3 +77,26 @@
     schema:name "Reusable reproduction prompts go in a saved-prompts/ sibling folder, never inside md/"@en ;
     schema:text """When a user asks for the prompt that would reproduce a generated collection (or any other standalone reusable prompt text) to be saved, write it to {model-root}/saved-prompts/{slug}-reproduction-prompt.md — a SIBLING of rdf/, md/, and webpages/ under the same model-specific output root, never a file placed inside md/. A reproduction prompt is a distinct artifact type from the collection's own Markdown companion document, even though both use the .md extension; conflating them in the same folder makes the companion doc and the meta-prompt indistinguishable at a glance. Found and corrected 2026-07-06: a reproduction prompt was first saved to Claude Generated/md/ alongside the actual MD companion; user corrected it to a new saved-prompts/ sibling directory. Create the directory if it does not yet exist — do not ask for a different location, since the model-specific root itself is already established by step-outputDirs."""@en ;
     rdfs:seeAlso <../preferences.ttl>, <../core.ttl> .
+
+# ── Step 9: vsps/ Sibling Folder for Virtuoso Server Page Artifacts ──────────
+
+:step-vspsFolder a schema:HowToStep ;
+    schema:position "9"^^xsd:integer ;
+    schema:name "Generated VSP artifacts go in a vsps/ sibling folder under the model-specific output root"@en ;
+    schema:text """When a task produces a Virtuoso Server Page (.vsp) — plus any deployment companions such as an isql deploy script or README — write them to {model-root}/vsps/, a SIBLING of rdf/, md/, webpages/, and saved-prompts/ under the output root resolved by step-outputDirs. Group multi-file VSP deliverables in a per-artifact subfolder (e.g. vsps/webpages-weblog/) when more than one VSP collection accumulates. Create the vsps/ directory if it does not yet exist. Established 2026-07-16 when a weblog index.vsp for /DAV/home/kidehen/webpages/ was first misplaced in a repo-root vsp-weblog/ folder and Kingsley routed it to the prefs-discerned destination."""@en ;
+    rdfs:seeAlso <../preferences.ttl> .
+
+# ── Step 10: Screencast Distribution Bundles ────────────────────────────────
+
+:step-screencastDistributionArtifacts a schema:HowToStep ;
+    schema:position "10"^^xsd:integer ;
+    schema:name "HTML wrappers that embed screencasts are routed with screencast assets, not webpages/"@en ;
+    schema:text """When an HTML document embeds, frames, or primarily distributes a screencast/video recording, classify it as part of the screencast distribution bundle. Route it to {model-root}/screencasts/ alongside the MP4/WebM, voiceover MP3, VTT/SRT captions, poster frames, logs, and storyboard files. Do not place such HTML wrappers in {model-root}/webpages/ unless the user explicitly requests a standalone web article/page separate from the screencast bundle.
+
+Bundle rules:
+1. Use relative media links inside the HTML for MP4, WebM, MP3, VTT, SRT, and poster assets that live in the same screencasts/ folder.
+2. Avoid absolute local file: or /Users/... media URLs in distributable HTML.
+3. Apply hero-meta attribution and footer attribution using the skills + AI agent on-behalf-of principal pattern from kg-curation-attribution.ttl.
+4. Keep generator scripts and drafts in their work folder if needed, but mirror the final distribution bundle to {model-root}/screencasts/.
+5. Remove or clearly supersede any accidental copy in webpages/ so there is only one canonical local distribution location."""@en ;
+    rdfs:seeAlso <../preferences.ttl>, <screencast-distribution-artifacts.ttl>, <kg-curation-attribution.ttl>, <infographic-authoring.ttl> .

--- a/agent-rdf-memory/howto/curl-first-mcp-last-resort.ttl
+++ b/agent-rdf-memory/howto/curl-first-mcp-last-resort.ttl
@@ -1,0 +1,22 @@
+@prefix schema: <http://schema.org/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <#> .
+
+:howto a schema:HowTo ;
+    schema:name "curl first; MCP tools last resort"@en ;
+    schema:dateCreated "2026-07-16"^^xsd:date ;
+    schema:description "Tool-selection order for HTTP and data interactions, stated by Kingsley Idehen on 2026-07-16."@en ;
+    schema:step :step1, :step2, :step3 .
+
+:step1 a schema:HowToStep ;
+    schema:position 1 ;
+    schema:text "HTTP interactions (GET, PUT, PROPFIND, feed fetches, endpoint probes, content negotiation) use curl via Bash. WebDAV listings use 'curl -X PROPFIND -H \"Depth: 1\"'."@en .
+
+:step2 a schema:HowToStep ;
+    schema:position 2 ;
+    schema:text "Database access prefers local CLI (isql) when credentials are available; filesystem reads/writes prefer local tools."@en .
+
+:step3 a schema:HowToStep ;
+    schema:position 3 ;
+    schema:text "MCP server tools are the LAST resort — only when privileged server-side access is required and no curl/CLI path exists. State the justification before using them."@en .

--- a/agent-rdf-memory/howto/resolvable-iri-payload-presentation.ttl
+++ b/agent-rdf-memory/howto/resolvable-iri-payload-presentation.ttl
@@ -1,0 +1,37 @@
+@prefix : <#> .
+@prefix schema: <http://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix onto: <../ontology.ttl#> .
+
+<> a schema:CreativeWork ;
+    schema:name "Resolvable IRI Payload Presentation"@en ;
+    schema:description "Presentation rule for query/tool results containing both human labels and resolvable IRIs: hyperlink labels and avoid redundant raw-IRI columns by default."@en ;
+    schema:dateCreated "2026-07-17T15:35:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-07-17T15:35:00Z"^^xsd:dateTime ;
+    schema:author <https://linkedin.com/in/kidehen#this> ;
+    schema:about :resolvableIriPayloadPresentation ;
+    rdfs:seeAlso <../preferences.ttl> .
+
+:resolvableIriPayloadPresentation a schema:HowTo ;
+    schema:name "Present Resolvable IRIs as Hyperlinked Labels"@en ;
+    schema:description "Default response presentation for payloads that pair labels/titles with resolvable IRIs."@en ;
+    schema:step :stepDetectLabelIriPairs, :stepRenderLabelAsLink, :stepPreserveRawWhenRequested .
+
+:stepDetectLabelIriPairs a schema:HowToStep ;
+    schema:position 1 ;
+    schema:name "Detect label/title plus resolvable IRI pairs in payloads"@en ;
+    schema:text "When a result payload includes a human-readable label/title/name column and a URL/IRI column for the same entity, treat the IRI as the hyperlink target for the label rather than as a separate reader-facing value."@en ;
+    onto:hasTrigger onto:triggerPreferencesUpdate .
+
+:stepRenderLabelAsLink a schema:HowToStep ;
+    schema:position 2 ;
+    schema:name "Render labels as Markdown hyperlinks and omit redundant IRI columns"@en ;
+    schema:text "In chat-response tables and lists, render the label as [label](IRI) and remove the redundant raw-IRI column by default. This keeps result tables compact while preserving dereferenceability."@en ;
+    onto:hasTrigger onto:triggerPreferencesUpdate .
+
+:stepPreserveRawWhenRequested a schema:HowToStep ;
+    schema:position 3 ;
+    schema:name "Preserve raw IRI columns when explicitly requested"@en ;
+    schema:text "If the user asks for raw IRIs, machine-readable tables, debugging output, CSV/TSV-style columns, or separate identifier columns, include the raw IRI column in addition to or instead of hyperlinks."@en ;
+    onto:hasTrigger onto:triggerPreferencesUpdate .

--- a/agent-rdf-memory/howto/screencast-distribution-artifacts.ttl
+++ b/agent-rdf-memory/howto/screencast-distribution-artifacts.ttl
@@ -1,0 +1,55 @@
+@prefix : <#> .
+@prefix schema: <http://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<> a schema:HowTo ;
+    schema:name "Screencast Distribution Artifacts"@en ;
+    schema:description "Routing and attribution rules for screencast bundles, including HTML documents that embed or distribute video recordings with captions and voiceover."@en ;
+    schema:dateCreated "2026-07-17T18:44:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-07-17T19:14:00Z"^^xsd:dateTime ;
+    schema:author <https://linkedin.com/in/kidehen#this> ;
+    schema:about :screencastDistributionWorkflow ;
+    rdfs:seeAlso <../preferences.ttl>, <artifact-routing.ttl>, <kg-curation-attribution.ttl>, <infographic-authoring.ttl> .
+
+:screencastDistributionWorkflow a schema:HowTo ;
+    schema:name "Route and Attribute Screencast Distribution Bundles"@en ;
+    schema:description "A screencast bundle may include video, audio, captions, storyboard files, logs, poster frames, and an HTML wrapper. The HTML wrapper follows screencast routing, not ordinary webpage routing, when its purpose is to embed or distribute the recording."@en ;
+    schema:step :stepClassifyBundle,
+        :stepRouteToScreencasts,
+        :stepUseRelativeMediaLinks,
+        :stepApplyAttribution,
+        :stepEmbedRichMetadata,
+        :stepValidateBundle .
+
+:stepClassifyBundle a schema:HowToStep ;
+    schema:position 1 ;
+    schema:name "Classify HTML that embeds a screencast as part of the screencast bundle"@en ;
+    schema:text "If the HTML document's primary purpose is to play, frame, describe, or distribute a screencast/video recording, treat it as a screencast distribution artifact rather than an ordinary HTML webpage collection."@en .
+
+:stepRouteToScreencasts a schema:HowToStep ;
+    schema:position 2 ;
+    schema:name "Route the final bundle to {model-root}/screencasts/"@en ;
+    schema:text "Place the final HTML wrapper, MP4/WebM files, voiceover MP3, VTT/SRT captions, poster frames, logs, and storyboard files in the model-specific screencasts/ folder. For GPT-5 Chat Codex Desktop, that is {LLM_ROOT}/GPT5-Chat-Generated/screencasts/."@en .
+
+:stepUseRelativeMediaLinks a schema:HowToStep ;
+    schema:position 3 ;
+    schema:name "Use bundle-relative media links"@en ;
+    schema:text "Inside the distributable HTML wrapper, link to local MP4/WebM/MP3/VTT/SRT/poster assets using relative href/src values when those assets are in the same screencasts/ folder. Do not use file: URLs or absolute /Users/... paths in distributable HTML."@en .
+
+:stepApplyAttribution a schema:HowToStep ;
+    schema:position 4 ;
+    schema:name "Apply hero and footer on-behalf-of attribution"@en ;
+    schema:text "HTML wrappers for screencasts still inherit generated-HTML attribution rules: include a hero-meta or equivalent visible hero attribution and a footer attribution variant that names the producing skills, the AI agent/model, and the human principal using the on-behalf-of pattern. Follow kg-curation-attribution.ttl and use <p> prose in the footer rather than chip-style attribution divs."@en ;
+    rdfs:seeAlso <kg-curation-attribution.ttl>, <infographic-authoring.ttl> .
+
+:stepEmbedRichMetadata a schema:HowToStep ;
+    schema:position 5 ;
+    schema:name "Embed rich JSON-LD and POSH metadata"@en ;
+    schema:text "Every screencast HTML wrapper must include rich machine-readable metadata: a script type=\"application/ld+json\" graph describing the WebPage/CreativeWork, VideoObject, AudioObject, caption sidecars, producing skills/agents, principal/accountablePerson, and prov:actedOnBehalfOf delegation; plus POSH head links/meta such as rel=\"author\", rel=\"me\", rel=\"about\", rel=\"alternate\" for captions, rel=\"enclosure\" for video/audio, description, author, Open Graph, and Twitter card metadata. Validate the JSON-LD parses before delivery."@en ;
+    rdfs:seeAlso <kg-curation-attribution.ttl>, <rdf-document-authoring.ttl> .
+
+:stepValidateBundle a schema:HowToStep ;
+    schema:position 6 ;
+    schema:name "Validate the bundle before delivery"@en ;
+    schema:text "Before delivery, verify that the HTML file lives in screencasts/, every relative media/caption link resolves, embedded JSON-LD parses, POSH links are present, the MP4 contains expected video/audio/subtitle streams when applicable, and no stale canonical copy remains in webpages/ unless explicitly requested as a separate webpage artifact."@en .

--- a/agent-rdf-memory/preferences.ttl
+++ b/agent-rdf-memory/preferences.ttl
@@ -10,7 +10,7 @@
 <> a schema:CreativeWork ;
     schema:name "preferences.ttl"@en ;
     schema:description "Configuration for agent RDF memory management and semantic memory skill usage." ;
-    schema:dateModified "2026-07-14T19:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-07-17T18:44:00Z"^^xsd:dateTime ;
     schema:dateCreated "2026-05-29T17:22:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :agentBehaviorGuide .
@@ -124,7 +124,8 @@
         :step-noMemoryMdWrite, :step-preferencesSparse, :step-secretEchoRedaction,
         :step-preferencesPresentationFormat,
         :step-sessionLogReconciliation,
-        :step-semanticSessionBootstrap, :step-symbolicLogOffloading .
+        :step-semanticSessionBootstrap, :step-symbolicLogOffloading,
+        :step-resolvableIriPayloadPresentation .
 
 # ── 3. Artifact Output Routing ──────────────────────────────────────────────
 
@@ -132,13 +133,14 @@
     schema:name "Artifact Output Routing"@en ;
     schema:description "Model-specific output directory routing, model identity pre-flight gate, model-over-environment tiebreaker, prompt-specified model-name override prevention, artifact placement elicitation, and remote WebDAV upload."@en ;
     rdfs:seeAlso <howto/artifact-routing.ttl>,
+        <howto/screencast-distribution-artifacts.ttl>,
         <howto/remote-webdav-upload.ttl>,
         <howto/filesystem-path-verification.ttl>,
         <howto/model-identity-resolution.ttl> ;
     schema:step :step-outputDirs, :step-gpt5ChatCodexOutputDirs,
         :step-modelIdentityPreflight, :step-defaultOutputRoot,
         :step-modelOverEnvironment, :step-noPromptModelOverride, :step-modelIdentityResolution,
-        :step-artifactPlacement,
+        :step-artifactPlacement, :step-screencastDistributionArtifacts,
         :step-remoteWebdavUpload, :step-savedPromptsFolder, :step-filesystemPathVerification .
 
 # ── 4. RDF Authoring & Entity Resolution ────────────────────────────────────
@@ -1777,3 +1779,39 @@
     schema:text "Before writing a schema:Person, DefinedTerm, or TBox registry entry, grep the actual source document for its real asserted IRI instead of guessing a plausible slug, and manually review any census-surfaced owl:sameAs cluster before reuse since corpus documents can themselves contain entity-resolution errors."@en ;
     onto:hasTrigger onto:triggerBehaviorGapIdentified ;
     rdfs:seeAlso <howto/entity-registry-census-verification.ttl>, <howto/external-iri-verification.ttl>, <entities/people.ttl> .
+
+# ── Step 133: HTTP Interactions Use curl First; MCP Tools Are Last Resort ────
+
+:step-curlFirstMcpLastResort a schema:HowToStep ;
+    schema:position 133 ;
+    schema:name "Use curl (or other local CLI tools) for HTTP interactions; invoke MCP server tools only as a last resort"@en ;
+    schema:text "For fetching pages, WebDAV PROPFIND/PUT, feed retrieval, and endpoint probing, always reach for curl and local CLI utilities first. MCP tools (execute_sql_query, EXECUTE_SQL_SCRIPT, WEB_FETCH, etc.) are a last resort, justified only when the task genuinely requires privileged server-side access that no local CLI path (curl, isql with known credentials, filesystem) can provide. Stated by Kingsley on 2026-07-16 after an MCP SQL call was used where a curl PROPFIND sufficed."@en ;
+    onto:hasTrigger onto:triggerBehaviorGapIdentified ;
+    rdfs:seeAlso <howto/curl-first-mcp-last-resort.ttl> .
+
+# ── Step 134: VSP Artifacts Route to a vsps/ Subfolder of the Model Output Root ──
+
+:step-vspArtifactsFolder a schema:HowToStep ;
+    schema:position 134 ;
+    schema:name "Generated VSP (Virtuoso Server Page) artifacts go in a vsps/ subfolder under the model-specific output root"@en ;
+    schema:text "VSP pages and their deployment companions (SQL deploy scripts, READMEs) are routed to {model-root}/vsps/ — a sibling of rdf/, md/, webpages/, and saved-prompts/ under the output root resolved by artifact-routing step-outputDirs (e.g. Claude models → {LLM_ROOT}/Claude Generated/vsps/). Never leave them in the working repo or a generator work folder. Stated by Kingsley on 2026-07-16 when a weblog index.vsp was first placed in a repo-root vsp-weblog/ folder."@en ;
+    onto:hasTrigger onto:triggerArtifactGeneration ;
+    rdfs:seeAlso <howto/artifact-routing.ttl> .
+
+# ── Step 135: Resolvable IRI Payload Presentation ───────────────────────────
+
+:step-resolvableIriPayloadPresentation a schema:HowToStep ;
+    schema:position 135 ;
+    schema:name "When result payloads contain resolvable IRIs, hyperlink the label and omit redundant raw-IRI columns by default"@en ;
+    schema:text "For chat-response tables or lists derived from query/tool payloads that include both a human label/title and its resolvable IRI, render the human label/title as a Markdown hyperlink to that IRI and drop any redundant separate IRI column unless the user explicitly asks for raw IRIs, debugging output, or machine-readable tabular columns."@en ;
+    onto:hasTrigger onto:triggerPreferencesUpdate, onto:triggerBehaviorGapIdentified ;
+    rdfs:seeAlso <howto/resolvable-iri-payload-presentation.ttl> .
+
+# ── Step 136: Screencast Distribution Artifacts ─────────────────────────────
+
+:step-screencastDistributionArtifacts a schema:HowToStep ;
+    schema:position 136 ;
+    schema:name "HTML documents that embed screencasts are screencast distribution artifacts and go in the model screencasts/ folder"@en ;
+    schema:text "When an HTML document embeds or primarily distributes a screencast, route that HTML wrapper plus caption sidecars, narration assets, and the video files to {model-root}/screencasts/ rather than {model-root}/webpages/. Use bundle-relative media links, and apply the same hero-meta and footer on-behalf-of attribution rules used for generated HTML artifacts."@en ;
+    onto:hasTrigger onto:triggerPreferencesUpdate, onto:triggerArtifactGeneration, onto:triggerBehaviorGapIdentified ;
+    rdfs:seeAlso <howto/screencast-distribution-artifacts.ttl>, <howto/artifact-routing.ttl>, <howto/kg-curation-attribution.ttl>, <howto/infographic-authoring.ttl> .

--- a/data-twingler/SKILL.md
+++ b/data-twingler/SKILL.md
@@ -66,6 +66,30 @@ Use default endpoint. Format `text/x-html+tr`. Max 20 rows. Tabulate results.
 - Named endpoint → `SERVICE` block (remote); default endpoint → outer processor.
 - `SERVICE` block **must** contain a `SELECT` with an inner `LIMIT`.
 
+### Remote SPARQL Endpoint Intent
+**Trigger:** User names a known remote knowledge graph or endpoint brand, even
+when the prompt does not include the endpoint URL literally. Examples:
+`DBpedia`, `Wikidata`, `Bio2RDF`, `UniProt`, or "Using DBpedia...".
+
+For API, REST, MCP, OPAL, or A2A-mediated execution, normalize the intent to a
+remote SPARQL call before invoking a backend function:
+
+| Mention | Endpoint URL |
+|---|---|
+| `DBpedia` | `https://dbpedia.org/sparql` |
+| `Wikidata` | `https://query.wikidata.org/sparql` |
+
+Required parameter contract:
+- Remote SPARQL function: provide both `url` and `query`.
+- Local SPARQL function: provide `query` and `format`.
+- SPASQL function: provide `sql`; include `max_rows`, `timeout`, and `format`
+  when the function surface supports them.
+
+Never call an OPAL/A2A backend query function with only the natural-language
+prompt when the target function requires structured parameters. If the user
+names a remote KG such as DBpedia, first generate the concrete SPARQL query and
+bind the endpoint URL, then invoke the function.
+
 ### SPASQL
 Wraps SPARQL inside SQL: `FROM (SPARQL ... WHERE ...) AS <alias>`
 
@@ -144,9 +168,10 @@ enumeration has been attempted.
 ### Step 0 — Local Vector Search (Local-First, Pre-Graph Discovery)
 
 **Every** T5, T6, T7, and T8 query MUST execute a local vector search
-**before** any endpoint call. This inverts the workflow: local RDF files
-are the primary data space; URIBurner and fallback endpoints are the
-secondary layer.
+**before** any endpoint call — unless the user signals KG-only mode or
+names an endpoint (see Rule 1 override). This inverts the workflow: local
+RDF files are the primary data space; URIBurner and fallback endpoints are
+the secondary layer.
 
 #### Folder Resolution
 
@@ -417,6 +442,7 @@ examine `?s1` and `?o1`:
 | Function | Signature | Use Case |
 |---|---|---|
 | `UB.DBA.sparqlQuery` | `(query, format)` | SPARQL |
+| `OAI.DBA.sparqlRemoteQuery` | `(url, query)` | Remote SPARQL |
 | `Demo.demo.execute_spasql_query` | `(sql, maxrows, timeout)` | SPASQL |
 | `UB.DBA.sparqlQuery` | `(sql, url)` | SQL |
 | `DB.DBA.graphqlQuery` | `(query)` | GraphQL |
@@ -428,11 +454,54 @@ speed are not valid reasons to bypass the template gate.
 
 Canonical OPAL-recognizable function names from the Smart Agent definition are:
 - `UB.DBA.sparqlQuery` with signature `(query, format)` for SPARQL
+- `OAI.DBA.sparqlRemoteQuery` with signature `(url, query)` for remote SPARQL
 - `Demo.demo.execute_spasql_query` with signature `(sql, maxrows, timeout)` for SPASQL
 - `UB.DBA.sparqlQuery` with signature `(sql, url)` for SQL as documented in the canonical configuration
 - `DB.DBA.graphqlQuery` with signature `(query)` for GraphQL
 
 Treat OPAL as an agent routing layer over these named functions, not merely another transport.
+
+### OPAL/A2A Parameter Preflight
+
+Before invoking Data Twingler through OPAL Agent routing or A2A, build and
+verify the exact structured function arguments that the selected backend
+function requires.
+
+For a prompt such as:
+
+```text
+Using DBpedia, list movies by Spike Lee.
+```
+
+The preflight MUST produce either:
+
+```json
+{
+  "function": "OAI.DBA.sparqlRemoteQuery",
+  "arguments": {
+    "url": "https://dbpedia.org/sparql",
+    "query": "PREFIX dbr: <http://dbpedia.org/resource/> ... SELECT ..."
+  }
+}
+```
+
+or, when the route is SPASQL:
+
+```json
+{
+  "function": "Demo.demo.execute_spasql_query",
+  "arguments": {
+    "sql": "SPARQL PREFIX dbr: <http://dbpedia.org/resource/> ... SELECT ...",
+    "maxrows": 20,
+    "timeout": 30
+  }
+}
+```
+
+Abort with an actionable error before the backend call if any required
+parameter is missing. Report the missing parameter name and the intended
+function. Do not send a backend function call with an empty, null, or
+natural-language-only placeholder for `url`, `query`, or `sql`.
 
 ---
 
@@ -455,7 +524,12 @@ The local-first workflow inverts the traditional order:
 The local-first + KG-hybrid workflow:
 
 ```
-Step 0 (Local Vector Search) → Step 1a (bif:contains Keyword) → Step 1b (vvec:cosine Vector) → Semantic Variants → Fallback Endpoints → Final Report
+[User signals KG-only?] → YES → Step 1a (bif:contains Keyword) directly
+                     ↓ NO
+Step 0 (Local Vector Search) → [zero match?] → YES → Step 1a (bif:contains)
+                              ↓ match found → checkpoint → user confirms → answer
+                                                      ↓ declines → Step 1a
+Step 1a (bif:contains Keyword) → Step 1b (vvec:cosine Vector) → Semantic Variants → Fallback Endpoints → Final Report
 ```
 
 1. **Local Vector Search** (Step 0) — Executes first, before any endpoint call.
@@ -507,6 +581,14 @@ Step 0 (Local Vector Search) → Step 1a (bif:contains Keyword) → Step 1b (vve
    checkpoint before proceeding to endpoint queries. Do not skip local search
    because an endpoint "should" have the answer or because a KG was recently
    generated — the local file is the source of truth.
+   - **Endpoint-first override:** When the user signals KG-only mode, names
+     URIBurner, or says "query the endpoint", skip Step 0 entirely and proceed
+     directly to Graph IRI Discovery on the default endpoint. Per
+     `preferences.ttl` step `:step-sparqlEndpointSearchOrder`.
+   - **Early-exit on zero match:** If the first local search pass returns zero
+     matches, pivot to the endpoint immediately. Do not repeat local search
+     with variant terms — the endpoint's `bif:contains` full-text index is
+     faster and more comprehensive than additional local file scanning.
 2. Use predefined templates **before any query execution** — direct queries,
    ad-hoc SPARQL/SPASQL/SQL, and general LLM knowledge all come after template
    matching is attempted and either succeeds or is honestly exhausted.
@@ -546,3 +628,8 @@ Step 0 (Local Vector Search) → Step 1a (bif:contains Keyword) → Step 1b (vve
 14. Leverage caching (TTL 3600s) and parallel execution.
 15. Tabulate all query results by default.
 16. Read and follow `references/sparql-syntax-rules.md` before constructing any SPARQL query — structural validation (UNION placement, SERVICE limits, bif:contains usage, FILTER scoping) applies to both template-based and ad-hoc queries.
+17. For OPAL/A2A-routed execution, run the OPAL/A2A Parameter Preflight before
+    backend invocation. Remote KG prompts such as "Using DBpedia..." must bind
+    the remote endpoint URL and concrete SPARQL query; SPASQL prompts must bind
+    the `sql` string. Never rely on the backend to infer these required
+    parameters from only the natural-language message.

--- a/data-twingler/references/protocol-routing.md
+++ b/data-twingler/references/protocol-routing.md
@@ -43,6 +43,31 @@ Do not retry a failed call more than once before triggering the OAuth flow.
 
 Use the URIBurner REST function surface when direct native execution is not the selected route. Keep OPAL naming distinct from raw REST endpoint naming.
 
+### Required Parameters
+
+Before calling a REST, MCP, OPAL, or A2A backend function, construct and verify
+the required structured parameters for the chosen function.
+
+| Intent | Function | Required parameters |
+|---|---|---|
+| Local SPARQL | `UB.DBA.sparqlQuery` | `query`, `format` |
+| Remote SPARQL | `OAI.DBA.sparqlRemoteQuery` | `url`, `query` |
+| SPASQL | `Demo.demo.execute_spasql_query` | `sql` |
+| SQL | `Demo.demo.execute_sql_query` | `sql` |
+| GraphQL | `DB.DBA.graphqlQuery` | `query` |
+
+Known remote KG aliases:
+
+| Alias | Endpoint URL |
+|---|---|
+| `DBpedia` | `https://dbpedia.org/sparql` |
+| `Wikidata` | `https://query.wikidata.org/sparql` |
+
+If a user asks "Using DBpedia, ...", treat that as remote SPARQL intent and
+bind `url=https://dbpedia.org/sparql` plus a generated SPARQL `query` before
+calling the backend. Do not forward only the natural-language prompt to a
+function that requires `url`, `query`, or `sql`.
+
 ## MCP
 
 Endpoints:
@@ -56,7 +81,31 @@ Guidance:
 
 Treat OPAL as an agent layer over recognizable tools/functions. Use the canonical Smart Agent function names when the user asks for OPAL-oriented routing:
 - `UB.DBA.sparqlQuery`
+- `OAI.DBA.sparqlRemoteQuery`
 - `Demo.demo.execute_spasql_query`
 - `DB.DBA.graphqlQuery`
 
 Keep authenticated `chatPromptComplete` as a separate routing option after MCP; do not present it as one of the canonical Data Twingler tool names unless the source configuration is updated.
+
+### OPAL/A2A Guard
+
+For OPAL/A2A routing, perform a preflight check immediately before the backend
+function call:
+
+1. Identify the intended function.
+2. Build the concrete argument object.
+3. Verify all required parameters are non-empty strings or valid values.
+4. If anything is missing, return an actionable error naming the missing
+   parameter and function instead of making the backend call.
+
+Example preflight result for "Using DBpedia, list movies by Spike Lee":
+
+```json
+{
+  "function": "OAI.DBA.sparqlRemoteQuery",
+  "arguments": {
+    "url": "https://dbpedia.org/sparql",
+    "query": "PREFIX dbr: <http://dbpedia.org/resource/>\\nPREFIX dbo: <http://dbpedia.org/ontology/>\\nSELECT DISTINCT ?movie WHERE { ?movie a dbo:Film ; dbo:director dbr:Spike_Lee . } LIMIT 20"
+  }
+}
+```


### PR DESCRIPTION
## Changes

### Preferences (steps 133-136)
- **curl-first-mcp-last-resort**: HTTP interactions use curl before MCP tools (step 133)
- **vsp-artifacts-folder**: VSP routes to `{model-root}/vsps/` (step 134)
- **resolvable-iri-payload-presentation**: hyperlink labels, drop raw IRI columns (step 135)
- **screencast-distribution-artifacts**: screencast HTML to `{model-root}/screencasts/` (step 136)

### Data Twingler
- **Rule 1**: endpoint-first override — KG-only mode skips local search, queries SPARQL endpoint directly (per preferences.ttl step `step-sparqlEndpointSearchOrder`)
- **Rule 1**: early-exit on zero local matches — pivot to `bif:contains` immediately, no variant-term retry
- **Step 0 preamble**: references override from preferences.ttl
- **Workflow diagram**: branching logic for KG-only vs local-first
- **Remote SPARQL intent routing**: DBpedia, Wikidata endpoint aliases with required parameter contract
- **OPAL/A2A parameter preflight**: required params (`url`, `query`, `sql`) before backend calls

### Companion HowTos
- `curl-first-mcp-last-resort.ttl`
- `resolvable-iri-payload-presentation.ttl`
- `screencast-distribution-artifacts.ttl`
- `artifact-routing.ttl` updated with VSP + screencast routing

---

Session context: big-pickle + OpenCode, 2026-07-15. Endpoint-first optimization triggered by URIBurner `bif:contains` speed observation during KG-only retry.