### PR TITLE
Agent RDF memory: step-level granularity across the howto corpus

### DIFF
--- a/agent-rdf-memory/howto/agent-identity.ttl
+++ b/agent-rdf-memory/howto/agent-identity.ttl
@@ -7,39 +7,120 @@
     schema:name "Agent Identity — Whoami Format, Verified Identity Gate, and Stripe Sandbox Card"@en ;
     schema:description "Rules for agent identity presentation: the canonical two-section bullet response to whoami (with verified identity lines for both user and agent), the certificate verification gate that runs before composing the response, and the Stripe sandbox card credentials for ACP test payments."@en ;
     schema:dateCreated "2026-06-05T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-07-14T00:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-07-19T00:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
-    schema:about :step-whoamiFormat, :step-verifiedIdentityGate, :step-stripeSandboxCard ;
-    schema:step :step-whoamiFormat, :step-verifiedIdentityGate, :step-stripeSandboxCard ;
+    schema:step :step-classifyTrigger, :step-runGateForTriggerA, :step-emitUserSection,
+        :step-emitAgentSection, :step-sameAsHyperlinks, :step-currentSessionValues,
+        :step-resolveCredentialDirs, :step-modulusVerification, :step-assignBadges,
+        :step-stripeSandboxCard ;
+    schema:workExample :workExample-triggerAResponse, :workExample-triggerBResponse,
+        :workExample-knownSanUris ;
     rdfs:seeAlso <../preferences.ttl#step-whoamiFormat>, <../preferences.ttl#step-webidTlsVerification>, <../preferences.ttl#step-urlsAsHyperlinks>, <../preferences.ttl#step-whoamiSameAsHyperlinks>, <../preferences.ttl#step-stripeSandboxCard>, <verified-identity.ttl>,
         <filesystem-path-verification.ttl> .
 
-# ── Step 1: Whoami Format ─────────────────────────────────────────────────────
+# ══ Section A: Whoami Response Composition (Steps 1–6) ═══════════════════════
 
-:step-whoamiFormat a schema:HowToStep ;
+# ── Step 1: Classify the Identity Query Trigger ──────────────────────────────
+
+:step-classifyTrigger a schema:HowToStep ;
     schema:position "1"^^xsd:integer ;
-    schema:name "Respond to identity queries: full two-section for 'whoami', agent-only for 'who are you?'"@en ;
-    schema:text """Identity queries have two triggers:
+    schema:name "Classify the identity query: 'whoami?' → Trigger A (full two-section); 'who are you?' → Trigger B (agent-only)"@en ;
+    schema:text "Identity queries have two triggers. Trigger A — 'whoami?' — produces the full two-section response (User + Agent) with verification badges. Trigger B — 'who are you?' / 'who is this?' / 'identify yourself' — produces only the Agent section: no User lines, no cert verification, no ✅/⚠️ badges."@en .
 
-**Trigger A — "whoami?" → Full two-section (User + Agent):**
-Run the verified identity gate (Step 2), then respond with both sections.
+# ── Step 2: Run the Verification Gate (Trigger A Only) ───────────────────────
 
-**Trigger B — "who are you?" / "who is this?" / "identify yourself" → Agent-only:**
-Skip the verified identity gate. Respond with only the Agent section. No User lines, no cert verification.
+:step-runGateForTriggerA a schema:HowToStep ;
+    schema:position "2"^^xsd:integer ;
+    schema:name "For Trigger A, run the verified identity gate (Steps 7–9) before composing; for Trigger B, skip it"@en ;
+    schema:text "The verification gate (Steps 7–9) runs BEFORE composing a Trigger A response — it fills the ✅/⚠️ badges on the WebID, cert, On-Behalf-Of, and Delegation lines. Trigger B responses skip the gate entirely and omit badges."@en .
 
-After running the appropriate trigger, respond in this format:
+# ── Step 3: Emit the User Section (Trigger A Only) ───────────────────────────
 
-**For Trigger A ("whoami?") — Full two-section:**
+:step-emitUserSection a schema:HowToStep ;
+    schema:position "3"^^xsd:integer ;
+    schema:name "Emit the User (principal) section: name, email, role, WebID + badge, cert line, owl:sameAs links"@en ;
+    schema:text "The User section carries: Name (Kingsley Uyi Idehen), Email (kidehen@openlinksw.com), Role (Founder & CEO, OpenLink Software), WebID ({user SAN URI} with ✅ or ⚠️ Unverified badge), User cert ({subject} · {SHA-256 fingerprint} · {validFrom → validTo} · modulus ✅ match / ⚠️ mismatch against profile.ttl — omitted if no local credential files found), and the owl:sameAs hyperlink line (Step 5). See :workExample-triggerAResponse for the full template."@en .
 
-**User (principal)**
+# ── Step 4: Emit the Agent Section (Both Triggers) ───────────────────────────
+
+:step-emitAgentSection a schema:HowToStep ;
+    schema:position "4"^^xsd:integer ;
+    schema:name "Emit the Agent (me) section: model, environment, output root, project, memory store, contract, WebID, cert, On-Behalf-Of, delegation"@en ;
+    schema:text "The Agent section carries: Model ({model name} + {llm-id used in session filenames}), Environment, Artifact output root (from step-outputDirs rules for the active LLM model ID), Active project, Memory store (absolute path to agent-rdf-memory/), Behavioral contract (preferences.ttl with standing-instruction count and notable recent additions), Agent WebID, Agent cert line, On-Behalf-Of ({user SAN URI}), and — Trigger A only — the Delegation corroboration line (✅ Corroborated (both profiles) / ⚠️ Partially corroborated ({which side} missing) / ⚠️ Unconfirmed). Always emit the Agent WebID and On-Behalf-Of lines even when unverified. See both workExample templates."@en .
+
+# ── Step 5: owl:sameAs Hyperlink Line ────────────────────────────────────────
+
+:step-sameAsHyperlinks a schema:HowToStep ;
+    schema:position "5"^^xsd:integer ;
+    schema:name "Build the owl:sameAs line from <link rel=\"me\"> tags as [Title](URL) hyperlinks — never prose category descriptions"@en ;
+    schema:text "Grep <link rel=\"me\"> from the user WebID index.html and emit each as a [Title](URL) Markdown hyperlink, separated by · dots. Never substitute prose platform-category descriptions for the actual hyperlinked URIs. See :workExample-triggerAResponse for the expected rendering."@en ;
+    rdfs:seeAlso <../preferences.ttl#step-whoamiSameAsHyperlinks> .
+
+# ── Step 6: Current-Session Values Only ──────────────────────────────────────
+
+:step-currentSessionValues a schema:HowToStep ;
+    schema:position "6"^^xsd:integer ;
+    schema:name "Fill model, environment, and output root from the CURRENT session — never copy from a prior session"@en ;
+    schema:text "Use the current session's model and environment when filling the Agent section — never copy identity values from a prior session's response. Fill the artifact output root from step-outputDirs rules based on the active LLM model ID."@en ;
+    rdfs:seeAlso <filesystem-path-verification.ttl> .
+
+# ══ Section B: Verified Identity Gate (Steps 7–9) ════════════════════════════
+
+# ── Step 7: Resolve Credential Directories ───────────────────────────────────
+
+:step-resolveCredentialDirs a schema:HowToStep ;
+    schema:position "7"^^xsd:integer ;
+    schema:name "Resolve both credential directories via the blocking gate; elicit on failure — never guess a path"@en ;
+    schema:text """Both credential directories are resolved at session start by the verified-identity.ttl Step 0 blocking gate:
+  USER:  {resolved-credential-root}/Templates/YouID/link-in-bio-credentials-5/
+  AGENT: {resolved-credential-root}/Templates/YouID/link-in-bio-agent-credentials/
+If resolution fails, the gate elicits from the user — never guess a path."""@en ;
+    rdfs:seeAlso <verified-identity.ttl> .
+
+# ── Step 8: Modulus Verification Procedure ───────────────────────────────────
+
+:step-modulusVerification a schema:HowToStep ;
+    schema:position "8"^^xsd:integer ;
+    schema:name "For each party, compare the cert modulus against profile.ttl cert:modulus"@en ;
+    schema:text """For each party (user, then agent):
+  1. Find cert.pem (or cert.p12 → empty passphrase) in the credentials dir.
+  2. Extract SAN URI:
+       openssl x509 -noout -ext subjectAltName -in cert.pem
+  3. Read cert:modulus from local profile.ttl (grep 'cert:modulus' → lowercase hex).
+  4. Extract local cert modulus:
+       openssl x509 -noout -modulus -in cert.pem | sed 's/Modulus=//' | tr '[:upper:]' '[:lower:]'
+  5. Compare the two values.
+Full procedure: see howto/verified-identity.ttl."""@en ;
+    rdfs:seeAlso <verified-identity.ttl> .
+
+# ── Step 9: Assign Badges From the Comparison ────────────────────────────────
+
+:step-assignBadges a schema:HowToStep ;
+    schema:position "9"^^xsd:integer ;
+    schema:name "Match → SAN URI + ✅; mismatch or missing files → memory IRI + ⚠️ Unverified"@en ;
+    schema:text "If the moduli match, present the SAN URI with a ✅ badge. On mismatch or absent credential files, present the memory IRI with ⚠️ Unverified. Known-good SAN URIs are recorded in :workExample-knownSanUris for cross-checking."@en .
+
+# ══ Section C: Payments (Step 10) ════════════════════════════════════════════
+
+# ── Step 10: Stripe Sandbox Card ─────────────────────────────────────────────
+
+:step-stripeSandboxCard a schema:HowToStep ;
+    schema:position "10"^^xsd:integer ;
+    schema:name "Use Stripe sandbox card credentials for ACP test payments"@en ;
+    schema:text "When filling Stripe invoice payment forms for ACP subscription payments in test/sandbox mode, use these credentials: Card number 4242 4242 4242 4242, Expiration 01/27, Security code 123, Country United States, ZIP 12345. These are Stripe's standard test mode card details for validating subscription payment flows."@en ;
+    rdfs:seeAlso <../preferences.ttl#step-stripeSandboxCard> .
+
+# ══ Worked Examples ══════════════════════════════════════════════════════════
+
+:workExample-triggerAResponse a schema:CreativeWork ;
+    schema:name "Trigger A ('whoami?') — full two-section response template"@en ;
+    schema:text """**User (principal)**
 • Name: Kingsley Uyi Idehen
 • Email: kidehen@openlinksw.com
 • Role: Founder & CEO, OpenLink Software
 • WebID: {user SAN URI} {✅ | ⚠️ Unverified}
 • User cert: {subject} · {SHA-256 fingerprint} · {validFrom → validTo} · modulus {✅ match | ⚠️ mismatch} with profile.ttl (omitted if no local credential files found)
-• owl:sameAs: grep <link rel="me"> from {user WebID index.html path} and emit each as [Title](URL). Example output:
-  [LinkedIn](https://www.linkedin.com/in/kidehen#this) · [X](https://x.com/kidehen) · [Substack](https://substack.com/@kidehen) · [Mastodon](https://mastodon.social/@kidehen) · [Bluesky](https://bsky.app/profile/kidehen.bsky.social) · [Threads](https://www.threads.net/@kidehen) · [GitHub](https://github.com/kidehen) · [Linktree](https://linktr.ee/kidehen) · [ID.MyOpenLink.NET](https://id.myopenlink.net/~KingsleyUyiIdehen/Public/) · [Carrd](https://kidehen.carrd.co/) · [Glitch](https://glitch.com/~kidehen) · [Facebook](https://facebook.com/kidehen) · [Instagram](https://www.instagram.com/kidehen) · [TikTok](https://www.tiktok.com/@kidehen) · [RSS](https://www.openlinksw.com/data/podcasts/?a=rss) · [Atom](https://www.openlinksw.com/data/podcasts/?a=atom) · [Email](mailto:kidehen@openlinksw.com)
-  Never substitute prose platform-category descriptions for the actual hyperlinked URIs.
+• owl:sameAs: [LinkedIn](https://www.linkedin.com/in/kidehen#this) · [X](https://x.com/kidehen) · [Substack](https://substack.com/@kidehen) · [Mastodon](https://mastodon.social/@kidehen) · [Bluesky](https://bsky.app/profile/kidehen.bsky.social) · [Threads](https://www.threads.net/@kidehen) · [GitHub](https://github.com/kidehen) · [Linktree](https://linktr.ee/kidehen) · [ID.MyOpenLink.NET](https://id.myopenlink.net/~KingsleyUyiIdehen/Public/) · [Carrd](https://kidehen.carrd.co/) · [Glitch](https://glitch.com/~kidehen) · [Facebook](https://facebook.com/kidehen) · [Instagram](https://www.instagram.com/kidehen) · [TikTok](https://www.tiktok.com/@kidehen) · [RSS](https://www.openlinksw.com/data/podcasts/?a=rss) · [Atom](https://www.openlinksw.com/data/podcasts/?a=atom) · [Email](mailto:kidehen@openlinksw.com)
 
 **Agent (me)**
 • Model: {model name} ({llm-id used in session filenames})
@@ -51,11 +132,11 @@ After running the appropriate trigger, respond in this format:
 • Agent WebID: {agent SAN URI} {✅ | ⚠️ Unverified}
 • Agent cert: {subject} · {SHA-256 fingerprint} · {validFrom → validTo} · modulus {✅ match | ⚠️ mismatch} with profile.ttl
 • On-Behalf-Of: {user SAN URI} {✅ | ⚠️ Unverified}
-• Delegation: {✅ Corroborated (both profiles) | ⚠️ Partially corroborated ({which side} missing) | ⚠️ Unconfirmed}
+• Delegation: {✅ Corroborated (both profiles) | ⚠️ Partially corroborated ({which side} missing) | ⚠️ Unconfirmed}"""@en .
 
-**For Trigger B ("who are you?") — Agent-only, no badges:**
-
-**Agent (me)**
+:workExample-triggerBResponse a schema:CreativeWork ;
+    schema:name "Trigger B ('who are you?') — agent-only response template, no badges"@en ;
+    schema:text """**Agent (me)**
 • Model: {model name} ({llm-id})
 • Environment: {agent environment name}
 • Artifact output root: {path from step-outputDirs} (rdf/, md/, webpages/)
@@ -66,43 +147,9 @@ After running the appropriate trigger, respond in this format:
 • Agent cert: {subject} · {SHA-256 fingerprint} · {validFrom → validTo} (omitted if no local credential files found)
 • On-Behalf-Of: {user SAN URI}
 
-(Omit ✅/⚠ badges — no cert verification for Trigger B. Omit the User section entirely.)
-Use the current session's model and environment — never copy from a prior session. Fill the artifact output root from step-outputDirs rules based on the active LLM model ID. Always emit the Agent WebID and On-Behalf-Of lines even when unverified."""@en .
+(Omit ✅/⚠ badges — no cert verification for Trigger B. Omit the User section entirely.)"""@en .
 
-# ── Step 2: Verified Identity Gate ───────────────────────────────────────────
-
-:step-verifiedIdentityGate a schema:HowToStep ;
-    schema:position "2"^^xsd:integer ;
-    schema:name "Run the verified identity gate before composing the whoami response"@en ;
-    schema:text """This gate runs BEFORE responding to whoami. It fills the ✓ / ⚠ badges.
-
-USER verification — creds dir (resolved by verified-identity.ttl Step 0 blocking gate):
-  {resolved-credential-root}/Templates/YouID/link-in-bio-credentials-5/
-
-AGENT verification — creds dir (resolved by verified-identity.ttl Step 0 blocking gate):
-  {resolved-credential-root}/Templates/YouID/link-in-bio-agent-credentials/
-
-Both dirs are resolved at session start by the blocking gate. If resolution fails, the gate elicits from the user — never guess a path.
-
-For each party (user, then agent):
-  1. Find cert.pem (or cert.p12 → empty passphrase) in the credentials dir.
-  2. Extract SAN URI:
-       openssl x509 -noout -ext subjectAltName -in cert.pem
-  3. Read cert:modulus from local profile.ttl (grep 'cert:modulus' → lowercase hex).
-  4. Extract local cert modulus:
-       openssl x509 -noout -modulus -in cert.pem | sed 's/Modulus=//' | tr '[:upper:]' '[:lower:]'
-  5. Compare. Match → SAN URI + ✅. Mismatch or file absent → memory IRI + ⚠️ Unverified.
-
-Known SAN URIs from certs (as of 2026-06-19; owl:sameAs profile.ttl#identity in each bundle):
-  User:  https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/index.html#netid
-  Agent: https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/index.html#netid
-
-Full procedure: see howto/verified-identity.ttl."""@en ;
-    rdfs:seeAlso <verified-identity.ttl> .
-
-# ── Step 2: Stripe Sandbox Card ──────────────────────────────────────────────
-
-:step-stripeSandboxCard a schema:HowToStep ;
-    schema:position "2"^^xsd:integer ;
-    schema:name "Use Stripe sandbox card credentials for ACP test payments"@en ;
-    schema:text "When filling Stripe invoice payment forms for ACP subscription payments in test/sandbox mode, use these credentials: Card number 4242 4242 4242 4242, Expiration 01/27, Security code 123, Country United States, ZIP 12345. These are Stripe's standard test mode card details for validating subscription payment flows."@en .
+:workExample-knownSanUris a schema:CreativeWork ;
+    schema:name "Known SAN URIs from certs (as of 2026-06-19; owl:sameAs profile.ttl#identity in each bundle)"@en ;
+    schema:text """User:  https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/index.html#netid
+Agent: https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/index.html#netid"""@en .

--- a/agent-rdf-memory/howto/artifact-routing.ttl
+++ b/agent-rdf-memory/howto/artifact-routing.ttl
@@ -9,13 +9,10 @@
     schema:dateCreated "2026-06-05T00:00:00Z"^^xsd:dateTime ;
     schema:dateModified "2026-07-17T18:44:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
-    schema:about :step-outputDirs, :step-gpt5ChatCodexOutputDirs,
-        :step-mashupVsMeshup, :step-defaultOutputRoot, :step-modelOverEnvironment,
-        :step-noPromptModelOverride, :step-savedPromptsFolder, :step-vspsFolder,
-        :step-screencastDistributionArtifacts ;
     schema:step :step-outputDirs, :step-gpt5ChatCodexOutputDirs,
         :step-mashupVsMeshup, :step-defaultOutputRoot, :step-modelOverEnvironment,
-        :step-noPromptModelOverride, :step-savedPromptsFolder, :step-vspsFolder,
+        :step-noPromptModelOverride, :step-outputRootBlockingGate,
+        :step-savedPromptsFolder, :step-vspsFolder,
         :step-screencastDistributionArtifacts ;
     rdfs:seeAlso <../preferences.ttl#step-outputDirs>, <../preferences.ttl#step-defaultOutputRoot>, <../preferences.ttl#step-gpt5ChatCodexOutputDirs>, <../preferences.ttl#step-modelOverEnvironment>, <../preferences.ttl#step-modelIdentityPreflight>, <../preferences.ttl#step-noPromptModelOverride>, <../preferences.ttl#step-mashupVsMeshup>, <../preferences.ttl#step-savedPromptsFolder>, <../preferences.ttl#step-vspArtifactsFolder>, <../preferences.ttl#step-screencastDistributionArtifacts>, <../preferences.ttl#step-chatResponsePortableLinks> .
 

--- a/agent-rdf-memory/howto/canonical-entity-iri-denotation.ttl
+++ b/agent-rdf-memory/howto/canonical-entity-iri-denotation.ttl
@@ -9,144 +9,108 @@
     schema:name "Canonical Entity IRI Denotation"@en ;
     schema:description "Rules for assigning canonical IRIs to people, organizations, software, and countries, and for correctly using owl:sameAs vs schema:sameAs. Establishes the principle that canonical platform IRIs replace document-local entity IRIs, never coexist with them."@en ;
     schema:dateCreated "2026-06-04T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-06-04T00:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-07-19T00:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
-    schema:about :step-canonicalPriority, :step-owlSameAsVsSchemaSameAs,
-        :step-localIriProhibition ;
-    schema:step :step-canonicalPriority, :step-owlSameAsVsSchemaSameAs,
-        :step-localIriProhibition ;
+    schema:step :step-personLadder, :step-nonPersonLadders, :step-thisFragmentRule,
+        :step-owlSameAsSemantics, :step-schemaSameAsSemantics, :step-sameAsDecisionRule,
+        :step-localIriProhibition, :step-localIriException ;
+    schema:workExample :workExample-sameAsQuickReference, :workExample-localIriWrongRight ;
     rdfs:seeAlso <../preferences.ttl#step-entityDenotation>, <../preferences.ttl#step-crossDocumentLocalTermReuse> .
 
-# ── Step 1: Canonical IRI Priority ──────────────────────────────────────────
+# ── Step 1: Person IRI Priority Ladder ───────────────────────────────────────
 
-:step-canonicalPriority a schema:HowToStep ;
+:step-personLadder a schema:HowToStep ;
     schema:position "1"^^xsd:integer ;
-    schema:name "Assign canonical IRIs by entity type using the priority ladder"@en ;
+    schema:name "Assign Person IRIs from the platform priority ladder — first available wins"@en ;
     onto:hasTrigger onto:triggerPreferencesUpdate ;
-    schema:text """Assign IRIs to entities using the following type-specific priority ladders. The first available IRI in the ladder is canonical — it becomes the primary subject for all triples about that entity.
-
-Person IRI (highest to lowest):
+    schema:text """Person IRI (highest to lowest priority; the first available is canonical and becomes the primary subject for all triples about that entity):
   1. LinkedIn profile URL with #this fragment (e.g., https://linkedin.com/in/kidehen#this)
   2. X/Twitter profile URL with #this fragment (e.g., https://x.com/kidehen#this)
   3. Substack profile URL with #this fragment
   4. Other platform profile URL with #this fragment
-  5. NO DOCUMENT-LOCAL FALLBACK — see step-localIRIProhibition
+  5. NO DOCUMENT-LOCAL FALLBACK — see :step-localIriProhibition
+Link all discovered platform identities via owl:sameAs (see :step-owlSameAsSemantics)."""@en .
 
-The #this fragment distinguishes the person entity from the profile page document. Example: https://linkedin.com/in/kidehen#this is the person; https://linkedin.com/in/kidehen is the profile page.
+# ── Step 2: Organization / Software / Country Ladders ────────────────────────
 
-Exception — IRIs that inherently denote entities: Wikidata entity IRIs (https://www.wikidata.org/entity/Q312) and DBpedia resource IRIs (http://dbpedia.org/resource/Apple_Inc.) ARE entity IRIs by their platform convention — no #this fragment is needed or added. The #this rule applies only to platforms where the same URL path is ambiguous between a document and an entity (LinkedIn, X/Twitter, GitHub, Substack, Mastodon, Medium).
-
-Organization IRI (highest to lowest):
-  1. DBpedia resource IRI (e.g., http://dbpedia.org/resource/OpenLink_Software)
-  2. Wikidata entity IRI (e.g., https://www.wikidata.org/entity/Q312)
-  3. LinkedIn company page URL with #this fragment
-  4. X/Twitter org profile URL with #this fragment
-  5. Homepage URL with #this fragment (e.g., https://www.openlinksw.com/#this)
-
-SoftwareApplication IRI (highest to lowest):
-  1. DBpedia resource IRI
-  2. Wikidata entity IRI
-  3. Homepage URL with #this fragment
-
-Country IRI (highest to lowest):
-  1. DBpedia resource IRI (e.g., http://dbpedia.org/resource/United_States)
-  2. Wikidata entity IRI (e.g., https://www.wikidata.org/entity/Q30)
-
-Link all discovered platform identities via owl:sameAs (see step-owlSameAsVsSchemaSameAs for the correct property)."""@en .
-
-# ── Step 2: owl:sameAs vs schema:sameAs ─────────────────────────────────────
-
-:step-owlSameAsVsSchemaSameAs a schema:HowToStep ;
+:step-nonPersonLadders a schema:HowToStep ;
     schema:position "2"^^xsd:integer ;
-    schema:name "Distinguish owl:sameAs from schema:sameAs — entity IRIs vs document URLs"@en ;
+    schema:name "Assign Organization, SoftwareApplication, and Country IRIs from their ladders — semantic databases first"@en ;
+    schema:text """Organization IRI (highest to lowest): 1. DBpedia resource IRI (e.g., http://dbpedia.org/resource/OpenLink_Software); 2. Wikidata entity IRI (e.g., https://www.wikidata.org/entity/Q312); 3. LinkedIn company page URL with #this; 4. X/Twitter org profile URL with #this; 5. Homepage URL with #this (e.g., https://www.openlinksw.com/#this).
+SoftwareApplication IRI: 1. DBpedia resource IRI; 2. Wikidata entity IRI; 3. Homepage URL with #this.
+Country IRI: 1. DBpedia resource IRI (e.g., http://dbpedia.org/resource/United_States); 2. Wikidata entity IRI (e.g., https://www.wikidata.org/entity/Q30)."""@en .
+
+# ── Step 3: The #this Fragment Rule ──────────────────────────────────────────
+
+:step-thisFragmentRule a schema:HowToStep ;
+    schema:position "3"^^xsd:integer ;
+    schema:name "Append #this on ambiguous platform URLs; never on inherently-entity IRIs (DBpedia, Wikidata)"@en ;
+    schema:text "The #this fragment distinguishes the entity from the profile page document: https://linkedin.com/in/kidehen#this is the person; https://linkedin.com/in/kidehen is the profile page. The rule applies only to platforms where the same URL path is ambiguous between a document and an entity (LinkedIn, X/Twitter, GitHub, Substack, Mastodon, Medium). Exception — IRIs that inherently denote entities: Wikidata entity IRIs (https://www.wikidata.org/entity/Q312) and DBpedia resource IRIs (http://dbpedia.org/resource/Apple_Inc.) ARE entity IRIs by their platform convention — no #this fragment is needed or added."@en .
+
+# ── Step 4: owl:sameAs Semantics ─────────────────────────────────────────────
+
+:step-owlSameAsSemantics a schema:HowToStep ;
+    schema:position "4"^^xsd:integer ;
+    schema:name "owl:sameAs connects entity IRI to entity IRI — symmetric, transitive identity"@en ;
     onto:hasTrigger onto:triggerPreferencesUpdate ;
-    schema:text """The properties owl:sameAs and schema:sameAs serve different roles and must not be conflated. Using the wrong property produces a knowledge graph that cannot be queried correctly by reasoners or applications.
+    schema:text """owl:sameAs connects two ENTITY IRIs — both sides identify the thing, not a document about it. It is fully symmetric (A owl:sameAs B ⇒ B owl:sameAs A) and transitive (A owl:sameAs B, B owl:sameAs C ⇒ A owl:sameAs C); both sides are the same kind of thing (both person entities, both organization entities). For ambiguous platform IRIs append #this per Step 3; DBpedia/Wikidata IRIs are valid targets as-is.
+Example (person):
+  <https://linkedin.com/in/kidehen#this> owl:sameAs <https://x.com/kidehen#this>, <https://github.com/kidehen#this> .
+Example (organization):
+  <http://dbpedia.org/resource/Apple_Inc.> owl:sameAs <https://www.wikidata.org/entity/Q312> ."""@en .
 
-OWL: owl:sameAs — Entity-to-Entity Identity
+# ── Step 5: schema:sameAs Semantics ──────────────────────────────────────────
 
-  - Connects two ENTITY IRIs — both sides identify the thing, not a document about it.
-  - Fully symmetric: if A owl:sameAs B, then B owl:sameAs A.
-  - Transitive: if A owl:sameAs B and B owl:sameAs C, then A owl:sameAs C.
-  - Both sides are the same kind of thing (both person entities, both organization entities).
-  - NO constraints on the object position — it is an entity IRI, not a document URL.
-  - For ambiguous platform IRIs (LinkedIn, X/Twitter, GitHub, Substack, etc.), append #this
-    to distinguish the entity from the document. Exception: Wikidata entity IRIs
-    (https://www.wikidata.org/entity/Q312) and DBpedia resource IRIs
-    (http://dbpedia.org/resource/Apple_Inc.) are inherently entity IRIs —
-    no #this fragment is needed.
-  - Example (person):
-      <https://linkedin.com/in/kidehen#this>
-          owl:sameAs  <https://x.com/kidehen#this> ,         # entity IRI with #this
-                      <https://github.com/kidehen#this> .    # entity IRI with #this
+:step-schemaSameAsSemantics a schema:HowToStep ;
+    schema:position "5"^^xsd:integer ;
+    schema:name "schema:sameAs connects an entity IRI to a document URL that uniquely identifies it"@en ;
+    schema:text """schema:sameAs connects an ENTITY IRI (subject, with #this fragment) to a DOCUMENT URL (object, NO fragment). It is not symmetric in practice: the subject is an entity, the object is a document describing that entity. The object behaves as an owl:inverseFunctional property value — if two different entity IRIs have the same schema:sameAs document URL, they are inferred to be the same entity; the object identifies the subject uniquely, the way a barcode identifies a product.
+Example:
+  <https://linkedin.com/in/kidehen#this> schema:sameAs <https://linkedin.com/in/kidehen>, <https://x.com/kidehen>, <https://github.com/kidehen> .
+All objects are document URLs (no fragment); the subject is the person entity (with #this)."""@en .
 
-  - Example (organization):
-      <http://dbpedia.org/resource/Apple_Inc.>
-          owl:sameAs  <https://www.wikidata.org/entity/Q312> .    # entity IRI (inherent)
+# ── Step 6: Decision Rule and Inference Hazard ───────────────────────────────
 
-  Platform profiles use #this; semantic databases (DBpedia, Wikidata) use
-  inherent entity IRIs. Both are valid owl:sameAs targets.
+:step-sameAsDecisionRule a schema:HowToStep ;
+    schema:position "6"^^xsd:integer ;
+    schema:name "Fragment ⇒ owl:sameAs; fragmentless page URL ⇒ schema:sameAs — never mix, reasoners amplify the error"@en ;
+    schema:text "When in doubt: if the URL has a #this fragment, use owl:sameAs; if it has no fragment (it's a page URL), use schema:sameAs. Never use owl:sameAs with a fragmentless document URL — that conflates the person with their webpage. Because owl:sameAs is transitive, a reasoner infers that all entity IRIs in a sameAs chain share all properties — correct for true identity, but if a document URL is mistakenly included, properties of the person (name, job title) get inferred onto the document. schema:sameAs does not carry this entailment hazard — reasoners do not infer owl:sameAs-level merging from it. Bottom line: owl:sameAs for identity chains (entity ↔ entity), schema:sameAs for documentation links (entity → page about entity). See :workExample-sameAsQuickReference."@en .
 
-SCHEMA: schema:sameAs — Entity to Document/Page
-
-  - Connects an ENTITY IRI (subject, with #this fragment) to a DOCUMENT URL (object, NO fragment).
-  - NOT symmetric in practice: the subject is an entity, the object is a document describing that entity.
-  - The object (document URL) behaves as an owl:inverseFunctional property value — if two different entity IRIs have the same schema:sameAs document URL, they are inferred to be the same entity.
-  - The object identifies the subject uniquely, the way a barcode identifies a product.
-  - Example:
-      <https://linkedin.com/in/kidehen#this>    # entity (person)
-          schema:sameAs  <https://linkedin.com/in/kidehen> ,     # document (profile page)
-                         <https://x.com/kidehen> ,               # document (profile page)
-                         <https://github.com/kidehen> .          # document (profile page)
-
-  All objects are document URLs (no fragment). The subject is the person entity (with #this).
-
-QUICK REFERENCE:
-
-  Property        | Subject         | Object          | Object type
-  ----------------+-----------------+-----------------+-----------------------
-  owl:sameAs      | entity IRI      | entity IRI      | has #this fragment
-  schema:sameAs   | entity IRI      | document URL    | no #this fragment
-
-  When in doubt: if the URL has a #this fragment, use owl:sameAs. If it has no fragment (it's a page URL), use schema:sameAs. Never use owl:sameAs with a fragmentless document URL — that conflates the person with their webpage.
-
-  Note on OWL inference: Because owl:sameAs is transitive, a reasoner will infer that
-  all entity IRIs linked via owl:sameAs share all properties. This is correct —
-  they are the same entity. But if a document URL is mistakenly included in an
-  owl:sameAs chain, properties of the person (name, job title) would be inferred
-  on the document, which is incorrect. Using the correct property prevents this.
-  schema:sameAs does not carry the same entailment hazard — reasoners do not
-  infer owl:sameAs-level merging from schema:sameAs.
-
-  Bottom line: owl:sameAs for identity chains (entity ↔ entity), schema:sameAs
-  for documentation links (entity → page about entity)."""@en .
-
-# ── Step 3: No Document-Local Entity IRIs ───────────────────────────────────
+# ── Step 7: No Document-Local Entity IRIs ────────────────────────────────────
 
 :step-localIriProhibition a schema:HowToStep ;
-    schema:position "3"^^xsd:integer ;
+    schema:position "7"^^xsd:integer ;
     schema:name "Never create document-local IRIs when a canonical platform IRI is available"@en ;
     onto:hasTrigger onto:triggerPreferencesUpdate ;
-    schema:text """When a canonical IRI exists (from step-canonicalPriority), do NOT create a document-local IRI in the article's or document's own namespace. The canonical IRI is the sole subject — all triples about that entity and all references to that entity use the canonical IRI directly.
+    schema:text "When a canonical IRI exists (Steps 1–2), do NOT create a document-local IRI in the article's or document's own namespace. The canonical IRI is the sole subject — all triples about that entity and all references to that entity use the canonical IRI directly. Rationale: document-local IRIs create unnecessary indirection, bloat the triple count with owl:sameAs statements whose sole purpose is aliasing, and prevent direct dereferencing. A consumer of the Turtle file should be able to resolve any entity IRI and get meaningful information without chasing aliases. See :workExample-localIriWrongRight."@en .
 
-WRONG — document-local IRI coexisting with canonical:
+# ── Step 8: The Only Permitted Local-IRI Case ────────────────────────────────
+
+:step-localIriException a schema:HowToStep ;
+    schema:position "8"^^xsd:integer ;
+    schema:name "Create a document-local IRI only when the entity has no platform presence at all"@en ;
+    schema:text "Only create a document-local IRI when no canonical platform IRI exists for an entity — i.e., when the entity has no LinkedIn, DBpedia, Wikidata, X/Twitter, Substack, or homepage presence. This applies only to minor or unreferenced entities that cannot be identified on any platform."@en .
+
+# ── Worked Examples ──────────────────────────────────────────────────────────
+
+:workExample-sameAsQuickReference a schema:CreativeWork ;
+    schema:name "owl:sameAs vs schema:sameAs quick reference"@en ;
+    schema:text """Property        | Subject         | Object          | Object type
+----------------+-----------------+-----------------+-----------------------
+owl:sameAs      | entity IRI      | entity IRI      | has #this fragment (or inherent entity IRI)
+schema:sameAs   | entity IRI      | document URL    | no #this fragment"""@en .
+
+:workExample-localIriWrongRight a schema:CreativeWork ;
+    schema:name "Document-local IRI: wrong vs right"@en ;
+    schema:text """WRONG — document-local IRI coexisting with canonical:
   @prefix : <https://example.com/article/#> .
   :kingsleyIdehen a schema:Person ;
       schema:name "Kingsley Uyi Idehen" ;
       owl:sameAs <https://linkedin.com/in/kidehen#this> .   # redundant local entity
-  :comment123 schema:author :kingsleyIdehen .                 # redundant reference
+  :comment123 schema:author :kingsleyIdehen .               # redundant reference
 
 RIGHT — canonical IRI as sole subject:
   <https://linkedin.com/in/kidehen#this> a schema:Person ;
       schema:name "Kingsley Uyi Idehen" ;
       owl:sameAs <https://x.com/kidehen#this> .
-  :comment123 schema:author <https://linkedin.com/in/kidehen#this> .
-
-Rationale: Document-local IRIs create unnecessary indirection, bloat the triple
-count with owl:sameAs statements whose sole purpose is aliasing, and prevent
-direct dereferencing. A consumer of the Turtle file should be able to resolve
-any entity IRI and get meaningful information without chasing aliases.
-
-Exception: Only create a document-local IRI when no canonical platform IRI
-exists for an entity — i.e., when the entity has no LinkedIn, DBpedia, Wikidata,
-X/Twitter, Substack, or homepage presence. This applies only to minor or
-unreferenced entities that cannot be identified on any platform."""@en .
+  :comment123 schema:author <https://linkedin.com/in/kidehen#this> ."""@en .

--- a/agent-rdf-memory/howto/cross-document-local-term-reuse.ttl
+++ b/agent-rdf-memory/howto/cross-document-local-term-reuse.ttl
@@ -5,41 +5,52 @@
 
 <> a schema:HowTo ;
     schema:name "Resolver-IRI Reuse of Document-Local Ontology Terms Across ANY Future Task Run"@en ;
-    schema:description "Protocol for treating every schema:DefinedTerm, custom rdfs:Class, and custom rdf:Property minted during ANY doc-collection production task as a standing, resolver-dereferenceable term available for reuse in ANY future task run — not only a topically-related companion/sequel — so that custom term bloat does not accumulate across the agent's output corpus."@en ;
+    schema:description "Protocol for treating every schema:DefinedTerm, custom rdfs:Class, and custom rdf:Property minted during ANY doc-collection production task as a standing, resolver-dereferenceable term available for reuse in ANY future task run — not only a topically-related companion/sequel — so that custom term bloat does not accumulate across the agent's output corpus. CORRECTION (2026-07-14, same-day): the initial version of this rule required the new document to be an explicit companion/sequel/rebuttal before reuse applied; the user clarified that resolver-IRI dereferenceability has no such precondition — any locally-minted term, once published, is reusable by any future task regardless of topic. Restricting reuse to 'companion documents' would still allow the same conceptual term to be re-minted under a fresh disjoint local IRI every time an unrelated topic touches it."@en ;
     schema:dateCreated "2026-07-14T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-07-14T00:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-07-19T00:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
-    schema:about :mainStep, :censusStep, :tboxStep ;
-    schema:step :mainStep, :censusStep, :tboxStep ;
+    schema:step :step-reuseScope, :step-preMintCheck, :step-reuseExistingTerm,
+        :step-mintOnlyNew, :step-promoteRecurring,
+        :step-censusQuery, :step-censusNormalization, :step-censusDedupRank,
+        :step-censusCanonicalIri,
+        :step-tboxAlignmentVocabulary, :step-tboxCensusQuery,
+        :step-tboxRegistryMaintenance, :step-tboxSameLabelCaution ;
+    schema:workExample :workExample-avcReuseTrend, :workExample-censusBaselines ;
     rdfs:seeAlso <../preferences.ttl#step-crossDocumentLocalTermReuse>, <ontology-discovery.ttl>, <canonical-entity-iri-denotation.ttl>, <ontology-cross-reference-gate.ttl>, <../entities/concepts.ttl>, <../entities/ontology-terms.ttl> .
 
-:mainStep a schema:HowToStep ;
+# ══ Section A: The Reuse Gate (Steps 1–5) ════════════════════════════════════
+
+:step-reuseScope a schema:HowToStep ;
     schema:position "1"^^xsd:integer ;
-    schema:name "Any doc-collection production run's local ontology terms are permanently reusable in ANY future run via their resolver IRI — check before minting a new one, regardless of topical relation"@en ;
-    schema:text """This gate is distinct from the two adjacent ontology gates already in memory: ontology-discovery.ttl covers discovering EXTERNAL shared vocabularies (prefix.cc) before inventing new predicates; canonical-entity-iri-denotation.ttl covers real-world entity IRIs (people, organizations). Neither covers a third, more fundamental case: once a document-local schema:DefinedTerm, rdfs:Class, or rdf:Property is minted during a doc-collection production task and published to DAV (linkeddata.uriburner.com/DAV/demos/daas/{filename}), it becomes dereferenceable through the standard resolver IRI pattern (linkeddata.uriburner.com/describe/?url={encoded-IRI}) — the same mechanism used for every other entity hyperlink in this system. Dereferenceability is what makes the term reusable: any future task, on ANY topic, can reference that same term by its bound prefix instead of minting a new local equivalent, exactly as it would for a schema.org or DBpedia term.
+    schema:name "Understand the mechanism: publication to DAV makes every local term resolver-dereferenceable, hence reusable corpus-wide"@en ;
+    schema:text "This gate is distinct from the two adjacent ontology gates: ontology-discovery.ttl covers discovering EXTERNAL shared vocabularies (prefix.cc) before inventing new predicates; canonical-entity-iri-denotation.ttl covers real-world entity IRIs (people, organizations). This gate covers a third case: once a document-local schema:DefinedTerm, rdfs:Class, or rdf:Property is minted during a doc-collection production task and published to DAV (linkeddata.uriburner.com/DAV/demos/daas/{filename}), it becomes dereferenceable through the standard resolver IRI pattern (linkeddata.uriburner.com/describe/?url={encoded-IRI}) — the same mechanism used for every other entity hyperlink in this system. Dereferenceability is what makes the term reusable: any future task, on ANY topic, can reference that same term by its bound prefix instead of minting a new local equivalent, exactly as it would for a schema.org or DBpedia term."@en .
 
-CORRECTION to the original framing of this gate (2026-07-14): the rule is NOT conditioned on the new document being an explicit companion, sequel, or rebuttal to the term's origin document. That framing was too narrow — it only captured a 'trilogy' or 'series' relationship. The actual mechanism is broader and unconditional: because the term is resolver-dereferenceable the moment it is published, it is reusable in ANY subsequent doc-collection production task, whether or not the new task is topically or thematically related to the one that minted it. Restricting reuse to 'companion documents' would still allow the same conceptual term (e.g. 'ABAC', 'enterprise knowledge graph', 'reasoning/learning separation') to be re-minted under a fresh disjoint local IRI every time an unrelated topic happens to touch on it — which is exactly the 'custom term bloat' this rule exists to prevent.
-
-Observed trend (2026-07-14) across three related RDF Knowledge Graphs, used as illustrative evidence, not as the scope boundary of the rule:
-1. ai-value-capture-response-claude_sonnet_5-1.ttl (prefix avc:) mints local DefinedTerms :abac, :enterpriseKnowledgeGraph, :reasoningLearningSeparation, :linkedDataPrinciples, :semanticWeb, :agentHarness, :dereference, :knowledgeCaptureVsExfiltration, :enterpriseOwnedLearningCurve, :iriDenotation.
-2. reverse-information-paradox-claude_sonnet_5-1.ttl imports the avc: prefix bound to the FIRST document's own DAV URL and reuses avc:abac, avc:enterpriseKnowledgeGraph, avc:reasoningLearningSeparation AS-IS, instead of re-minting a differently-named local equivalent. It also reuses theCUBE Research's karp:CriticalPerspective class and karp:respondsTo property, minted in a third, earlier document.
-3. Real-world entity IRIs (e.g. <https://linkedin.com/in/kidehen#this>, dbr:OpenLink_Software) are likewise carried forward rather than redeclared per-document — the same discipline this rule extends from entities to document-local ONTOLOGY terms, and from 'related documents only' to the full accumulated corpus.
-
-Rule: before minting ANY new schema:DefinedTerm, rdfs:Class, or rdf:Property in ANY doc-collection production task, first check whether an equivalent term already exists among this agent's previously-published, resolver-dereferenceable local terms — via the entities/ registry (entities/concepts.ttl and any future ontology-term-specific registry), via a targeted SPARQL query against the DAV-hosted graphs, or by recalling prior session/output files known to define the concept. If an equivalent term already exists:
-(a) Add an @prefix binding for the origin document's namespace, using ITS OWN canonical DAV URL as the IRI base — never restate or copy the term's definition into the new document's own namespace.
-(b) Reference the existing term directly by its bound prefix (e.g. avc:abac) wherever the new document would otherwise define an equivalent concept.
-(c) Do NOT create a new local term with a different name for the same concept, regardless of whether the new document is topically related to the term's origin — that duplicates meaning under two disjoint IRIs and defeats the cross-document graph merge Linked Data is supposed to provide for free, and is precisely the custom-term-bloat failure mode this rule targets.
-(d) Only mint a genuinely new local term when the concept is new to the agent's accumulated corpus, or represents a meaningfully narrower/broader refinement of an existing term — in which case link it via rdfs:subClassOf / rdfs:seeAlso / skos:broader to the prior term rather than silently duplicating it.
-(e) When a term proves broadly reusable across two or more unrelated productions, consider promoting it into entities/concepts.ttl (or a parallel ontology-terms registry) as a standing, curated entry — mirroring how real-world entities already get promoted into the entities/ registry.
-
-Why this gate exists and was corrected: the initial version of this rule (created earlier in the same session) required the new document to be an explicit companion/sequel/rebuttal before reuse applied. The user clarified that the underlying mechanism — resolver-IRI dereferenceability — has no such precondition: any locally-minted term, once published, is reusable by any future task regardless of topic, and the whole point of checking first is to prevent custom term bloat from accumulating across the agent's full output corpus, not just within a single narrative series."""@en .
-
-:censusStep a schema:HowToStep ;
+:step-preMintCheck a schema:HowToStep ;
     schema:position "2"^^xsd:integer ;
-    schema:name "Corpus-wide concept census: query DefinedTerm instances across DAV named graphs via the URIBurner SPARQL endpoint (curl), rank by cross-document recurrence, promote recurring terms into entities/concepts.ttl"@en ;
-    schema:text """Executed 2026-07-14 with results promoted into entities/concepts.ttl (20 new entries). This is the standing discovery mechanism for finding which concepts are being re-minted across the published corpus — preferred over local-folder parsing because named graphs at the URIBurner quad store span ALL producing models and output folders (Claude, GPT-5, DeepSeek, Qwen, Big Pickle, Kimi, MiniMax), whereas any local rdf/ folder holds only one model's output.
+    schema:name "Before minting ANY new term, check for an existing equivalent among previously-published local terms"@en ;
+    schema:text "Before minting ANY new schema:DefinedTerm, rdfs:Class, or rdf:Property in ANY doc-collection production task, first check whether an equivalent term already exists among this agent's previously-published, resolver-dereferenceable local terms — via the entities/ registry (entities/concepts.ttl and entities/ontology-terms.ttl), via a targeted SPARQL query against the DAV-hosted graphs, or by recalling prior session/output files known to define the concept."@en .
 
-Method (query the public SPARQL endpoint DIRECTLY via curl — not via MCP tool wrappers):
+:step-reuseExistingTerm a schema:HowToStep ;
+    schema:position "3"^^xsd:integer ;
+    schema:name "When an equivalent exists: bind the origin document's prefix and reference the term as-is — never re-mint"@en ;
+    schema:text "(a) Add an @prefix binding for the origin document's namespace, using ITS OWN canonical DAV URL as the IRI base — never restate or copy the term's definition into the new document's own namespace. (b) Reference the existing term directly by its bound prefix (e.g. avc:abac) wherever the new document would otherwise define an equivalent concept. (c) Do NOT create a new local term with a different name for the same concept, regardless of whether the new document is topically related to the term's origin — that duplicates meaning under two disjoint IRIs and defeats the cross-document graph merge Linked Data provides for free."@en .
+
+:step-mintOnlyNew a schema:HowToStep ;
+    schema:position "4"^^xsd:integer ;
+    schema:name "Mint a new local term only for genuinely new concepts, linking refinements to their prior term"@en ;
+    schema:text "Only mint a genuinely new local term when the concept is new to the agent's accumulated corpus, or represents a meaningfully narrower/broader refinement of an existing term — in which case link it via rdfs:subClassOf / rdfs:seeAlso / skos:broader to the prior term rather than silently duplicating it."@en .
+
+:step-promoteRecurring a schema:HowToStep ;
+    schema:position "5"^^xsd:integer ;
+    schema:name "Promote broadly-reused terms into the entities/ registries as standing curated entries"@en ;
+    schema:text "When a term proves broadly reusable across two or more unrelated productions, promote it into entities/concepts.ttl (or entities/ontology-terms.ttl for TBox terms) as a standing, curated entry — mirroring how real-world entities already get promoted into the entities/ registry."@en .
+
+# ══ Section B: DefinedTerm Census (Steps 6–9) ════════════════════════════════
+
+:step-censusQuery a schema:HowToStep ;
+    schema:position "6"^^xsd:integer ;
+    schema:name "Run the corpus-wide DefinedTerm census against the URIBurner SPARQL endpoint via curl"@en ;
+    schema:text """This is the standing discovery mechanism for finding which concepts are being re-minted across the published corpus — preferred over local-folder parsing because named graphs at the URIBurner quad store span ALL producing models and output folders (Claude, GPT-5, DeepSeek, Qwen, Big Pickle, Kimi, MiniMax), whereas any local rdf/ folder holds only one model's output. Query the public SPARQL endpoint DIRECTLY via curl — not via MCP tool wrappers:
 
   curl -s "https://linkeddata.uriburner.com/sparql" \\
     --data-urlencode 'query=SELECT ?g ?term ?name WHERE {
@@ -50,28 +61,54 @@ Method (query the public SPARQL endpoint DIRECTLY via curl — not via MCP tool 
       }
       FILTER(STRSTARTS(STR(?g), "https://linkeddata.uriburner.com/DAV/demos/daas/"))
     }' \\
-    --data-urlencode 'format=application/sparql-results+json'
+    --data-urlencode 'format=application/sparql-results+json'"""@en .
 
-Post-processing rules:
-(a) Normalize names: lowercase, strip parenthetical acronym expansions, collapse whitespace. Exact-name grouping alone is NOT sufficient — re-mints commonly hide behind plural/hyphen/long-form label variants ('Forward-Deployed Engineer' vs 'Forward Deployed Engineer', 'Systems of Record' vs 'System of Record', 'RDF — Resource Description Framework' vs 'RDF', '#AILiteracy' vs '##AILiteracySkill' even within one source document). Run a second, token-overlap similarity pass against the registry anchors; wire confirmed same-concept variant IRIs into the registry entry via owl:sameAs plus skos:altLabel for the label variant. Broader/adjacent concepts ('Governance' vs 'AI Governance', 'Access Control' vs 'ABAC') get skos:related, never owl:sameAs.
-(b) Deduplicate by document BASENAME (strip .ttl/.jsonld) — every published doc has both serializations loaded as separate named graphs, so raw graph counts double-count.
-(c) Rank by count of distinct documents; the promotion threshold is recurrence in >= 3 independent documents.
-(d) For each promoted concept: canonical IRI is the verified DBpedia resource where one exists (verify via https://dbpedia.org/data/{resource}.json returning HTTP 200 with own rdfs:label/description — a 2-key redirect stub does NOT count until inspected); otherwise the most-recurrent previously-published document IRI is canonical. Link the other via owl:sameAs either way, preserving cross-corpus graph merge.
-(e) Census baseline 2026-07-14: 149 graphs, 2,141 DefinedTerm instances, 1,163 distinct concepts, 35 recurring in >= 3 docs. Re-run periodically; any NEW concept crossing the 3-doc threshold since the last census is a promotion candidate and evidence the pre-mint check (step 1) was skipped."""@en .
+:step-censusNormalization a schema:HowToStep ;
+    schema:position "7"^^xsd:integer ;
+    schema:name "Normalize names and run a similarity pass — exact-name grouping alone misses variant re-mints"@en ;
+    schema:text "Normalize names: lowercase, strip parenthetical acronym expansions, collapse whitespace. Exact-name grouping alone is NOT sufficient — re-mints commonly hide behind plural/hyphen/long-form label variants ('Forward-Deployed Engineer' vs 'Forward Deployed Engineer', 'Systems of Record' vs 'System of Record', 'RDF — Resource Description Framework' vs 'RDF', '#AILiteracy' vs '##AILiteracySkill' even within one source document). Run a second, token-overlap similarity pass against the registry anchors; wire confirmed same-concept variant IRIs into the registry entry via owl:sameAs plus skos:altLabel for the label variant. Broader/adjacent concepts ('Governance' vs 'AI Governance', 'Access Control' vs 'ABAC') get skos:related, never owl:sameAs."@en .
 
-:tboxStep a schema:HowToStep ;
-    schema:position "3"^^xsd:integer ;
-    schema:name "TBox harmonization: align re-minted classes/properties with owl:equivalentClass / owl:equivalentProperty (never owl:sameAs), maintained in entities/ontology-terms.ttl, to enable reasoning and inference"@en ;
-    schema:text """The DefinedTerm census (step 2) covers ABox-level concepts aligned via owl:sameAs. TBox terms — rdfs:Class, owl:Class, rdf:Property, owl:ObjectProperty, owl:DatatypeProperty minted relative to a graph IRI — require the RDFS/OWL alignment vocabulary instead, because that is what reasoners (Virtuoso inference rules and SPIN, FuXi) exploit to merge instance data across named graphs:
+:step-censusDedupRank a schema:HowToStep ;
+    schema:position "8"^^xsd:integer ;
+    schema:name "Deduplicate by document basename and rank by distinct-document recurrence (promotion threshold: ≥ 3)"@en ;
+    schema:text "Deduplicate by document BASENAME (strip .ttl/.jsonld) — every published doc has both serializations loaded as separate named graphs, so raw graph counts double-count. Rank by count of distinct documents; the promotion threshold is recurrence in >= 3 independent documents. Any NEW concept crossing the 3-doc threshold since the last census is a promotion candidate and evidence the pre-mint check (Step 2) was skipped."@en .
 
-  - Same-meaning class re-minted under disjoint IRIs → owl:equivalentClass to the canonical IRI.
-  - Same-meaning property re-minted → owl:equivalentProperty.
-  - Hierarchical relation (one class genuinely narrower) → rdfs:subClassOf / rdfs:subPropertyOf, not equivalence.
-  - NEVER owl:sameAs between classes or properties — that treats TBox terms as individuals (OWL Full territory) and is invisible to class/property-level inference.
-  - For SKOS-modeled concepts in entities/concepts.ttl, hierarchical relations use skos:broader/skos:narrower (assert skos:broader on the narrower concept); skos:related is ONLY for non-hierarchical associative links.
+:step-censusCanonicalIri a schema:HowToStep ;
+    schema:position "9"^^xsd:integer ;
+    schema:name "Canonical IRI: verified DBpedia resource where one exists, else the most-recurrent published document IRI"@en ;
+    schema:text "For each promoted concept: the canonical IRI is the verified DBpedia resource where one exists (verify via https://dbpedia.org/data/{resource}.json returning HTTP 200 with own rdfs:label/description — a 2-key redirect stub does NOT count until inspected); otherwise the most-recurrent previously-published document IRI is canonical. Link the other via owl:sameAs either way, preserving cross-corpus graph merge."@en .
 
-TBox census query: same GRAPH/FILTER shape as the DefinedTerm census but matching ?term a rdfs:Class|owl:Class|rdf:Property|owl:ObjectProperty|owl:DatatypeProperty, excluding external vocabularies (w3.org, schema.org, dbpedia.org, purl.org, xmlns.com hosts). Baseline 2026-07-14: 656 locally-minted TBox terms, 86 recurring in >= 2 documents.
+# ══ Section C: TBox Harmonization (Steps 10–13) ══════════════════════════════
 
-Alignment axioms live in entities/ontology-terms.ttl — loadable into Virtuoso as an alignment/inference graph. Canonical IRI selection: most-used IRI in the corpus wins (e.g. the FDE/IRE single-# family, 5 loads, beats the double-## family, 2 loads, caused by an @prefix ending in ## in one producing file). Generator-template analysis classes (KeyPrinciple, KeyConcept, ComparisonDimension, UseCase, ArchitectureConcept, hasLaborTAM, hasAutomationReadiness, ...) are minted by the skill workflow itself, not by source articles, so they re-mint EVERY run unless the canonical registry IRI is reused — check ontology-terms.ttl before minting any analysis-pattern class or property.
+:step-tboxAlignmentVocabulary a schema:HowToStep ;
+    schema:position "10"^^xsd:integer ;
+    schema:name "Align TBox terms with owl:equivalentClass / owl:equivalentProperty — NEVER owl:sameAs"@en ;
+    schema:text "TBox terms (rdfs:Class, owl:Class, rdf:Property, owl:ObjectProperty, owl:DatatypeProperty minted relative to a graph IRI) require the RDFS/OWL alignment vocabulary, because that is what reasoners (Virtuoso inference rules and SPIN, FuXi) exploit to merge instance data across named graphs: same-meaning class re-minted under disjoint IRIs → owl:equivalentClass to the canonical IRI; same-meaning property → owl:equivalentProperty; hierarchical relation (one class genuinely narrower) → rdfs:subClassOf / rdfs:subPropertyOf, not equivalence. NEVER owl:sameAs between classes or properties — that treats TBox terms as individuals (OWL Full territory) and is invisible to class/property-level inference. For SKOS-modeled concepts in entities/concepts.ttl, hierarchical relations use skos:broader/skos:narrower (assert skos:broader on the narrower concept); skos:related is ONLY for non-hierarchical associative links."@en .
 
-Same-label caution (mirror of step 2's similarity caution, in reverse): a shared label does NOT prove identity for TBox terms. truck-ontology 'driverStatus'/'truckStatus' vs a generic 'status', or two 'Customer' classes with different ontological commitments, must never be equated — record such collisions in the ontology-terms.ttl watchlist section so future census passes don't misalign them."""@en .
+:step-tboxCensusQuery a schema:HowToStep ;
+    schema:position "11"^^xsd:integer ;
+    schema:name "Run the TBox census with the same GRAPH/FILTER shape, excluding external vocabulary hosts"@en ;
+    schema:text "TBox census query: same GRAPH/FILTER shape as the DefinedTerm census (Step 6) but matching ?term a rdfs:Class|owl:Class|rdf:Property|owl:ObjectProperty|owl:DatatypeProperty, excluding external vocabularies (w3.org, schema.org, dbpedia.org, purl.org, xmlns.com hosts)."@en .
+
+:step-tboxRegistryMaintenance a schema:HowToStep ;
+    schema:position "12"^^xsd:integer ;
+    schema:name "Maintain alignment axioms in entities/ontology-terms.ttl; check it before minting any analysis-pattern class"@en ;
+    schema:text "Alignment axioms live in entities/ontology-terms.ttl — loadable into Virtuoso as an alignment/inference graph. Canonical IRI selection: most-used IRI in the corpus wins (e.g. the FDE/IRE single-# family, 5 loads, beats the double-## family, 2 loads, caused by an @prefix ending in ## in one producing file). Generator-template analysis classes (KeyPrinciple, KeyConcept, ComparisonDimension, UseCase, ArchitectureConcept, hasLaborTAM, hasAutomationReadiness, ...) are minted by the skill workflow itself, not by source articles, so they re-mint EVERY run unless the canonical registry IRI is reused — check ontology-terms.ttl before minting any analysis-pattern class or property."@en .
+
+:step-tboxSameLabelCaution a schema:HowToStep ;
+    schema:position "13"^^xsd:integer ;
+    schema:name "A shared label does NOT prove identity — record collisions in the ontology-terms.ttl watchlist"@en ;
+    schema:text "Mirror of Step 7's similarity caution, in reverse: a shared label does NOT prove identity for TBox terms. truck-ontology 'driverStatus'/'truckStatus' vs a generic 'status', or two 'Customer' classes with different ontological commitments, must never be equated — record such collisions in the ontology-terms.ttl watchlist section so future census passes don't misalign them."@en .
+
+# ══ Worked Examples ══════════════════════════════════════════════════════════
+
+:workExample-avcReuseTrend a schema:CreativeWork ;
+    schema:name "Observed reuse trend (2026-07-14) across three related KGs — illustrative evidence, not the rule's scope boundary"@en ;
+    schema:text """1. ai-value-capture-response-claude_sonnet_5-1.ttl (prefix avc:) mints local DefinedTerms :abac, :enterpriseKnowledgeGraph, :reasoningLearningSeparation, :linkedDataPrinciples, :semanticWeb, :agentHarness, :dereference, :knowledgeCaptureVsExfiltration, :enterpriseOwnedLearningCurve, :iriDenotation.
+2. reverse-information-paradox-claude_sonnet_5-1.ttl imports the avc: prefix bound to the FIRST document's own DAV URL and reuses avc:abac, avc:enterpriseKnowledgeGraph, avc:reasoningLearningSeparation AS-IS, instead of re-minting a differently-named local equivalent. It also reuses theCUBE Research's karp:CriticalPerspective class and karp:respondsTo property, minted in a third, earlier document.
+3. Real-world entity IRIs (e.g. <https://linkedin.com/in/kidehen#this>, dbr:OpenLink_Software) are likewise carried forward rather than redeclared per-document — the same discipline this rule extends from entities to document-local ONTOLOGY terms, and from 'related documents only' to the full accumulated corpus."""@en .
+
+:workExample-censusBaselines a schema:CreativeWork ;
+    schema:name "Census baselines (2026-07-14)"@en ;
+    schema:text """DefinedTerm census: 149 graphs, 2,141 DefinedTerm instances, 1,163 distinct concepts, 35 recurring in >= 3 docs; 20 entries promoted into entities/concepts.ttl. Re-run periodically.
+TBox census: 656 locally-minted TBox terms, 86 recurring in >= 2 documents."""@en .

--- a/agent-rdf-memory/howto/howto-authoring-structure.ttl
+++ b/agent-rdf-memory/howto/howto-authoring-structure.ttl
@@ -18,15 +18,15 @@
 :step-oneRequirementPerStep a schema:HowToStep ;
     schema:position "1"^^xsd:integer ;
     schema:name "Model each distinct requirement as its own positioned schema:HowToStep"@en ;
-    schema:text "A howto's schema:HowTo entity must decompose its procedure into multiple schema:HowToStep entities with sequential integer schema:position values — one requirement, gate, or action per step. Never collapse several requirements, enforcement rules, examples, and rationale into a single step's schema:text prose literal: a SPARQL query over the memory graph must be able to address each requirement individually. A file is only legitimately single-step when it genuinely prescribes exactly one atomic action."@en ;
+    schema:text "A howto's schema:HowTo entity must decompose its procedure into multiple schema:HowToStep entities with sequential integer schema:position values — one requirement, gate, or action per step. Never collapse several requirements, enforcement rules, examples, and rationale into a single step's schema:text prose literal: a SPARQL query over the memory graph must be able to address each requirement individually. This applies WITHIN multi-step files too — a step whose text bundles several independent rules (e.g. one beginning 'Three rules:', or mixing a default, a procedure, and a response format) must be split into one step per rule; a single coherent procedure with paragraphs is fine. A file is only legitimately single-step when it genuinely prescribes exactly one atomic action. Every schema:step list must include every positioned step defined in the file (no orphans), with no duplicate positions."@en ;
     onto:hasTrigger onto:triggerPreferencesUpdate .
 
 # ── Step 2: Content Slotting ─────────────────────────────────────────────────
 
 :step-contentSlotting a schema:HowToStep ;
     schema:position "2"^^xsd:integer ;
-    schema:name "Route examples to schema:workExample and rationale/provenance to schema:description"@en ;
-    schema:text "Worked examples (sample Turtle, CSS blocks, command transcripts) belong in a schema:workExample entity (a schema:CreativeWork linked from the HowTo), not inside a step's schema:text. The 'why this rule exists' narrative — the triggering session, date, and failure mode — belongs in the HowTo's schema:description (or a provenance note), not in step text. Step text states only what to do and how."@en .
+    schema:name "Route examples and reference data to schema:workExample, rationale/provenance to schema:description"@en ;
+    schema:text "Worked examples (sample Turtle, CSS blocks, command transcripts) AND reference data (known-good values, response templates, mapping tables, category catalogs, URL lists) belong in schema:workExample entities (schema:CreativeWork linked from the HowTo), not inside a step's schema:text — steps cite them by fragment (see :workExample-…). A template needed by several howtos lives in ONE file's workExample and is referenced cross-file by anchor (e.g. <agent-identity.ttl#workExample-triggerAResponse>), never duplicated. The 'why this rule exists' narrative — the triggering session, date, and failure mode — belongs in the HowTo's schema:description (or a provenance note), not in step text. Step text states only what to do and how."@en .
 
 # ── Step 3: Anchored Cross-References ────────────────────────────────────────
 

--- a/agent-rdf-memory/howto/infographic-authoring.ttl
+++ b/agent-rdf-memory/howto/infographic-authoring.ttl
@@ -5,14 +5,14 @@
 
 <> a schema:HowTo ;
     schema:name "Infographic Authoring — Attribution, Dark Mode, KG Explorer Reuse, Template Selection"@en ;
-    schema:description "Four rules governing the authoring of HTML infographics: footer attribution format, dark mode CSS requirements, KG Explorer template reuse mandate, and template selection by content type."@en ;
+    schema:description "Rules governing the authoring of HTML infographics: footer attribution format, dark mode CSS requirements (two-block selectors, general anchor rule, bright accent), KG Explorer template reuse mandate, template selection by content type, and the long-token overflow gate. The overflow gate exists because the same defect recurred three times (fixed 2026-06-29, recurred 2026-07-01 and 2026-07-02) in different element types — including a plain-text <h4> with no <code> wrapper, and a shared .sparql-code class that had never carried the fix and would have propagated the bug silently through reuse."@en ;
     schema:dateCreated "2026-06-05T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-07-02T03:30:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-07-19T00:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
-    schema:about :step-attribution, :step-darkModeCSS,
-        :step-kgExplorerReuse, :step-templateSelection, :step-footerCardOverflow ;
-    schema:step :step-attribution, :step-darkModeCSS,
-        :step-kgExplorerReuse, :step-templateSelection, :step-footerCardOverflow ;
+    schema:step :step-attribution, :step-darkModeCSS, :step-generalAnchorRule,
+        :step-brightDarkAccent, :step-kgExplorerReuse, :step-templateSelection,
+        :step-footerCardOverflow, :step-overflowVerification ;
+    schema:workExample :workExample-kgExplorerProvenPatterns ;
     rdfs:seeAlso <../preferences.ttl#step-templateSelection>, <../preferences.ttl#step-darkModeCSS>, <../preferences.ttl#step-attribution>, <../preferences.ttl#step-iifeGlobalScope>, <../preferences.ttl#step-kgExplorerReuse>, <../preferences.ttl#step-themeToggleInNavHeader>, <../preferences.ttl#step-footerCardOverflow>, <../preferences.ttl#step-openlinkBrandColorScheme>, <../preferences.ttl#step-readerFacingCopyGate>, <../preferences.ttl#step-screencastDistributionArtifacts> .
 
 # ── Step 1: Footer Attribution ───────────────────────────────────────────────
@@ -20,47 +20,73 @@
 :step-attribution a schema:HowToStep ;
     schema:position "1"^^xsd:integer ;
     schema:name "Use <p> prose format for footer attribution, never chip <div>"@en ;
-    schema:text """Every HTML infographic footer MUST use a <p> element with inline prose for skills attribution — never <div class='skills-attribution'> with chip/button styling. All tool/product names MUST hyperlink to their canonical homepages (not resolver URLs): kg-generator and rdf-infographic-skill → GitHub repo, URIBurner → https://linkeddata.uriburner.com/, Virtuoso → https://virtuoso.openlinksw.com/. The resolver is for semantic KG entities only, not product credits."""@en .
+    schema:text "Every HTML infographic footer MUST use a <p> element with inline prose for skills attribution — never <div class='skills-attribution'> with chip/button styling. All tool/product names MUST hyperlink to their canonical homepages (not resolver URLs): kg-generator and rdf-infographic-skill → GitHub repo, URIBurner → https://linkeddata.uriburner.com/, Virtuoso → https://virtuoso.openlinksw.com/. The resolver is for semantic KG entities only, not product credits."@en .
 
-# ── Step 2: Dark Mode CSS ────────────────────────────────────────────────────
+# ── Step 2: Dark Mode Two-Block CSS ──────────────────────────────────────────
 
 :step-darkModeCSS a schema:HowToStep ;
     schema:position "2"^^xsd:integer ;
-    schema:name "Dark mode: two-block CSS, link contrast, general a rule, bright accent"@en ;
-    schema:text """Three rules:
-(1) SEPARATE BLOCKS — Dark mode CSS MUST use two separate blocks: html[data-theme='dark'] { ... } for the explicit toggle, and @media (prefers-color-scheme: dark) { :root { ... } } for system preference. Never comma-combine these selectors. All colors must use CSS variables; never hardcode hex values.
+    schema:name "Dark mode CSS uses two separate selector blocks; all colors via CSS variables"@en ;
+    schema:text "Dark mode CSS MUST use two separate blocks: html[data-theme='dark'] { ... } for the explicit toggle, and @media (prefers-color-scheme: dark) { :root { ... } } for system preference. Never comma-combine these selectors. All colors must use CSS variables; never hardcode hex values."@en .
 
-(2) GENERAL a RULE — HTML MUST include a general a { color: var(--accent); text-decoration: underline; } rule (or a { color: var(--primary); ... }). Without this, inline <a> tags in body text (paragraphs, notes, cards, lists) fall through to browser-default blue (#0000ee on dark navy #0f172a) which is nearly invisible in dark mode. Container-specific overrides (nav, header, blockquote attributions, resource lists, footer cards) already set text-decoration: none and their own colors via higher-specificity selectors, so the general a rule only affects body-content links — exactly where it's needed.
+# ── Step 3: General Anchor Rule ──────────────────────────────────────────────
 
-(3) BRIGHT DARK-MODE ACCENT — The dark mode accent/link color must be bright and high-contrast on the dark background. A muted color like #60a5fa (light blue) or #4F46E5 (indigo) produces 4-5:1 contrast on #0f172a, which passes WCAG AA but feels washed out. Use a saturated bright blue: #7dd3fc (sky-300) on #0f172a achieves 7.2:1 contrast — vivid and unmistakably clickable. Test any candidate dark-mode accent at https://webaim.org/resources/contrastchecker/ against both --bg and --card-bg before finalizing."""@en .
+:step-generalAnchorRule a schema:HowToStep ;
+    schema:position "3"^^xsd:integer ;
+    schema:name "Include a general a { color: var(--accent) } rule so body-text links survive dark mode"@en ;
+    schema:text "HTML MUST include a general a { color: var(--accent); text-decoration: underline; } rule (or a { color: var(--primary); ... }). Without this, inline <a> tags in body text (paragraphs, notes, cards, lists) fall through to browser-default blue (#0000ee on dark navy #0f172a) which is nearly invisible in dark mode. Container-specific overrides (nav, header, blockquote attributions, resource lists, footer cards) already set text-decoration: none and their own colors via higher-specificity selectors, so the general a rule only affects body-content links — exactly where it's needed."@en .
 
-# ── Step 3: KG Explorer Template Reuse ──────────────────────────────────────
+# ── Step 4: Bright Dark-Mode Accent ──────────────────────────────────────────
+
+:step-brightDarkAccent a schema:HowToStep ;
+    schema:position "4"^^xsd:integer ;
+    schema:name "The dark-mode accent must be bright and high-contrast — verify with a contrast checker"@en ;
+    schema:text "The dark mode accent/link color must be bright and high-contrast on the dark background. A muted color like #60a5fa (light blue) or #4F46E5 (indigo) produces 4-5:1 contrast on #0f172a, which passes WCAG AA but feels washed out. Use a saturated bright blue: #7dd3fc (sky-300) on #0f172a achieves 7.2:1 contrast — vivid and unmistakably clickable. Test any candidate dark-mode accent at https://webaim.org/resources/contrastchecker/ against both --bg and --card-bg before finalizing."@en .
+
+# ── Step 5: KG Explorer Template Reuse ──────────────────────────────────────
 
 :step-kgExplorerReuse a schema:HowToStep ;
-    schema:position "3"^^xsd:integer ;
+    schema:position "5"^^xsd:integer ;
     schema:name "Reuse the validated template for KG Explorer — never regenerate from scratch"@en ;
-    schema:text """When generating a new HTML infographic, open the appropriate template from rdf-infographic-skill/assets/templates/ (see step-templateSelection) and adapt its content. Never write KG Explorer JS/CSS/HTML from scratch — regenerating reintroduces fixed bugs. Canonical template as of 2026-06-03: assets/templates/competitive-analysis-head-to-head-claude_sonnet_4_6.html. Proven patterns that MUST carry forward from this template: (a) D3 mutation-safe getFiltered() — always rebuild links as fresh objects: {source: typeof l.source==='object'?l.source.id:l.source, target: typeof l.target==='object'?l.target.id:l.target, label:l.label} — D3 forceLink mutates source/target in place, breaking subsequent renders if not normalised; (b) zoom isolation — svg.on('click.zoomActivate') adds kg-active class and arms zoom; document click outside #kg-explorer removes kg-active and calls svg.on('.zoom',null) to disarm — never attach zoom on init; (c) setPredAll(val) bulk-checks/unchecks all #pred-filters checkboxes, reads allPredicates array; (d) setNodeTypeAll(val) bulk-toggles all node type chips; (e) toggleNodeType(type) updates both toolbar button and #node-type-chips with aria-pressed; (f) populatePredFilters(links) inserts dynamic checkboxes into #pred-filters from link labels; (g) populateNodeTypeChips() inserts dynamic chips into #node-type-chips from node group data; (h) updatePhysics() wired to sliders — calls simulation.force('charge').strength(val), simulation.force('link').distance(val), simulation.alpha(0.3).restart(); (i) setSparqlFormat(fmt) uses pre-encoded SPARQL_PRE/SPARQL_POST string constants to avoid \\\\n double-escape bug; (j) #kg-explorer.kg-active CSS rule provides border-glow zoom indicator; (k) theme toggle lives in #fnav-header, never inside the collapsible #fnav-links."""@en ;
+    schema:text "When generating a new HTML infographic, open the appropriate template from rdf-infographic-skill/assets/templates/ (see :step-templateSelection) and adapt its content. Never write KG Explorer JS/CSS/HTML from scratch — regenerating reintroduces fixed bugs. Canonical template as of 2026-06-03: assets/templates/competitive-analysis-head-to-head-claude_sonnet_4_6.html. The proven patterns that MUST carry forward are catalogued in :workExample-kgExplorerProvenPatterns."@en ;
     rdfs:seeAlso <kg-explorer-reuse-first.ttl> .
 
-# ── Step 4: Template Selection ───────────────────────────────────────────────
+# ── Step 6: Template Selection ───────────────────────────────────────────────
 
 :step-templateSelection a schema:HowToStep ;
-    schema:position "4"^^xsd:integer ;
+    schema:position "6"^^xsd:integer ;
     schema:name "Select the correct template from assets/templates/ based on content type"@en ;
     schema:text """Select template from rdf-infographic-skill/assets/templates/ by content type. Four options and their decision trigger: (1) COMPETITIVE/HEAD-TO-HEAD → assets/templates/competitive-analysis-head-to-head-claude_sonnet_4_6.html — trigger: source compares two or more named platforms, products, or systems. Dark premium aesthetic, hero dual-badges, horizontal timeline, split comparison matrix, two-column capability panels. (2) GARTNER DASHBOARD → assets/templates/gartner-da-london-2026-claude-sonnet4-dashboard.html — trigger: conference report, strategy briefing, field notes, or dense operational dashboard with many metrics/chips. Top horizontal nav bar. (3) SEMANTIC MEDALLION EDITORIAL/TECHNICAL → assets/templates/semantic-medallion-editorial-technical.html — trigger: architecture explainer, SPARQL tutorial, layered/staged system (Bronze/Silver/Gold/Platinum). Narrow reading column, query accordions. (4) HARNESS REFERENCE → scripts/rdf_infographic_harness.py — fallback when none of the above clearly fits. Decision shortcut: comparing platforms → COMPETITIVE; conference/strategy → GARTNER; architecture/SPARQL → SEMANTIC MEDALLION; otherwise → HARNESS."""@en .
 
-# ── Step 5: Footer/Attribution Card Text Overflow ────────────────────────────
+# ── Step 7: Long-Token Overflow Baseline CSS ─────────────────────────────────
 
 :step-footerCardOverflow a schema:HowToStep ;
-    schema:position "5"^^xsd:integer ;
-    schema:name "ANY card/heading/pre with a long unbroken token can overflow — not just <code> URLs in footer cards"@en ;
-    schema:text """Recurring defect (fixed 2026-06-29, recurred 2026-07-01, recurred again 2026-07-02 in a DIFFERENT element type): a container rendering a long unbroken token overflows its boundary. Root cause: white-space:normal alone only breaks at spaces; a single unbroken token (URL, IRI, camelCase identifier, base64) has no spaces to break at, and CSS grid/flex items default to min-width:auto (sized to their largest unbreakable content), so the container refuses to shrink and the token spills out.
-
-The 2026-07-02 recurrence proved the defect is NOT limited to <code> tags or footer cards: it hit an offer card's plain-text <h4> title (a camelCase identifier extracted from an offer's IRI local name, no <code> wrapper at all), and nearly hit a NEW panel because it reused the existing .sparql-code <pre> class — which itself had never carried the fix, so the bug would have propagated silently through reuse.
-
-GENERALIZED MANDATORY CSS — apply as a baseline default on shared classes, not as an opt-in per instance:
+    schema:position "7"^^xsd:integer ;
+    schema:name "Apply min-width:0 + overflow-wrap:anywhere as baseline CSS on ANY element that may carry a long unbroken token"@en ;
+    schema:text """Any container rendering a long unbroken token (URL, IRI, camelCase identifier, base64) can overflow its boundary: white-space:normal only breaks at spaces, and CSS grid/flex items default to min-width:auto (sized to their largest unbreakable content), so the container refuses to shrink and the token spills out. GENERALIZED MANDATORY CSS — apply as a baseline default on shared classes, not as an opt-in per instance:
   {any-card-class} { min-width: 0 }
   {any-text-element-that-may-carry-a-long-token} { overflow-wrap: anywhere; word-break: break-word }
-This includes: attribution/footer cards, offer/source/id cards' <h4> titles, and any <pre>/<code> block (including shared ones like .sparql-code) — audit the SHARED CLASS ITSELF before reusing it for new content, don't assume a class used elsewhere in the same document already has the protection.
+This includes: attribution/footer cards, offer/source/id cards' <h4> titles, and any <pre>/<code> block (including shared ones like .sparql-code) — audit the SHARED CLASS ITSELF before reusing it for new content; don't assume a class used elsewhere in the same document already has the protection."""@en .
 
-VERIFICATION: after generating or editing any card, heading, or pre/code block that may contain a long token, check el.scrollWidth <= el.clientWidth via preview_eval — do not rely on a screenshot alone, overflow can be subtle at normal viewport widths. This is a BLOCKING check before delivery, not an optional nicety — it has now recurred twice already after being fixed, in two different element types."""@en .
+# ── Step 8: Overflow Verification (BLOCKING) ─────────────────────────────────
+
+:step-overflowVerification a schema:HowToStep ;
+    schema:position "8"^^xsd:integer ;
+    schema:name "BLOCKING pre-delivery check: el.scrollWidth <= el.clientWidth on every long-token element"@en ;
+    schema:text "After generating or editing any card, heading, or pre/code block that may contain a long token, check el.scrollWidth <= el.clientWidth via preview_eval — do not rely on a screenshot alone, overflow can be subtle at normal viewport widths. This is a BLOCKING check before delivery, not an optional nicety — the defect recurred twice after being fixed, in two different element types."@en .
+
+# ── Worked Example: KG Explorer Proven Patterns ──────────────────────────────
+
+:workExample-kgExplorerProvenPatterns a schema:CreativeWork ;
+    schema:name "Proven KG Explorer patterns that must carry forward from the canonical template"@en ;
+    schema:text """(a) D3 mutation-safe getFiltered() — always rebuild links as fresh objects: {source: typeof l.source==='object'?l.source.id:l.source, target: typeof l.target==='object'?l.target.id:l.target, label:l.label} — D3 forceLink mutates source/target in place, breaking subsequent renders if not normalised;
+(b) zoom isolation — svg.on('click.zoomActivate') adds kg-active class and arms zoom; document click outside #kg-explorer removes kg-active and calls svg.on('.zoom',null) to disarm — never attach zoom on init;
+(c) setPredAll(val) bulk-checks/unchecks all #pred-filters checkboxes, reads allPredicates array;
+(d) setNodeTypeAll(val) bulk-toggles all node type chips;
+(e) toggleNodeType(type) updates both toolbar button and #node-type-chips with aria-pressed;
+(f) populatePredFilters(links) inserts dynamic checkboxes into #pred-filters from link labels;
+(g) populateNodeTypeChips() inserts dynamic chips into #node-type-chips from node group data;
+(h) updatePhysics() wired to sliders — calls simulation.force('charge').strength(val), simulation.force('link').distance(val), simulation.alpha(0.3).restart();
+(i) setSparqlFormat(fmt) uses pre-encoded SPARQL_PRE/SPARQL_POST string constants to avoid \\\\n double-escape bug;
+(j) #kg-explorer.kg-active CSS rule provides border-glow zoom indicator;
+(k) theme toggle lives in #fnav-header, never inside the collapsible #fnav-links."""@en .

--- a/agent-rdf-memory/howto/memory-protocol-gate.ttl
+++ b/agent-rdf-memory/howto/memory-protocol-gate.ttl
@@ -8,211 +8,171 @@
     schema:name "Agent RDF Memory Protocol Validation Gate"@en ;
     schema:description "Mandatory post-session audit gate that validates every Claude Code session transcript against the 5-step Agent RDF Memory Protocol. Programmatic backstop — the SessionStart hook injection is the primary prevention mechanism; this validator is the audit trail that proves compliance."@en ;
     schema:dateCreated "2026-06-10T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-06-10T00:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-07-19T00:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :protocolGate ;
-    schema:step :step-understandGate, :step-locateTranscript, :step-runValidator,
-                :step-interpretFailures, :step-fixAndReaudit ;
     rdfs:seeAlso <../preferences.ttl#step-memoryProtocolGate>, <../preferences.ttl#step-preferencesSparse>, <session-governance.ttl> .
 
 # ── Primary entity ────────────────────────────────────────────────────────────
 
 :protocolGate a schema:HowTo ;
     schema:name "Memory Protocol Validation Gate — Post-Session Audit"@en ;
-    schema:description "Five-step gate procedure for auditing every Claude Code session transcript against the mandatory 5-step Agent RDF Memory Protocol. The validator checks: (1) directory listing of agent-rdf-memory/, (2) Read core.ttl, (3) Read preferences.ttl, (4) Read index.ttl, (5) Followed references to at least one additional file beyond the core three. GATE: 0 failures required before considering a session protocol-compliant."@en ;
-    schema:step :step-understandGate, :step-locateTranscript, :step-runValidator,
-                :step-interpretFailures, :step-fixAndReaudit ;
+    schema:description "Gate procedure for auditing every Claude Code session transcript against the mandatory 5-step Agent RDF Memory Protocol. GATE: 0 failures required before considering a session protocol-compliant. Why this gate exists: in a prior session, a simple 'whoami' query was answered from CLAUDE.md prose instead of the canonical format in howto/agent-identity.ttl — the SessionStart hook had injected compact step names but not the whoami format spec, and the agent treated the compact injection as 'memory already loaded' and skipped the full-read protocol. The audit trail proves the full protocol was executed."@en ;
+    schema:step :step-understandGate, :step-strictMode, :step-locateTranscript,
+        :step-runValidator, :step-interpretFailures, :step-classifyRootCause,
+        :step-fixHookInjection, :step-fixIgnoredGate, :step-fixPartialExecution,
+        :step-fixAndReaudit, :step-preferencesSparseContract, :step-sparseVerification ;
+    schema:workExample :workExample-validatorOutput, :workExample-failInterpretation,
+        :workExample-sparseCheck ;
     schema:tool <../scripts/validate-memory-protocol.py> .
 
-# ── Step 1: Understand the gate ───────────────────────────────────────────────
+# ── Step 1: The Five Protocol Checks ─────────────────────────────────────────
 
 :step-understandGate a schema:HowToStep ;
     schema:position 1 ;
-    schema:name "Understand what the gate validates and why it exists"@en ;
-    schema:text """The memory protocol validation gate audits a Claude Code JSONL session transcript to verify that the agent executed all 5 mandatory steps of the Agent RDF Memory Protocol:
-
-**Protocol steps checked:**
+    schema:name "Know the 5 protocol steps the validator checks"@en ;
+    schema:text """The validator audits a Claude Code JSONL session transcript for all 5 mandatory steps of the Agent RDF Memory Protocol:
 1. `ls agent-rdf-memory/` — directory listing (Bash tool call)
 2. `Read core.ttl` — user identity and output routing
 3. `Read preferences.ttl` — the queryable behavioral contract
 4. `Read index.ttl` — session index with cross-references
-5. Follow at least one index reference — read additional files under howto/, sessions/, projects/, or entities/
+5. Follow at least one index reference — read additional files under howto/, sessions/, projects/, or entities/"""@en .
 
-**Optional --strict mode** also verifies that all protocol reads occurred before the agent's first substantive text response. A "read-after-respond" pattern indicates the protocol was skipped and executed retroactively only after a behavioral lapse was detected.
+# ── Step 2: Strict Mode (Read-Before-Respond Timing) ─────────────────────────
 
-**Why this gate exists:**
-In a prior session, a simple "whoami" query was answered from CLAUDE.md prose instead of the canonical format in howto/agent-identity.ttl. The SessionStart hook injection had provided compact step names but NOT the whoami format spec (it lived in a howto/ file the hook didn't load). The agent treated the compact injection as "memory already loaded" and skipped the full-read protocol. This gate prevents that class of failure by providing a post-session audit trail that proves the full protocol was executed.
+:step-strictMode a schema:HowToStep ;
+    schema:position 2 ;
+    schema:name "Use --strict to catch read-after-respond violations; skip it when the transcript lacks user text prompts"@en ;
+    schema:text "Optional --strict mode additionally verifies that all protocol reads occurred BEFORE the agent's first substantive text response. A read-after-respond pattern is the canonical failure the gate was designed to catch: the response was generated from CLAUDE.md prose or prior context, and the protocol was executed retroactively only after a behavioral lapse was detected. Do not run --strict if the transcript lacks user text prompts — Claude Code JSONL transcripts don't always contain the literal user prompt text, in which case the strict timing check gracefully skips."@en .
 
-The SessionStart hook injection and this validator are complementary:
-- **Hook injection** = primary prevention (compact context + GATE instruction at session start)
-- **Validator** = audit trail (proves compliance after the fact)
-
-If the hook injection changes, the gate catches the gap before the next session starts."""@en .
-
-# ── Step 2: Locate the transcript ─────────────────────────────────────────────
+# ── Step 3: Locate the Transcript ────────────────────────────────────────────
 
 :step-locateTranscript a schema:HowToStep ;
-    schema:position 2 ;
-    schema:name "Locate the most recent Claude Code session transcript for audit"@en ;
-    schema:text """Claude Code JSONL transcripts follow the path pattern:
+    schema:position 3 ;
+    schema:name "Locate the most recent complete Claude Code session transcript for audit"@en ;
+    schema:text """Claude Code JSONL transcripts follow the path pattern ~/.claude/projects/-{project-path-slugified}/{session-uuid}.jsonl. For this repository:
+  ls -lt ~/.claude/projects/-Users-kidehen-Documents-Management-Development-ai-agent-skills/*.jsonl | head -1
+Or run the validator against a specific known transcript UUID. The transcript must be a COMPLETE session — running the validator against a partial or in-progress transcript produces false negatives, since steps that appear missing may simply not have been written to the file yet."""@en .
 
-```
-~/.claude/projects/-{project-path-slugified}/{session-uuid}.jsonl
-```
-
-For this repository, the project transcripts directory is:
-```
-~/.claude/projects/-Users-kidehen-Documents-Management-Development-ai-agent-skills/
-```
-
-**To find the most recent transcript:**
-```bash
-ls -lt ~/.claude/projects/-Users-kidehen-Documents-Management-Development-ai-agent-skills/*.jsonl | head -1
-```
-
-Or run the validator against a specific known transcript UUID.
-
-**The transcript must be a complete session.** Running the validator against a partial or in-progress transcript will produce false negatives — steps that appear missing may simply not have been written to the file yet."""@en .
-
-# ── Step 3: Run the validator ─────────────────────────────────────────────────
+# ── Step 4: Run the Validator ────────────────────────────────────────────────
 
 :step-runValidator a schema:HowToStep ;
-    schema:position 3 ;
+    schema:position 4 ;
     schema:name "Run validate-memory-protocol.py against the transcript"@en ;
-    schema:text """Run the validator from the repository root:
+    schema:text """Run from the repository root:
+  python3 agent-rdf-memory/scripts/validate-memory-protocol.py ~/.claude/projects/-Users-kidehen-Documents-Management-Development-ai-agent-skills/{uuid}.jsonl --verbose
+Modes: default checks all 5 protocol steps (pass/fail output); --verbose (-v) prints every detected protocol-relevant tool call with line numbers; --strict adds the read-before-respond timing check (Step 2). Exit codes: 0 = PASS (all 5 steps verified), 1 = FAIL (at least one step not executed). See :workExample-validatorOutput for sample output."""@en .
 
-```bash
-python3 agent-rdf-memory/scripts/validate-memory-protocol.py ~/.claude/projects/-Users-kidehen-Documents-Management-Development-ai-agent-skills/{uuid}.jsonl --verbose
-```
-
-**Modes:**
-- **Default:** Checks all 5 protocol steps. Pass/fail output only unless --verbose is used.
-- **--verbose (-v):** Prints every detected protocol-relevant tool call with line numbers.
-- **--strict:** Additionally verifies that all protocol reads occurred before the first substantive assistant text response — catches "read-after-respond" violations.
-
-**Exit codes:**
-- 0 = PASS — all 5 steps verified
-- 1 = FAIL — at least one step not executed
-
-**PASS output:**
-```
-PASS: Agent RDF Memory Protocol executed — all 5 steps verified (43 tool calls audited)
-```
-
-**FAIL output:**
-```
-FAIL: 3 protocol step(s) not executed
-  - Protocol step 1: Did not list agent-rdf-memory/ directory...
-  - Protocol step 3: Read preferences.ttl
-  - Protocol step 5: Did not follow index.ttl references...
-```
-
-**Do not run --strict if the transcript lacks user text prompts** — Claude Code JSONL transcripts don't always contain the literal user prompt text, in which case the strict timing check gracefully skips."""@en .
-
-# ── Step 4: Interpret failures ────────────────────────────────────────────────
+# ── Step 5: Interpret FAIL Lines ─────────────────────────────────────────────
 
 :step-interpretFailures a schema:HowToStep ;
-    schema:position 4 ;
-    schema:name "Map each FAIL line to the protocol step it violates and determine root cause"@en ;
-    schema:text """Each FAIL line names a specific protocol step. The root cause is typically one of:
+    schema:position 5 ;
+    schema:name "Map each FAIL line to the protocol step it violates"@en ;
+    schema:text "Each FAIL line names a specific protocol step; :workExample-failInterpretation carries the full FAIL-message → root-cause mapping table. The most common partial-compliance failure is step 5 (core files read, but no howto/session/project/entity files consulted)."@en .
 
-| FAIL message | Likely root cause |
+# ── Step 6: Classify the Root Cause ──────────────────────────────────────────
+
+:step-classifyRootCause a schema:HowToStep ;
+    schema:position 6 ;
+    schema:name "Classify the failure: hook didn't fire, GATE ignored, or partial execution"@en ;
+    schema:text """Root cause classification:
+1. HOOK INJECTION DIDN'T FIRE — the SessionStart hook was not configured, or the GATE instruction was not injected. Check that .claude/settings.json has the hook enabled.
+2. GATE INSTRUCTION WAS IGNORED — the injection fired but the agent treated it as 'memory already loaded'. This is the exact failure the GATE instruction's ASCII art box was designed to prevent.
+3. PROTOCOL PARTIALLY EXECUTED — some steps ran but the agent stopped short (typically step 5). The compact injection provided step names without content, making the agent think it had 'enough'."""@en .
+
+# ── Step 7: Fix — Hook Injection ─────────────────────────────────────────────
+
+:step-fixHookInjection a schema:HowToStep ;
+    schema:position 7 ;
+    schema:name "If the hook injection is the issue, repair load_memory.py and the hook configuration"@en ;
+    schema:text """1. Review agent-rdf-memory/load_memory.py to ensure the GATE instruction section is intact and prominent.
+2. Verify the additionalContext output includes all 5 protocol steps.
+3. Check .claude/settings.json that the SessionStart hook is configured and points to the correct script path.
+4. If new failure patterns have emerged, add additional inline text excerpts to the hook injection (as was done for the whoami format spec)."""@en .
+
+# ── Step 8: Fix — Ignored GATE Instruction ───────────────────────────────────
+
+:step-fixIgnoredGate a schema:HowToStep ;
+    schema:position 8 ;
+    schema:name "If the GATE instruction was present but ignored, make it more prominent"@en ;
+    schema:text """1. Make the instruction more prominent — add CRITICAL markers, larger ASCII art, or restructure to appear earlier in the injected context.
+2. Consider adding a second injection point (e.g., an additional context block at the end of the injection that repeats the GATE requirement).
+3. The load_memory.py script has a documented rationale section — verify it's still accurate and update if new failure patterns have emerged."""@en .
+
+# ── Step 9: Fix — Partial Execution ──────────────────────────────────────────
+
+:step-fixPartialExecution a schema:HowToStep ;
+    schema:position 9 ;
+    schema:name "If steps 1–4 pass but step 5 fails, reduce injected excerpts and call out step 5 explicitly"@en ;
+    schema:text """1. The compact injection may be providing too much content, making the agent think it has enough. Reduce the injected step text excerpts to names + howto references only.
+2. Add an explicit instruction to the GATE box: 'Step 5 is the most commonly skipped step. You MUST open at least one howto/*.ttl file.'"""@en .
+
+# ── Step 10: Re-Audit ────────────────────────────────────────────────────────
+
+:step-fixAndReaudit a schema:HowToStep ;
+    schema:position 10 ;
+    schema:name "Fixes are preventive only — audit the NEXT session's transcript to confirm"@en ;
+    schema:text "A FAIL result means the current session's protocol compliance is already compromised; the transcript cannot be retroactively fixed. After applying a fix, audit the NEXT session's transcript. A passing audit confirms the fix is effective; if the next session also fails, iterate — the validator is the feedback loop that drives hook injection improvements."@en .
+
+# ── Step 11: preferences.ttl Sparse-Index Contract ───────────────────────────
+
+:step-preferencesSparseContract a schema:HowToStep ;
+    schema:position 11 ;
+    schema:name "preferences.ttl sparse-index contract — schema:text is ONE sentence; prose belongs in howto/"@en ;
+    schema:text """PRE-WRITE GATE — applies every time a new schema:HowToStep is added to preferences.ttl, which is read in full at every session start (verbose inline schema:text directly inflates context cost before any task begins). Two-tier split:
+- Tier 1, preferences.ttl (always loaded, must stay compact): schema:name (rule as noun phrase), schema:text (ONE sentence — the core rule, nothing else), onto:hasTrigger, rdfs:seeAlso pointer to the howto file.
+- Tier 2, howto/*.ttl (loaded on-demand, can be verbose): full rationale, incident notes, code examples, verification gates, edge cases.
+Before writing a new step to preferences.ttl, ask: does schema:text exceed one sentence? If yes, it belongs in the howto file — the one-sentence summary stays, everything else moves. Incident (2026-06-25): over ~10 sessions, 55 of 79 steps accumulated multi-paragraph schema:text totalling ~2300 lines; a subagent refactor was required to trim them because no gate existed to prevent re-inflation."""@en ;
+    schema:dateCreated "2026-06-25T00:00:00Z"^^xsd:dateTime .
+
+# ── Step 12: Sparse-Contract Verification ────────────────────────────────────
+
+:step-sparseVerification a schema:HowToStep ;
+    schema:position 12 ;
+    schema:name "After adding any preferences.ttl step, run the >300-char schema:text check"@en ;
+    schema:text "Run the rdflib check in :workExample-sparseCheck after adding any new step to preferences.ttl; it lists every schema:text literal over 300 characters. The result must be 'Violations: None'."@en .
+
+# ── Root cause note ───────────────────────────────────────────────────────────
+
+:rootCauseNote a schema:Thing ;
+    schema:name "Root cause of memory protocol failures — two-layer defense"@en ;
+    schema:description """Primary defense — SessionStart hook injection (load_memory.py): injects compact memory context with the GATE instruction (ASCII art box listing all 5 protocol steps, warning that the compact injection is a safety net, not a replacement) plus inline excerpts for critical specs. Preferred prevention path.
+
+Secondary defense — transcript audit validator (validate-memory-protocol.py): post-session audit that proves the protocol was or wasn't executed, catches failures the hook couldn't prevent, and provides actionable data for improving the hook injection.
+
+Why both: the hook injects text into the context window — it cannot force tool calls. The validator is the objective audit that proves whether prevention worked. Closed loop: hook prevents → validator confirms → if validation fails, hook improves → next session passes. See step-memoryProtocol (the protocol itself) and step-memoryProtocolGate (enforcement) in preferences.ttl."""@en ;
+    schema:dateCreated "2026-06-10T00:00:00Z"^^xsd:dateTime .
+
+# ── Worked Examples ──────────────────────────────────────────────────────────
+
+:workExample-validatorOutput a schema:CreativeWork ;
+    schema:name "Validator PASS and FAIL output samples"@en ;
+    schema:text """PASS:
+  PASS: Agent RDF Memory Protocol executed — all 5 steps verified (43 tool calls audited)
+
+FAIL:
+  FAIL: 3 protocol step(s) not executed
+    - Protocol step 1: Did not list agent-rdf-memory/ directory...
+    - Protocol step 3: Read preferences.ttl
+    - Protocol step 5: Did not follow index.ttl references..."""@en .
+
+:workExample-failInterpretation a schema:CreativeWork ;
+    schema:name "FAIL message → likely root cause mapping"@en ;
+    schema:text """| FAIL message | Likely root cause |
 |---|---|
 | Step 1: Did not list agent-rdf-memory/ | Agent skipped the protocol entirely — no directory listing was run |
 | Step 2: Read core.ttl | Protocol was started but core files were not read |
 | Step 3: Read preferences.ttl | As above — behavioral contract was not loaded |
 | Step 4: Read index.ttl | Session index was not consulted |
-| Step 5: Did not follow index.ttl references | Core files were read but no howto/session/project/entity files were consulted — the most common partial-compliance failure |
+| Step 5: Did not follow index.ttl references | Core files were read but no howto/session/project/entity files were consulted — the most common partial-compliance failure |"""@en .
 
-**If --strict mode fails (read-after-respond):**
-The agent responded to the user BEFORE executing the protocol. This is the canonical failure pattern the gate was designed to catch. The response was generated from CLAUDE.md prose or prior context rather than from the authoritative memory files.
-
-**Root cause classification:**
-1. **Hook injection didn't fire** — SessionStart hook was not configured, or the GATE instruction was not injected. Check that `.claude/settings.json` has the hook enabled.
-2. **GATE instruction was ignored** — The injection fired but the agent treated it as "memory already loaded." This is the exact failure the GATE instruction's ASCII art box was designed to prevent.
-3. **Protocol was partially executed** — Some steps ran but the agent stopped short (typically step 5 — following references). The compact injection provided step names without content, making the agent think it had "enough."
-
-**If the hook injection needs updating:**
-Edit `agent-rdf-memory/load_memory.py` to inject additional context for the missing step(s). The hook is the primary prevention mechanism — the validator is the backstop that tells you when the hook needs improvement."""@en .
-
-# ── Step 5: Fix and re-audit ──────────────────────────────────────────────────
-
-:step-fixAndReaudit a schema:HowToStep ;
-    schema:position 5 ;
-    schema:name "Fix the root cause, then re-audit on the next session transcript"@en ;
-    schema:text """A FAIL result means the current session's protocol compliance is already compromised. You cannot retroactively fix the transcript — the fix must be preventive for future sessions.
-
-**If the hook injection is the issue:**
-1. Review `agent-rdf-memory/load_memory.py` to ensure the GATE instruction section is intact and prominent.
-2. Verify the `additionalContext` output includes all 5 protocol steps.
-3. Check `.claude/settings.json` that the SessionStart hook is configured and points to the correct script path.
-4. If new failure patterns have emerged, add additional inline text excerpts to the hook injection (as was done for the whoami format spec).
-
-**If the GATE instruction was present but ignored:**
-1. Make the instruction more prominent — add `CRITICAL` markers, larger ASCII art, or restructure to appear earlier in the injected context.
-2. Consider adding a second injection point (e.g., an additional context block at the end of the injection that repeats the GATE requirement).
-3. The `load_memory.py` script has a documented rationale section — verify it's still accurate and update if new failure patterns have emerged.
-
-**If partial execution is the pattern (steps 1-4 pass, step 5 fails):**
-1. The compact injection may be providing too much content, making the agent think it has enough. Reduce the injected step text excerpts to names + howto references only.
-2. Add an explicit instruction to the GATE box: "Step 5 is the most commonly skipped step. You MUST open at least one howto/*.ttl file."
-
-**After fixing:**
-Audit the NEXT session's transcript. A passing audit confirms the fix is effective. If the next session also fails, iterate — the validator is the feedback loop that drives hook injection improvements."""@en .
-
-# ── Root cause note ───────────────────────────────────────────────────────────
-
-:rootCauseNote a schema:Thing ;
-    schema:name "Root cause of memory protocol failures"@en ;
-    schema:description """Two-layer defense against the recurring failure pattern:
-
-**Primary defense — SessionStart hook injection (load_memory.py):**
-- Injects compact memory context with GATE instruction at session start
-- The GATE instruction (ASCII art box) lists all 5 protocol steps and warns that the compact injection is a safety net, not a replacement
-- Inline text excerpts for critical specs (whoami format, step names + howto refs) reduce the chance that the agent answers from stale context
-- This is the PREFERRED prevention path — if the hook works, the validator is just a confirming audit
-
-**Secondary defense — Transcript audit validator (validate-memory-protocol.py):**
-- Post-session audit that proves the protocol was or wasn't executed
-- Catches failures the hook couldn't prevent (e.g., agent ignoring the GATE instruction)
-- Provides actionable data for improving the hook injection
-
-**Why both layers are needed:**
-The hook injection is a best-effort prevention mechanism. It injects text into the context window — it cannot force the agent to execute tool calls. The validator is the objective audit that proves whether prevention worked. Together they form a closed loop: hook prevents → validator confirms → if validation fails, hook improves → next session passes.
-
-See also: step 5 (step-memoryProtocol) in preferences.ttl for the protocol itself, and step-memoryProtocolGate for the enforcement step."""@en ;
-    schema:dateCreated "2026-06-10T00:00:00Z"^^xsd:dateTime .
-
-# ── Gate: preferences.ttl sparse-index contract ──────────────────────────────────
-
-:step-preferencesSparseContract a schema:HowToStep ;
-    schema:position 6 ;
-    schema:name "preferences.ttl sparse-index contract — prose belongs in howto/, never inline"@en ;
-    schema:text """**PRE-WRITE GATE — applies every time a new schema:HowToStep is added to preferences.ttl.**
-
-preferences.ttl is read in full at every session start. Verbose inline schema:text values directly inflate context cost before any task begins. The architecture is a two-tier split:
-
-**Tier 1 — preferences.ttl (always loaded, must stay compact):**
-- schema:name — the rule as a noun phrase (already concise)
-- schema:text — ONE sentence only; the core rule, nothing else
-- onto:hasTrigger — when the rule fires
-- rdfs:seeAlso — pointer to the howto file with full detail
-
-**Tier 2 — howto/*.ttl (loaded on-demand, can be verbose):**
-- Full rationale, incident notes, code examples, verification gates, edge cases
-
-**The gate:**
-Before writing a new step to preferences.ttl, ask: does schema:text exceed one sentence? If yes, it belongs in the howto file. The one-sentence summary stays; everything else moves.
-
-**Verification (run after adding any new step):**
-python3 -c "
+:workExample-sparseCheck a schema:CreativeWork ;
+    schema:name "Sparse-contract verification one-liner"@en ;
+    schema:text """python3 -c "
 import rdflib
 g = rdflib.Graph()
 g.parse('agent-rdf-memory/preferences.ttl', format='turtle')
 from rdflib import URIRef
 long = [(str(s).split('#')[-1], len(str(o))) for s,p,o in g.triples((None, URIRef('http://schema.org/text'), None)) if len(str(o)) > 300]
 print('Violations (>300 chars):', long or 'None')
-"
-
-**Incident (2026-06-25):** Over ~10 sessions, 55 of 79 steps accumulated multi-paragraph schema:text values totalling ~2300 lines. A subagent refactor was required to trim them, moving all prose to howto files. The problem was no gate existed to prevent re-inflation."""@en ;
-    schema:dateCreated "2026-06-25T00:00:00Z"^^xsd:dateTime .
+\""""@en .

--- a/agent-rdf-memory/howto/owl-property-characterization.ttl
+++ b/agent-rdf-memory/howto/owl-property-characterization.ttl
@@ -6,109 +6,97 @@
 
 <> a schema:HowTo ;
     schema:name "OWL Property Characterization for Generated Ontologies"@en ;
-    schema:description "When generating a custom ontology as part of a KG task, every object property (owl:ObjectProperty) must be characterized using applicable OWL constructs from the nine semantic categories below. This supplements the ontology-cross-reference-gate requirements (label, comment, domain, range, isDefinedBy, seeAlso) with structural OWL rigor."@en ;
+    schema:description "When generating a custom ontology as part of a KG task, every object property (owl:ObjectProperty) must be characterized using applicable OWL constructs from nine semantic categories. This supplements the ontology-cross-reference-gate requirements (label, comment, domain, range, isDefinedBy, seeAlso) with structural OWL rigor."@en ;
     schema:dateCreated "2026-07-01"^^xsd:date ;
-    schema:dateModified "2026-07-01T00:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-07-19T00:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
-    schema:about :mainStep ;
-    schema:step :mainStep, :step-symmetry, :step-cardinality, :step-hierarchy, :step-inverse, :step-composition ;
-    rdfs:seeAlso <../preferences.ttl#step-owlPropertyCharacterization>, <../preferences.ttl#step-edgePropertyTyping> .
+    schema:step :step-applyCategories, :step-applicationRules, :step-symmetry,
+        :step-cardinality, :step-hierarchy, :step-inverse, :step-composition,
+        :step-verificationGate ;
+    schema:workExample :workExample-categoryCatalog, :workExample-defaultTemplate ;
+    rdfs:seeAlso <../preferences.ttl#step-owlPropertyCharacterization>, <../preferences.ttl#step-edgePropertyTyping>,
+        <ontology-cross-reference-gate.ttl> .
 
-:mainStep a schema:HowToStep ;
+# ── Step 1: Apply the Semantic Categories ────────────────────────────────────
+
+:step-applyCategories a schema:HowToStep ;
     schema:position 1 ;
-    schema:name "Apply OWL semantic categories to every generated custom property"@en ;
-    schema:text """Every custom object property defined during KG/ontology generation must be characterized using applicable OWL constructs from these nine semantic categories. Not every category applies to every property — apply only those that are semantically valid. The goal is structural rigor, not exhaustive tagging.
+    schema:name "Characterize every custom object property from the nine OWL semantic categories"@en ;
+    schema:text "Every custom object property defined during KG/ontology generation must be characterized using applicable OWL constructs from the nine semantic categories catalogued in :workExample-categoryCatalog. Not every category applies to every property — apply only those that are semantically valid. The goal is structural rigor, not exhaustive tagging."@en .
 
-=== OWL Property Semantic Categories ===
+# ── Step 2: Application Rules ────────────────────────────────────────────────
 
-Category 1 — Typing (MANDATORY — already required by ontology-cross-reference-gate):
-  • rdfs:domain  — what kinds of entities the relationship connects FROM
-  • rdfs:range   — what kinds of entities the relationship connects TO
-
-Category 2 — Hierarchy:
-  • rdfs:subPropertyOf       — parent property in a broader vocabulary
-  • owl:equivalentProperty   — equivalent property in another vocabulary
-  • owl:propertyDisjointWith — mutually exclusive with another property
-
-Category 3 — Identity / Direction:
-  • owl:inverseOf — define inverse relationships (e.g., :employs owl:inverseOf :employedBy)
-
-Category 4 — Reflexivity:
-  • owl:ReflexiveProperty   — may relate something to itself
-  • owl:IrreflexiveProperty — may NOT relate something to itself
-
-Category 5 — Symmetry:
-  • owl:SymmetricProperty  — relationship holds in both directions
-  • owl:AsymmetricProperty — relationship does NOT hold in both directions
-
-Category 6 — Propagation:
-  • owl:TransitiveProperty — relationship propagates through intermediate entities
-
-Category 7 — Cardinality / Uniqueness:
-  • owl:FunctionalProperty        — at most one value per subject
-  • owl:InverseFunctionalProperty — at most one subject per value
-
-Category 8 — Composition:
-  • owl:propertyChainAxiom — define relationships derived from combinations of others
-
-Category 9 — Class-based Constraints:
-  • owl:someValuesFrom, owl:allValuesFrom, owl:hasValue
-  • Cardinality restrictions (owl:minCardinality, owl:maxCardinality, owl:cardinality)
-
-=== Application Rules ===
-
-1. Category 1 (Typing) is MANDATORY per ontology-cross-reference-gate — already required.
+:step-applicationRules a schema:HowToStep ;
+    schema:position 2 ;
+    schema:name "Apply the per-category defaults: typing mandatory, hierarchy when a broader term exists, advanced categories only when verifiable"@en ;
+    schema:text """1. Category 1 (Typing) is MANDATORY per ontology-cross-reference-gate — already required.
 2. Category 2 (Hierarchy) — if a broader or equivalent property exists in schema.org, DBpedia, or Wikidata, assert rdfs:subPropertyOf or owl:equivalentProperty. This goes beyond the rdfs:seeAlso cross-reference required by the cross-reference gate by making the semantic relationship explicit.
 3. Category 4 (Reflexivity) — apply to properties where the reflexivity behavior is knowable. Most custom properties will be owl:IrreflexiveProperty (e.g., a blog's :blogStatus cannot be its own status).
 4. Category 5 (Symmetry) — apply when the symmetry is clear. Most directional properties are owl:AsymmetricProperty.
 5. Category 7 (Cardinality) — apply owl:FunctionalProperty when the property has at most one value per subject (e.g., :blogStatus, :hcuImpact, :dataConfidence each have exactly one value per blog).
-6. Categories 6, 8, and 9 are advanced — apply only when the semantics are clear and verifiable.
+6. Categories 6, 8, and 9 are advanced — apply only when the semantics are clear and verifiable."""@en .
 
-=== Default Characterization Template ===
-
-For a typical custom classification/status property (the most common pattern in study-oriented KGs), the default characterization is:
-
-  :exampleProperty a owl:ObjectProperty, owl:FunctionalProperty, owl:AsymmetricProperty, owl:IrreflexiveProperty ;
-      rdfs:label "..."@en ;
-      rdfs:comment "..."@en ;
-      rdfs:domain ... ;
-      rdfs:range ... ;
-      rdfs:isDefinedBy :exampleOntology ;
-      rdfs:seeAlso <dbr:RelatedConcept> .
-
-This asserts: one value per subject (FunctionalProperty), the property is directional (AsymmetricProperty), and the subject cannot have this relationship with itself (IrreflexiveProperty).
-
-=== Verification Gate ===
-
-Before delivering a generated ontology, verify:
-1. Every custom owl:ObjectProperty has rdfs:domain and rdfs:range (Category 1) — REUSE cross-reference gate check.
-2. Every custom property has at least one OWL characteristic beyond typing, chosen from the applicable categories.
-3. The chosen characteristics are semantically defensible — if unsure, omit rather than guess.
-4. owl:FunctionalProperty is applied to every custom property that has at most one value per subject (the common case for classification/status properties)."""@en .
-
-# ── Category-specific guidance steps ────────────────────────────────────────────
+# ── Steps 3–7: Category-Specific Guidance ────────────────────────────────────
 
 :step-symmetry a schema:HowToStep ;
-    schema:position 2 ;
+    schema:position 3 ;
     schema:name "Symmetry: directional properties are AsymmetricProperty by default"@en ;
-    schema:text """Most custom properties in domain-specific ontologies are directional: subject → object. Apply owl:AsymmetricProperty unless the relationship is genuinely bidirectional. Example: :blogStatus connects a Blog to a Status — it is asymmetric because a Status cannot have a blogStatus pointing back to the Blog."""@en .
+    schema:text "Most custom properties in domain-specific ontologies are directional: subject → object. Apply owl:AsymmetricProperty unless the relationship is genuinely bidirectional. Example: :blogStatus connects a Blog to a Status — it is asymmetric because a Status cannot have a blogStatus pointing back to the Blog."@en .
 
 :step-cardinality a schema:HowToStep ;
-    schema:position 3 ;
+    schema:position 4 ;
     schema:name "Cardinality: classification/status properties default to FunctionalProperty"@en ;
-    schema:text """Any custom property that assigns a single classification, status, or category to an entity should be typed owl:FunctionalProperty. Examples: :blogStatus (one status per blog), :hcuImpact (one impact level per blog), :dataConfidence (one confidence level per blog). Do NOT apply FunctionalProperty to properties that may have multiple values (e.g., schema:offers, schema:about, schema:hasPart)."""@en .
+    schema:text "Any custom property that assigns a single classification, status, or category to an entity should be typed owl:FunctionalProperty. Examples: :blogStatus (one status per blog), :hcuImpact (one impact level per blog), :dataConfidence (one confidence level per blog). Do NOT apply FunctionalProperty to properties that may have multiple values (e.g., schema:offers, schema:about, schema:hasPart)."@en .
 
 :step-hierarchy a schema:HowToStep ;
-    schema:position 4 ;
+    schema:position 5 ;
     schema:name "Hierarchy: prefer rdfs:subPropertyOf over bare rdfs:seeAlso when a broader property exists"@en ;
-    schema:text """If a custom property can be characterized as a sub-property of an existing schema.org or Dublin Core property, assert rdfs:subPropertyOf in addition to the rdfs:seeAlso cross-reference. Example: a custom :studyOutcome property could be rdfs:subPropertyOf schema:result if the semantics align. This provides stronger semantic alignment than rdfs:seeAlso alone."""@en .
+    schema:text "If a custom property can be characterized as a sub-property of an existing schema.org or Dublin Core property, assert rdfs:subPropertyOf in addition to the rdfs:seeAlso cross-reference. Example: a custom :studyOutcome property could be rdfs:subPropertyOf schema:result if the semantics align. This provides stronger semantic alignment than rdfs:seeAlso alone."@en .
 
 :step-inverse a schema:HowToStep ;
-    schema:position 5 ;
+    schema:position 6 ;
     schema:name "Inverse: define inverse properties when both directions are meaningful"@en ;
-    schema:text """If a relationship is naturally navigable in both directions, define the inverse explicitly. Example: if a custom :hasBlogger property is defined, also define :bloggerOf with owl:inverseOf :hasBlogger. This enables bidirectional SPARQL navigation."""@en .
+    schema:text "If a relationship is naturally navigable in both directions, define the inverse explicitly. Example: if a custom :hasBlogger property is defined, also define :bloggerOf with owl:inverseOf :hasBlogger. This enables bidirectional SPARQL navigation."@en .
 
 :step-composition a schema:HowToStep ;
-    schema:position 6 ;
+    schema:position 7 ;
     schema:name "Composition: use property chains only when the derivation is unambiguous"@en ;
-    schema:text """owl:propertyChainAxiom should be used sparingly. Apply only when a relationship is clearly the composition of two or more existing relationships. Example: if :worksFor connects Person→Organization and :locatedIn connects Organization→City, then :worksInCity could be defined as owl:propertyChainAxiom (:worksFor :locatedIn). Verify the chain semantics before asserting."""@en .
+    schema:text "owl:propertyChainAxiom should be used sparingly. Apply only when a relationship is clearly the composition of two or more existing relationships. Example: if :worksFor connects Person→Organization and :locatedIn connects Organization→City, then :worksInCity could be defined as owl:propertyChainAxiom (:worksFor :locatedIn). Verify the chain semantics before asserting."@en .
+
+# ── Step 8: Verification Gate ────────────────────────────────────────────────
+
+:step-verificationGate a schema:HowToStep ;
+    schema:position 8 ;
+    schema:name "Before delivery, verify typing, at least one extra characteristic, and semantic defensibility"@en ;
+    schema:text """Before delivering a generated ontology, verify:
+1. Every custom owl:ObjectProperty has rdfs:domain and rdfs:range (Category 1) — REUSE the cross-reference gate check.
+2. Every custom property has at least one OWL characteristic beyond typing, chosen from the applicable categories.
+3. The chosen characteristics are semantically defensible — if unsure, omit rather than guess.
+4. owl:FunctionalProperty is applied to every custom property that has at most one value per subject (the common case for classification/status properties)."""@en ;
+    rdfs:seeAlso <ontology-cross-reference-gate.ttl#step-gateEnforcement> .
+
+# ── Worked Examples ──────────────────────────────────────────────────────────
+
+:workExample-categoryCatalog a schema:CreativeWork ;
+    schema:name "The nine OWL property semantic categories"@en ;
+    schema:text """Category 1 — Typing (MANDATORY): rdfs:domain (connects FROM), rdfs:range (connects TO).
+Category 2 — Hierarchy: rdfs:subPropertyOf (parent property), owl:equivalentProperty (equivalent in another vocabulary), owl:propertyDisjointWith (mutually exclusive).
+Category 3 — Identity / Direction: owl:inverseOf (e.g., :employs owl:inverseOf :employedBy).
+Category 4 — Reflexivity: owl:ReflexiveProperty (may relate something to itself), owl:IrreflexiveProperty (may NOT).
+Category 5 — Symmetry: owl:SymmetricProperty (holds in both directions), owl:AsymmetricProperty (does NOT).
+Category 6 — Propagation: owl:TransitiveProperty (propagates through intermediate entities).
+Category 7 — Cardinality / Uniqueness: owl:FunctionalProperty (at most one value per subject), owl:InverseFunctionalProperty (at most one subject per value).
+Category 8 — Composition: owl:propertyChainAxiom (derived from combinations of others).
+Category 9 — Class-based Constraints: owl:someValuesFrom, owl:allValuesFrom, owl:hasValue; cardinality restrictions (owl:minCardinality, owl:maxCardinality, owl:cardinality)."""@en .
+
+:workExample-defaultTemplate a schema:CreativeWork ;
+    schema:name "Default characterization for a classification/status property"@en ;
+    schema:text """:exampleProperty a owl:ObjectProperty, owl:FunctionalProperty, owl:AsymmetricProperty, owl:IrreflexiveProperty ;
+    rdfs:label "..."@en ;
+    rdfs:comment "..."@en ;
+    rdfs:domain ... ;
+    rdfs:range ... ;
+    rdfs:isDefinedBy :exampleOntology ;
+    rdfs:seeAlso <dbr:RelatedConcept> .
+
+This asserts: one value per subject (FunctionalProperty), the property is directional (AsymmetricProperty), and the subject cannot have this relationship with itself (IrreflexiveProperty). It is the most common pattern in study-oriented KGs."""@en .

--- a/agent-rdf-memory/howto/session-governance.ttl
+++ b/agent-rdf-memory/howto/session-governance.ttl
@@ -6,16 +6,16 @@
 
 <> a schema:HowTo ;
     schema:name "Session Governance — Approval, Memory, Git, and Safety Rules"@en ;
-    schema:description "Nine standing rules governing how the agent conducts every session: approval before acting, memory protocol, git discipline, URL fabrication prohibition, curl authentication elicitation, secret redaction, verbatim prompt recording, session log reconciliation, and semantic session bootstrap."@en ;
+    schema:description "Standing rules governing how the agent conducts every session: approval before acting, memory read protocol and write-on-trigger rule, git discipline, URL fabrication prohibition, curl authentication elicitation, secret redaction, verbatim prompt recording, session log reconciliation, and semantic session bootstrap."@en ;
     schema:dateCreated "2026-06-05T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-07-06T00:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-07-19T00:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
-    schema:about :step-approval, :step-memoryProtocol, :step-gitWorkflow,
-        :step-noFabricatedUrls, :step-curlAuth, :step-secretRedaction,
-        :step-promptRecording, :step-sessionLogReconciliation, :step-semanticSessionBootstrap ;
-    schema:step :step-approval, :step-memoryProtocol, :step-gitWorkflow,
-        :step-noFabricatedUrls, :step-curlAuth, :step-secretRedaction,
-        :step-promptRecording, :step-sessionLogReconciliation, :step-semanticSessionBootstrap ;
+    schema:step :step-approval, :step-memoryProtocol, :step-memoryWriteRule,
+        :step-sessionFileContents, :step-gitWorkflow, :step-noFabricatedUrls,
+        :step-urlVerification, :step-curlAuth, :step-secretRedaction,
+        :step-retroactiveRedaction, :step-promptRecording,
+        :step-assistantResponseRecording, :step-opalVocabularyPreference,
+        :step-sessionLogReconciliation, :step-semanticSessionBootstrap ;
     rdfs:seeAlso <../preferences.ttl#step-memoryProtocol>, <../preferences.ttl#step-approval>, <../preferences.ttl#step-gitWorkflow>, <../preferences.ttl#step-noFabricatedUrls>, <../preferences.ttl#step-curlAuth>, <../preferences.ttl#step-secretRedaction>, <../preferences.ttl#step-secretEchoRedaction>, <../preferences.ttl#step-promptRecording>, <../preferences.ttl#step-sessionLogReconciliation>, <../preferences.ttl#step-semanticSessionBootstrap> .
 
 # ── Step 1: Seek Approval ────────────────────────────────────────────────────
@@ -23,13 +23,21 @@
 :step-approval a schema:HowToStep ;
     schema:position "1"^^xsd:integer ;
     schema:name "Seek approval before acting unless told otherwise"@en ;
-    schema:text """Present plans for user approval before implementing. Never proactively fix or modify documents without explicit request and approval. If unsure, ask. Once approval is granted for a scope, operate autonomously within that scope."""@en .
+    schema:text "Present plans for user approval before implementing. Never proactively fix or modify documents without explicit request and approval. If unsure, ask. Once approval is granted for a scope, operate autonomously within that scope."@en .
 
-# ── Step 2: Memory Protocol ──────────────────────────────────────────────────
+# ── Step 2: Memory Read Protocol ─────────────────────────────────────────────
 
 :step-memoryProtocol a schema:HowToStep ;
     schema:position "2"^^xsd:integer ;
-    schema:name "Read agent-rdf-memory/ before tasks, write immediately on trigger events"@en ;
+    schema:name "Read agent-rdf-memory/ before any task needing context"@en ;
+    onto:hasTrigger onto:triggerSessionStart ;
+    schema:text "BEFORE any task needing context: list agent-rdf-memory/, read core.ttl, preferences.ttl, and index.ttl, then follow index.ttl to relevant session/project files. Reason over the loaded Turtle before proceeding. Never skip this — the RDF memory is the source of truth, not the Claude auto-memory."@en .
+
+# ── Step 3: Memory Write-on-Trigger Rule ─────────────────────────────────────
+
+:step-memoryWriteRule a schema:HowToStep ;
+    schema:position "3"^^xsd:integer ;
+    schema:name "Write to the session file immediately when any onto:MemoryWriteTrigger fires — never defer"@en ;
     onto:hasTrigger
         onto:triggerPreferencesUpdate ,
         onto:triggerSkillInvocation ,
@@ -37,58 +45,93 @@
         onto:triggerBehaviorGapIdentified ,
         onto:triggerTopicChange ,
         onto:triggerSessionEnd ;
-    schema:text """BEFORE any task needing context: list agent-rdf-memory/, read core.ttl, preferences.ttl, and index.ttl, then follow index.ttl to relevant session/project files. Reason over loaded Turtle before proceeding. WRITE RULE: write to sessions/YYYY-MM-DD-{llm-id}-{agent-env}.ttl immediately when any onto:MemoryWriteTrigger instance fires (see onto:hasTrigger). Do not defer — write at the trigger point. If multiple triggers fire close together, one write covering all is acceptable. Session file covers: tasks completed, skills invoked, artifacts generated, preferences updated, gaps identified, prompt text recorded verbatim (see step-promptRecording), and inferred user preferences. The trigger instances are defined in ontology.ttl as prov:Activity subclasses (owl:equivalentClass event:Event). Never skip this — the RDF memory is the source of truth, not the Claude auto-memory."""@en .
+    schema:text "WRITE RULE: write to sessions/YYYY-MM-DD-{llm-id}-{agent-env}.ttl immediately when any onto:MemoryWriteTrigger instance fires (see onto:hasTrigger). Do not defer — write at the trigger point. If multiple triggers fire close together, one write covering all is acceptable. The trigger instances are defined in ontology.ttl as prov:Activity subclasses (owl:equivalentClass event:Event)."@en .
 
-# ── Step 3: Git Workflow ─────────────────────────────────────────────────────
+# ── Step 4: Session File Contents ────────────────────────────────────────────
+
+:step-sessionFileContents a schema:HowToStep ;
+    schema:position "4"^^xsd:integer ;
+    schema:name "Cover the full session record in every session file write"@en ;
+    schema:text "The session file covers: tasks completed, skills invoked, artifacts generated, preferences updated, gaps identified, prompt text recorded verbatim (see :step-promptRecording), and inferred user preferences."@en .
+
+# ── Step 5: Git Workflow ─────────────────────────────────────────────────────
 
 :step-gitWorkflow a schema:HowToStep ;
-    schema:position "3"^^xsd:integer ;
+    schema:position "5"^^xsd:integer ;
     schema:name "Commit and push only when explicitly asked"@en ;
-    schema:text """Never commit or push as a side effect of other tasks. Edit skill files → repackage ZIP → commit only when asked → sync registries after commit, not before. Never amend published commits or skip hooks (--no-verify)."""@en .
+    schema:text "Never commit or push as a side effect of other tasks. Edit skill files → repackage ZIP → commit only when asked → sync registries after commit, not before. Never amend published commits or skip hooks (--no-verify)."@en .
 
-# ── Step 4: No Fabricated URLs ───────────────────────────────────────────────
+# ── Step 6: No Fabricated URLs ───────────────────────────────────────────────
 
 :step-noFabricatedUrls a schema:HowToStep ;
-    schema:position "4"^^xsd:integer ;
-    schema:name "Never fabricate, guess, or hallucinate URLs"@en ;
+    schema:position "6"^^xsd:integer ;
+    schema:name "Never fabricate, guess, or hallucinate URLs — three provenance paths only"@en ;
     onto:hasTrigger onto:triggerBehaviorGapIdentified ;
-    schema:text """NEVER fabricate, guess, construct, or hallucinate any URL. This prohibition is absolute and covers every URL type: encoded live-editor links (pako, base64), API endpoints, documentation pages, download links, image URLs, resolver links, and any other URI. If a URL cannot be produced by (a) copying it verbatim from a source the user provided, (b) computing it deterministically with a tool (e.g., Python script for pako encoding, curl for discovery), or (c) constructing it from a known, documented pattern where every path component is validated — then the agent MUST ask the user for the correct URL. A fabricated URL that renders a blank page, a 404, or wrong content is worse than no URL at all. After computing an encoded URL with a tool, verify it actually works before including it in any document. When in doubt, omit the URL and ask. This rule has no exceptions."""@en .
+    schema:text "NEVER fabricate, guess, construct, or hallucinate any URL. This prohibition is absolute and covers every URL type: encoded live-editor links (pako, base64), API endpoints, documentation pages, download links, image URLs, resolver links, and any other URI. A URL may only be produced by (a) copying it verbatim from a source the user provided, (b) computing it deterministically with a tool (e.g., Python script for pako encoding, curl for discovery), or (c) constructing it from a known, documented pattern where every path component is validated. Otherwise ask the user for the correct URL. This rule has no exceptions."@en .
 
-# ── Step 5: Authenticated curl ───────────────────────────────────────────────
+# ── Step 7: URL Verification Before Use ──────────────────────────────────────
+
+:step-urlVerification a schema:HowToStep ;
+    schema:position "7"^^xsd:integer ;
+    schema:name "Verify computed URLs actually work before including them; when in doubt, omit and ask"@en ;
+    schema:text "After computing an encoded URL with a tool, verify it actually works before including it in any document. A fabricated URL that renders a blank page, a 404, or wrong content is worse than no URL at all. When in doubt, omit the URL and ask."@en .
+
+# ── Step 8: Authenticated curl ───────────────────────────────────────────────
 
 :step-curlAuth a schema:HowToStep ;
-    schema:position "5"^^xsd:integer ;
+    schema:position "8"^^xsd:integer ;
     schema:name "Elicit user confirmation before optionally using authenticated curl with PKCS#12/PEM certificate and/or On-Behalf-Of"@en ;
     schema:text """When a skill workflow requires constructing a curl command against a protected or identity-aware endpoint (e.g. data-twingler, acp-client, linked-data-skills, uriburner-opal-agent-skills, or any other skill), first explicitly elicit from the user whether to apply curl with On-Behalf-Of and/or a client certificate (PKCS#12 or secure PEM file). Their use is optional; elicitation must be used to confirm if they apply for the specific request. Only if the user confirms, then supply the certificate via --cert /path/to/agent.p12:password (or --cert /path/to/agent.pem for PEM) and/or include -H 'On-Behalf-Of: <user-webid>'. Canonical example: curl --cert agent.p12:password -H 'On-Behalf-Of: http://example.com/alice#me' https://example.com/protected/resource. Do not default to, prefer, or assume authenticated curls without prior user elicitation and confirmation."""@en .
 
-# ── Step 6: Secret Redaction ─────────────────────────────────────────────────
+# ── Step 9: Secret Redaction ─────────────────────────────────────────────────
 
 :step-secretRedaction a schema:HowToStep ;
-    schema:position "6"^^xsd:integer ;
+    schema:position "9"^^xsd:integer ;
     schema:name "Redact passwords, API secrets, and credentials in all session memory, lessons, trace, and log documents"@en ;
     onto:hasTrigger onto:triggerBehaviorGapIdentified, onto:triggerPreferencesUpdate ;
-    schema:text """Passwords, API secret keys (e.g. STRIPE_API_KEY, ACP_AUTH_TOKEN, private cert passphrases, OAuth tokens, etc.), and other sensitive credentials MUST NEVER appear in cleartext in any session memory .ttl files (including schema:description, task literals, etc.), generated MD reports, trace/log docs, lessons learned, or related documents written to the agent-rdf-memory/ store or to LLM-specific output directories (rdf/, md/, webpages/). When a workflow involves such secrets, document using redacted placeholders only, e.g. 'ACP_AUTH_TOKEN=[REDACTED]' or 'user-provided fresh token (value redacted for security)'. This applies to all writes, including those triggered by :triggerPreferencesUpdate, :triggerSkillInvocation, :triggerNamedWorkflow, :triggerBehaviorGapIdentified, etc. Retroactively redact any existing cleartext secrets discovered in memory docs. The whoamiFormat step's reporting of the principal's On-Behalf-Of WebID is an identity declaration, not a secret value, and is exempt. This rule protects against accidental leakage in self-describing RDF memory and generated artifacts."""@en .
+    schema:text "Passwords, API secret keys (e.g. STRIPE_API_KEY, ACP_AUTH_TOKEN, private cert passphrases, OAuth tokens, etc.), and other sensitive credentials MUST NEVER appear in cleartext in any session memory .ttl files (including schema:description, task literals, etc.), generated MD reports, trace/log docs, lessons learned, or related documents written to the agent-rdf-memory/ store or to LLM-specific output directories (rdf/, md/, webpages/). Document with redacted placeholders only, e.g. 'ACP_AUTH_TOKEN=[REDACTED]' or 'user-provided fresh token (value redacted for security)'. This applies to all writes regardless of which trigger fired. Exemption: the whoamiFormat step's reporting of the principal's On-Behalf-Of WebID is an identity declaration, not a secret value."@en .
 
-# ── Step 7: Prompt Recording ─────────────────────────────────────────────────
+# ── Step 10: Retroactive Redaction ───────────────────────────────────────────
+
+:step-retroactiveRedaction a schema:HowToStep ;
+    schema:position "10"^^xsd:integer ;
+    schema:name "Retroactively redact any cleartext secrets discovered in existing memory documents"@en ;
+    schema:text "When a cleartext secret is discovered in any existing memory or output document, redact it at the point of discovery — do not merely avoid the pattern going forward. This protects against accidental leakage already baked into self-describing RDF memory and generated artifacts."@en .
+
+# ── Step 11: Prompt Recording ────────────────────────────────────────────────
 
 :step-promptRecording a schema:HowToStep ;
-    schema:position "7"^^xsd:integer ;
-    schema:name "Record verbatim user prompts in session memory files for intent-to-outcome traceability"@en ;
+    schema:position "11"^^xsd:integer ;
+    schema:name "Record verbatim user prompts as opal:ChatMessage entities in session memory files"@en ;
     onto:hasTrigger onto:triggerSkillInvocation, onto:triggerNamedWorkflow, onto:triggerBehaviorGapIdentified, onto:triggerSessionEnd ;
-    schema:text """Every session memory write MUST model the user prompt(s) using opal:ChatMessage with opal:messageRole 'user', opal:messageContent pointing to an opal:PromptText entity carrying the verbatim prompt string in rdf:value. Link the ChatMessage to the session via opal:hasMessage / opal:messageOf. Also record key assistant responses as opal:ChatMessage with opal:messageRole 'assistant', opal:usesTools (boolean), opal:timestamp, and opal:messageContent → opal:PromptText with a concise summary of the response or action taken. When a single session handles multiple distinct prompts, create one opal:ChatMessage per meaningful prompt boundary. This creates a causal chain from intent (prompt) to outcome (artifact/skill invocation/correction) that is queryable alongside preferences and session traces. The opal vocabulary is defined in the opal-analytics-ontology-2 at https://www.openlinksw.com/ontology/opal/ . Prefer opal terms over ad-hoc vocabulary — the ontology was purpose-built for modeling LLM chat interactions as RDF knowledge graphs."""@en .
+    schema:text "Every session memory write MUST model the user prompt(s) using opal:ChatMessage with opal:messageRole 'user', opal:messageContent pointing to an opal:PromptText entity carrying the verbatim prompt string in rdf:value. Link the ChatMessage to the session via opal:hasMessage / opal:messageOf. When a single session handles multiple distinct prompts, create one opal:ChatMessage per meaningful prompt boundary. This creates a causal chain from intent (prompt) to outcome (artifact/skill invocation/correction) that is queryable alongside preferences and session traces."@en .
 
-# ── Step 8: Session Log Reconciliation ───────────────────────────────────────
+# ── Step 12: Assistant Response Recording ────────────────────────────────────
+
+:step-assistantResponseRecording a schema:HowToStep ;
+    schema:position "12"^^xsd:integer ;
+    schema:name "Record key assistant responses alongside the prompts they answer"@en ;
+    schema:text "Also record key assistant responses as opal:ChatMessage with opal:messageRole 'assistant', opal:usesTools (boolean), opal:timestamp, and opal:messageContent → opal:PromptText with a concise summary of the response or action taken."@en .
+
+# ── Step 13: opal Vocabulary Preference ──────────────────────────────────────
+
+:step-opalVocabularyPreference a schema:HowToStep ;
+    schema:position "13"^^xsd:integer ;
+    schema:name "Prefer opal terms over ad-hoc vocabulary for chat-interaction modeling"@en ;
+    schema:text "The opal vocabulary is defined in the opal-analytics-ontology-2 at https://www.openlinksw.com/ontology/opal/ . Prefer opal terms over ad-hoc vocabulary — the ontology was purpose-built for modeling LLM chat interactions as RDF knowledge graphs."@en .
+
+# ── Step 14: Session Log Reconciliation ──────────────────────────────────────
 
 :step-sessionLogReconciliation a schema:HowToStep ;
-    schema:position "8"^^xsd:integer ;
+    schema:position "14"^^xsd:integer ;
     schema:name "Trace every structural violation to its source session log before applying the fix"@en ;
     onto:hasTrigger onto:triggerPreferencesUpdate, onto:triggerBehaviorGapIdentified ;
-    schema:text """When a structural violation is found in preferences.ttl or any howto/*.ttl file: (1) git log/blame to find the commit that introduced it, (2) grep the session log for that date/agent to surface the originating decision context, (3) cite both the commit and the session in the fix report. Never fix silently — the session log is the diagnostic record that distinguishes a judgment error from a mechanical omission."""@en .
+    schema:text "When a structural violation is found in preferences.ttl or any howto/*.ttl file: (1) git log/blame to find the commit that introduced it, (2) grep the session log for that date/agent to surface the originating decision context, (3) cite both the commit and the session in the fix report. Never fix silently — the session log is the diagnostic record that distinguishes a judgment error from a mechanical omission."@en .
 
-# ── Step 9: Semantic Session Bootstrap ───────────────────────────────────────
+# ── Step 15: Semantic Session Bootstrap ──────────────────────────────────────
 
 :step-semanticSessionBootstrap a schema:HowToStep ;
-    schema:position "9"^^xsd:integer ;
+    schema:position "15"^^xsd:integer ;
     schema:name "On session start, analyze the prompt for key concepts and load related session logs as bootstrap context"@en ;
     onto:hasTrigger onto:triggerSessionStart ;
-    schema:text """After reading core.ttl, preferences.ttl, and index.ttl per the memory protocol: (1) extract key concepts, entities, and task types from the user's prompt, (2) grep index.ttl and session file schema:description / schema:hasPart / schema:name fields for those terms, (3) load the 3–5 most semantically relevant session files, (4) inject relevant findings (contract fixes, pattern discoveries, behavioral corrections) into the current session's working context. This ensures every session benefits from accumulated experience rather than starting cold."""@en .
+    schema:text "After reading core.ttl, preferences.ttl, and index.ttl per the memory protocol: (1) extract key concepts, entities, and task types from the user's prompt, (2) grep index.ttl and session file schema:description / schema:hasPart / schema:name fields for those terms, (3) load the 3–5 most semantically relevant session files, (4) inject relevant findings (contract fixes, pattern discoveries, behavioral corrections) into the current session's working context. This ensures every session benefits from accumulated experience rather than starting cold."@en .

--- a/agent-rdf-memory/howto/skill-invocation.ttl
+++ b/agent-rdf-memory/howto/skill-invocation.ttl
@@ -5,13 +5,12 @@
 
 <> a schema:HowTo ;
     schema:name "Skill Invocation — Chain, KG Query Mode, Packaging, and Retrieval Order"@en ;
-    schema:description "Four rules governing skill selection and sequencing: the kg-generator → rdf-infographic-skill chain, KG query mode (kg-only vs kg-hybrid), ZIP repackaging discipline, and mandatory retrieval tool order."@en ;
+    schema:description "Rules governing skill selection and sequencing: the kg-generator → rdf-infographic-skill chain, KG-first question answering (KG-ONLY vs KG-HYBRID modes with the local RDF root and provenance format), ZIP repackaging discipline, and mandatory retrieval tool order."@en ;
     schema:dateCreated "2026-06-05T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-06-05T00:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-07-19T00:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
-    schema:about :step-skillChain, :step-kgQueryMode,
-        :step-zipRepackage, :step-retrievalToolOrder ;
-    schema:step :step-skillChain, :step-kgQueryMode,
+    schema:step :step-skillChain, :step-kgQueryMode, :step-kgLocalRdfRoot,
+        :step-kgOnlyMode, :step-kgHybridMode, :step-kgProvenanceFormat,
         :step-zipRepackage, :step-retrievalToolOrder ;
     rdfs:seeAlso <../preferences.ttl#step-skillChain>, <../preferences.ttl#step-zipRepackage>, <../preferences.ttl#step-kgQueryMode>, <../preferences.ttl#step-retrievalToolOrder>, <../preferences.ttl#step-sparqlEndpointSearchOrder> .
 
@@ -20,25 +19,53 @@
 :step-skillChain a schema:HowToStep ;
     schema:position "1"^^xsd:integer ;
     schema:name "Use kg-generator → rdf-infographic-skill chain for RDF/MD/HTML collections"@en ;
-    schema:text """When generating a Knowledge Graph collection (RDF + MD + HTML), invoke kg-generator first to produce RDF-Turtle, then hand off to rdf-infographic-skill for HTML and MD companions. Never hand-build HTML infographics when the skill exists. Let each skill's contract gates drive quality — do not bypass them."""@en .
+    schema:text "When generating a Knowledge Graph collection (RDF + MD + HTML), invoke kg-generator first to produce RDF-Turtle, then hand off to rdf-infographic-skill for HTML and MD companions. Never hand-build HTML infographics when the skill exists. Let each skill's contract gates drive quality — do not bypass them."@en .
 
-# ── Step 2: KG Query Mode ────────────────────────────────────────────────────
+# ── Step 2: KG-First Question Answering ──────────────────────────────────────
 
 :step-kgQueryMode a schema:HowToStep ;
     schema:position "2"^^xsd:integer ;
     schema:name "Answer questions from skills/KG first — ask before falling back to model knowledge"@en ;
-    schema:text """When answering user questions in general, invoke data-twingler first (or uriburner-opal-agent-skills as fallback), unless the user explicitly asks for a plain LLM answer, asks not to use KG/local RDF/SPARQL, or the request is clearly trivial/self-contained (e.g., simple rewrite, translation, arithmetic, or command output). This default includes Why/How/What/Define/Explain/Compare questions, questions about prior generated artifacts, Semantic Web, Linked Data, RDF, SPARQL, KG, LLM memory, wiki architecture, OpenLink, Virtuoso, OPAL, URIBurner, WebID, or any known article/graph/context. If the skill/KG route returns a sufficient answer, answer from it with provenance links. If the skill/KG route is unavailable, returns no match, weak match, or incomplete coverage, do NOT silently answer from general model knowledge; ask the user whether to fall back to model knowledge, broaden to KG-HYBRID/endpoint corroboration, or stop. NEVER use kg-generator or rdf-infographic-skill for interrogation workflows. DEFAULT MODE: use KG-ONLY MODE unless the user explicitly asks for hybrid mode, asks to include endpoint/server-side corroboration, approves fallback broadening, or rejects the KG-ONLY candidate and requests broader retrieval. LOCAL RDF ROOT: {LLM_ROOT}/ — this is the canonical root for all local RDF searches. Scan all model-specific subdirectories beneath it recursively: Claude Generated/RDF/, GPT5-Chat-Generated/rdf/, DeepSeek/rdf/, MiniMax Generated/rdf/, kimi/, Grok/rdf/, and any others present. This root takes precedence over any default paths configured in data-twingler's own settings. Two named modes: (A) KG-ONLY MODE — Step 0: recursively scan {LLM_ROOT}/ for RDF files (.ttl, .jsonld, .rdf, .nt), parse them, extract schema:Question/schema:DefinedTerm/schema:HowTo/skos:Concept candidates, embed against user prompt, compute cosine similarity, report top match above 0.75 threshold as checkpoint and ask 'Proceed with this answer?' If user confirms: deliver answer from local KG with no endpoint call. If user declines or no local match: ask whether to fall back to model knowledge, broaden to KG-HYBRID/endpoint corroboration, or stop. (B) KG-HYBRID MODE — all three layers active always: Step 0 (local vector search of {LLM_ROOT}/) + Step 1a (URIBurner endpoint keyword search via bif:contains, primary) + Step 1b (URIBurner server-side vector similarity via vvec:cosine_similarity_openai, fallback when Step 1a returns zero). Results from all layers that exceed their respective thresholds are merged and cited with their source layer identified. RESPONSE FORMAT FOR BOTH MODES: ALL entity references in the answer MUST be hyperlinked to their KG IRIs via the URIBurner resolver pattern https://linkeddata.uriburner.com/describe/?url={url-encoded-IRI}. This applies to question entities, answer entities, article entities, organizations, concepts, people, pricing models, and any named RDF resource referenced in the answer. Provenance links are not optional — they are the basic response format for all KG interrogation workflows."""@en .
+    schema:text "When answering user questions in general, invoke data-twingler first (or uriburner-opal-agent-skills as fallback), unless the user explicitly asks for a plain LLM answer, asks not to use KG/local RDF/SPARQL, or the request is clearly trivial/self-contained (e.g., simple rewrite, translation, arithmetic, or command output). This default includes Why/How/What/Define/Explain/Compare questions, questions about prior generated artifacts, Semantic Web, Linked Data, RDF, SPARQL, KG, LLM memory, wiki architecture, OpenLink, Virtuoso, OPAL, URIBurner, WebID, or any known article/graph/context. If the skill/KG route returns a sufficient answer, answer from it with provenance links. If the skill/KG route is unavailable, returns no match, weak match, or incomplete coverage, do NOT silently answer from general model knowledge; ask the user whether to fall back to model knowledge, broaden to KG-HYBRID/endpoint corroboration, or stop. NEVER use kg-generator or rdf-infographic-skill for interrogation workflows. DEFAULT MODE: KG-ONLY (Step 4) unless the user explicitly asks for hybrid mode, asks to include endpoint/server-side corroboration, approves fallback broadening, or rejects the KG-ONLY candidate and requests broader retrieval."@en .
 
-# ── Step 3: ZIP Repackage ────────────────────────────────────────────────────
+# ── Step 3: Local RDF Root ───────────────────────────────────────────────────
+
+:step-kgLocalRdfRoot a schema:HowToStep ;
+    schema:position "3"^^xsd:integer ;
+    schema:name "The canonical local RDF root is {LLM_ROOT}/ — scan all model subdirectories recursively"@en ;
+    schema:text "LOCAL RDF ROOT: {LLM_ROOT}/ — the canonical root for all local RDF searches. Scan all model-specific subdirectories beneath it recursively: Claude Generated/RDF/, GPT5-Chat-Generated/rdf/, DeepSeek/rdf/, MiniMax Generated/rdf/, kimi/, Grok/rdf/, and any others present. This root takes precedence over any default paths configured in data-twingler's own settings."@en .
+
+# ── Step 4: KG-ONLY Mode ─────────────────────────────────────────────────────
+
+:step-kgOnlyMode a schema:HowToStep ;
+    schema:position "4"^^xsd:integer ;
+    schema:name "KG-ONLY MODE: local vector search over {LLM_ROOT}/ with a user checkpoint, no endpoint call"@en ;
+    schema:text "KG-ONLY MODE — Step 0: recursively scan {LLM_ROOT}/ for RDF files (.ttl, .jsonld, .rdf, .nt), parse them, extract schema:Question/schema:DefinedTerm/schema:HowTo/skos:Concept candidates, embed against the user prompt, compute cosine similarity, report the top match above the 0.75 threshold as a checkpoint and ask 'Proceed with this answer?' If the user confirms: deliver the answer from the local KG with no endpoint call. If the user declines or there is no local match: ask whether to fall back to model knowledge, broaden to KG-HYBRID/endpoint corroboration, or stop."@en .
+
+# ── Step 5: KG-HYBRID Mode ───────────────────────────────────────────────────
+
+:step-kgHybridMode a schema:HowToStep ;
+    schema:position "5"^^xsd:integer ;
+    schema:name "KG-HYBRID MODE: local vector search + URIBurner keyword search + server-side vector fallback, merged with source layers"@en ;
+    schema:text "KG-HYBRID MODE — all three layers active always: Step 0 (local vector search of {LLM_ROOT}/) + Step 1a (URIBurner endpoint keyword search via bif:contains, primary) + Step 1b (URIBurner server-side vector similarity via vvec:cosine_similarity_openai, fallback when Step 1a returns zero). Results from all layers that exceed their respective thresholds are merged and cited with their source layer identified."@en .
+
+# ── Step 6: Provenance Response Format ───────────────────────────────────────
+
+:step-kgProvenanceFormat a schema:HowToStep ;
+    schema:position "6"^^xsd:integer ;
+    schema:name "Hyperlink ALL entity references via the URIBurner resolver — provenance links are the response format"@en ;
+    schema:text "RESPONSE FORMAT FOR BOTH MODES: ALL entity references in the answer MUST be hyperlinked to their KG IRIs via the URIBurner resolver pattern https://linkeddata.uriburner.com/describe/?url={url-encoded-IRI}. This applies to question entities, answer entities, article entities, organizations, concepts, people, pricing models, and any named RDF resource referenced in the answer. Provenance links are not optional — they are the basic response format for all KG interrogation workflows."@en .
+
+# ── Step 7: ZIP Repackage ────────────────────────────────────────────────────
 
 :step-zipRepackage a schema:HowToStep ;
-    schema:position "3"^^xsd:integer ;
+    schema:position "7"^^xsd:integer ;
     schema:name "Delete ZIP before recreating — zip -r on existing archive does not remove deleted files"@en ;
-    schema:text """After editing any skill, always: rm <skill-name>.zip && zip -r <skill-name>.zip <skill-name>/ -x '*.DS_Store'. Always exclude .DS_Store. The RSS feed generator bundle is named rss-feed-generator-skill.zip (not rss-feed-generator.zip)."""@en .
+    schema:text "After editing any skill, always: rm <skill-name>.zip && zip -r <skill-name>.zip <skill-name>/ -x '*.DS_Store'. Always exclude .DS_Store. The RSS feed generator bundle is named rss-feed-generator-skill.zip (not rss-feed-generator.zip)."@en .
 
-# ── Step 4: Retrieval Tool Order ─────────────────────────────────────────────
+# ── Step 8: Retrieval Tool Order ─────────────────────────────────────────────
 
 :step-retrievalToolOrder a schema:HowToStep ;
-    schema:position "4"^^xsd:integer ;
+    schema:position "8"^^xsd:integer ;
     schema:name "Content retrieval tool order: Chrome MCP → Playwright → PinchTab → Sponger last resort"@en ;
-    schema:text """When fetching content from any URL (article, profile, page), ALWAYS attempt retrieval in this fixed order — never skip or reorder without explicit user authorization: (1) Claude in Chrome MCP (mcp__Claude_in_Chrome__get_page_text, mcp__Claude_in_Chrome__navigate) — fastest, uses already-open browser session; (2) Playwright — via Bash 'npx playwright' or Python playwright script — for JS-heavy or login-protected pages if Chrome MCP is disconnected or unavailable; (3) PinchTab — via Bash 'pinchtab ...' or REST to http://localhost:9867 — browser automation fallback if both Chrome MCP and Playwright are unavailable; (4) Sponger (mcp__4ec1680e...SPONGE_URL) — LAST RESORT ONLY — invoke ONLY after all three above tools have been attempted and failed or are confirmed unavailable in the current session. If Bash is also unavailable (e.g. side-chat fork), document that tools 2 and 3 cannot be reached before considering the Sponger. This order exists to preserve user data privacy and control, avoid unnecessary third-party ingestion of URLs, and use the most direct retrieval path first. Never invoke the Sponger as a convenience shortcut when other tools are available."""@en .
+    schema:text "When fetching content from any URL (article, profile, page), ALWAYS attempt retrieval in this fixed order — never skip or reorder without explicit user authorization: (1) Claude in Chrome MCP (mcp__Claude_in_Chrome__get_page_text, mcp__Claude_in_Chrome__navigate) — fastest, uses already-open browser session; (2) Playwright — via Bash 'npx playwright' or Python playwright script — for JS-heavy or login-protected pages if Chrome MCP is disconnected or unavailable; (3) PinchTab — via Bash 'pinchtab ...' or REST to http://localhost:9867 — browser automation fallback if both Chrome MCP and Playwright are unavailable; (4) Sponger (mcp__4ec1680e...SPONGE_URL) — LAST RESORT ONLY — invoke ONLY after all three above tools have been attempted and failed or are confirmed unavailable in the current session. If Bash is also unavailable (e.g. side-chat fork), document that tools 2 and 3 cannot be reached before considering the Sponger. This order exists to preserve user data privacy and control, avoid unnecessary third-party ingestion of URLs, and use the most direct retrieval path first. Never invoke the Sponger as a convenience shortcut when other tools are available."@en .

--- a/agent-rdf-memory/howto/sparql-memory-loading.ttl
+++ b/agent-rdf-memory/howto/sparql-memory-loading.ttl
@@ -20,9 +20,12 @@
     schema:description "At session start, elicit a SPARQL endpoint from the user and load preferences, howto steps, and session context via SPARQL query rather than sequential file reads. Fallback to file reads if endpoint is unreachable."@en ;
     schema:step :stepNoMemoryMd,
                 :stepEndpointElicitation,
-                :stepSparqlQueries,
+                :stepBootstrapQuery,
+                :stepHarvestQuery,
+                :stepCoreFactsQuery,
                 :stepNamedGraphConvention,
-                :stepFallback .
+                :stepFallback ;
+    schema:workExample :workExample-urlPlaceholders .
 
 # ── Steps ─────────────────────────────────────────────────────────────────────
 
@@ -66,14 +69,10 @@ For option 3, the user supplies the endpoint URL and the base URI for the TTL fi
 
 Record the selected path in the session TTL as onto:usedSparqlEndpoint (SPARQL) or onto:usedFileReads "true"^^xsd:boolean (file reads). Wait for selection before loading memory."""@en .
 
-:stepSparqlQueries a schema:HowToStep ;
+:stepBootstrapQuery a schema:HowToStep ;
     schema:position 3 ;
-    schema:name "SPARQL queries with Sponger pragmas for progressive memory loading"@en ;
-    schema:text """Use two queries. The first bootstraps preferences and simultaneously sponges all companion howto files. The second harvests the loaded howto content.
-
-── Query 1: Bootstrap ────────────────────────────────────────────────────────
-
-DEFINE get:soft "soft"
+    schema:name "Query 1 — bootstrap preferences and sponge all companion howto files in one round-trip"@en ;
+    schema:text """DEFINE get:soft "soft"
 DEFINE input:grab-iri "{preferences-ttl-url}"
 DEFINE input:grab-var "seeAlso"
 
@@ -88,15 +87,12 @@ WHERE {
 }
 ORDER BY ?pos
 
-What this does:
-  - input:grab-iri loads preferences.ttl into Virtuoso's quad store as a named graph before the query runs
-  - get:soft "soft" uses the cached version on subsequent calls (avoids re-fetching on every session)
-  - input:grab-var "seeAlso" tells the Sponger to dereference every ?seeAlso binding (i.e., every howto/*.ttl referenced from a step) and load them as named graphs during query execution
-  - One round-trip loads preferences.ttl AND all companion howto files progressively
+What this does: input:grab-iri loads preferences.ttl into Virtuoso's quad store as a named graph before the query runs; get:soft "soft" uses the cached version on subsequent calls (avoids re-fetching on every session); input:grab-var "seeAlso" tells the Sponger to dereference every ?seeAlso binding (i.e., every howto/*.ttl referenced from a step) and load them as named graphs during query execution. One round-trip loads preferences.ttl AND all companion howto files progressively. URL placeholders: see :workExample-urlPlaceholders."""@en .
 
-── Query 2: Harvest howto content ────────────────────────────────────────────
-
-DEFINE get:soft "soft"
+:stepHarvestQuery a schema:HowToStep ;
+    schema:position 4 ;
+    schema:name "Query 2 — harvest the loaded howto content across all sponged named graphs"@en ;
+    schema:text """DEFINE get:soft "soft"
 
 SELECT ?howto ?stepPos ?stepName ?stepText
 FROM <{preferences-ttl-url}>
@@ -112,32 +108,18 @@ WHERE {
 }
 ORDER BY ?howtoGraph ?stepPos
 
-What this does:
-  - Queries across all named graphs loaded by Query 1
-  - Retrieves the full step-by-step content from each howto/*.ttl
-  - get:soft "soft" ensures cached graphs are reused without re-fetching
+What this does: queries across all named graphs loaded by Query 1, retrieving the full step-by-step content from each howto/*.ttl; get:soft "soft" ensures cached graphs are reused without re-fetching."""@en .
 
-── Query 3: core.ttl facts ───────────────────────────────────────────────────
-
-DEFINE get:soft "soft"
+:stepCoreFactsQuery a schema:HowToStep ;
+    schema:position 5 ;
+    schema:name "Query 3 — DESCRIBE core.ttl facts"@en ;
+    schema:text """DEFINE get:soft "soft"
 DEFINE input:grab-iri "{core-ttl-url}"
 
-DESCRIBE <{core-ttl-url}>
-
-── URL placeholder resolution ────────────────────────────────────────────────
-
-{preferences-ttl-url} = "file://{REPO_ROOT}/agent-rdf-memory/preferences.ttl"
-{core-ttl-url}        = "file://{REPO_ROOT}/agent-rdf-memory/core.ttl"
-
-These are the standard values for local Virtuoso at localhost:8890/sparql.
-The user substitutes a different URI only if the default file:// path does not match their setup
-(e.g., different filesystem root, DAV upload, or remote public URL).
-
-The Sponger fetches file:// URIs from the local filesystem and loads them as named graphs.
-The named graph IRI is the file:// URI itself — use FROM <file:///…/preferences.ttl> in all queries."""@en .
+DESCRIBE <{core-ttl-url}>"""@en .
 
 :stepNamedGraphConvention a schema:HowToStep ;
-    schema:position 4 ;
+    schema:position 6 ;
     schema:name "Named graph IRIs for agent-rdf-memory TTL files"@en ;
     schema:text """The named graph IRI is always the URI the Sponger was given to fetch.
 
@@ -156,7 +138,7 @@ Always use an explicit FROM <named-graph-iri> to scope queries. Never query the 
 Virtuoso is a quad store and the default graph union may return stale or unrelated content."""@en .
 
 :stepFallback a schema:HowToStep ;
-    schema:position 5 ;
+    schema:position 7 ;
     schema:name "Fall back to sequential file reads if endpoint is unreachable"@en ;
     schema:text """If the selected SPARQL endpoint returns an error or empty results:
 1. Report the failure: "SPARQL endpoint {url} unreachable — falling back to file reads."
@@ -166,6 +148,15 @@ Virtuoso is a quad store and the default graph union may return stale or unrelat
    - Read agent-rdf-memory/index.ttl
    - Follow index.ttl references to relevant session/project/entity files
 3. Never fail silently — the user must know which loading path was taken."""@en .
+
+# ── Worked Example: URL Placeholder Resolution ───────────────────────────────
+
+:workExample-urlPlaceholders a schema:CreativeWork ;
+    schema:name "URL placeholder resolution for the memory-loading queries"@en ;
+    schema:text """{preferences-ttl-url} = "file://{REPO_ROOT}/agent-rdf-memory/preferences.ttl"
+{core-ttl-url}        = "file://{REPO_ROOT}/agent-rdf-memory/core.ttl"
+
+These are the standard values for local Virtuoso at localhost:8890/sparql. The user substitutes a different URI only if the default file:// path does not match their setup (e.g., different filesystem root, DAV upload, or remote public URL). The Sponger fetches file:// URIs from the local filesystem and loads them as named graphs. The named graph IRI is the file:// URI itself — use FROM <file:///…/preferences.ttl> in all queries."""@en .
 
 # ── Registered Endpoints ──────────────────────────────────────────────────────
 

--- a/agent-rdf-memory/howto/verified-identity.ttl
+++ b/agent-rdf-memory/howto/verified-identity.ttl
@@ -9,27 +9,28 @@
     schema:name "Verified Identity Gate — Whoami Certificate Verification Protocol"@en ;
     schema:description "Protocol for cryptographically verifying both the user identity and the agent identity before responding to a whoami query. Uses local PKCS#12 / PEM certificates whose public key moduli are matched against the published cert:RSAPublicKey in each party's WebID profile document, plus remote verification of reciprocal delegation claims against live WebDAV-hosted profiles."@en ;
     schema:dateCreated "2026-06-19T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-07-14T00:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-07-19T00:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
-    schema:about :step-resolveCredentialsRoot,
-                 :step-locateUserCert, :step-verifyUserIdentity,
-                 :step-locateAgentCert, :step-verifyAgentIdentity,
-                 :step-verifyDelegationClaims,
-                 :step-verifyDelegationRemote,
-                 :step-assembleVerifiedWhoami ;
+    schema:about :verifiedIdentityGate ;
     schema:step :step-resolveCredentialsRoot,
-                :step-locateUserCert, :step-verifyUserIdentity,
-                :step-locateAgentCert, :step-verifyAgentIdentity,
-                :step-verifyDelegationClaims,
-                :step-verifyDelegationRemote,
-                :step-assembleVerifiedWhoami ;
+        :step-locateUserCert, :step-verifyUserIdentity,
+        :step-locateAgentCert, :step-verifyAgentIdentity,
+        :step-delegatorSideCheck, :step-agentSideCheck, :step-verifyDelegationClaims,
+        :step-remoteProfileFetch, :step-crossSerializationCheck,
+        :step-verifyDelegationRemote, :step-assembleVerifiedWhoami ;
+    schema:workExample :workExample-userKnownValues, :workExample-agentKnownValues,
+        :workExample-expectedDelegationTriples, :workExample-remoteUrls ;
     rdfs:seeAlso <../preferences.ttl#step-verifiedWhoami>, <../preferences.ttl#step-verifyRecipDelegation>, <../preferences.ttl#step-verifyDelegationRemote>, <agent-identity.ttl>,
         <filesystem-path-verification.ttl> .
 
-# ── Step 0: Resolve Credentials Root (BLOCKING GATE) ─────────────────────────
+:verifiedIdentityGate a schema:Thing ;
+    schema:name "Verified Identity Gate"@en ;
+    schema:description "Blocking credential-root resolution, per-party cert-modulus verification, reciprocal delegation corroboration (local then remote), and verified whoami assembly."@en .
+
+# ── Step 1: Resolve Credentials Root (BLOCKING GATE) ─────────────────────────
 
 :step-resolveCredentialsRoot a schema:HowToStep ;
-    schema:position "0"^^xsd:integer ;
+    schema:position "1"^^xsd:integer ;
     schema:name "BLOCKING GATE — resolve the YouID credentials root before any cert verification; never guess"@en ;
     schema:text """This is a hard blocking gate. No certificate verification and no whoami response may proceed until the YouID credentials root has been resolved and verified on disk.
 
@@ -38,13 +39,11 @@ PROCEDURE:
 2. Search common parent trees for directories matching 'Templates/YouID/link-in-bio-credentials-*' and 'Templates/YouID/link-in-bio-agent-credentials*' using 'ls' or 'find' (timeboxed).
 3. A valid credential directory MUST contain cert.pem (or cert.p12). Verify with 'ls <dir>/cert.pem' before accepting.
 4. If found → set the resolved credential root as the session's active path and proceed.
-5. If NOT found → ELICIT from the user:
-     'I cannot locate your YouID credential bundles. Where are they stored? Provide the path to the parent directory containing Templates/YouID/.'
-   Wait for the user's response before proceeding.
+5. If NOT found → ELICIT from the user: 'I cannot locate your YouID credential bundles. Where are they stored? Provide the path to the parent directory containing Templates/YouID/.' Wait for the user's response before proceeding.
 
 PROHIBITED FALLBACKS: guessing a path, using a path from a prior session file, constructing a path by convention alone, searching without timeboxing (which can hang on large filesystems).
 
-This gate exists because {CREDENTIALS_ROOT} was a dangling template placeholder with no resolution procedure — agents guessed wrong paths (e.g., ~/Documents/Management/Credentials/ instead of ~/Documents/Management/Marketing/WebID/). The gate must be satisfied before Step 1."""@en ;
+This gate exists because {CREDENTIALS_ROOT} was a dangling template placeholder with no resolution procedure — agents guessed wrong paths (e.g., ~/Documents/Management/Credentials/ instead of ~/Documents/Management/Marketing/WebID/)."""@en ;
     rdfs:seeAlso <filesystem-path-verification.ttl> .
 
 # ── Canonical credentials ─────────────────────────────────────────────────────
@@ -63,229 +62,151 @@ This gate exists because {CREDENTIALS_ROOT} was a dangling template placeholder 
     oplcert:SAN <https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/profile.ttl#identity> ;
     schema:url <https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/profile.ttl> .
 
-# ── Step 1: Locate user certificate ──────────────────────────────────────────
+# ── Step 2: Locate user certificate ──────────────────────────────────────────
 
 :step-locateUserCert a schema:HowToStep ;
-    schema:position "1"^^xsd:integer ;
+    schema:position "2"^^xsd:integer ;
     schema:name "Locate user credential file"@en ;
-    schema:text """User credentials directory (resolved by :step-resolveCredentialsRoot at session start):
+    schema:text """User credentials directory (resolved by :step-resolveCredentialsRoot):
   {resolved-credential-root}/Templates/YouID/link-in-bio-credentials-5/
-
-The credential root MUST have been resolved by the blocking gate (Step 0) before this step runs. If the user provided a different credential set path, use that instead.
-
-Look for (in order of preference):
-  1. cert.pem   — PEM-encoded certificate (no passphrase needed)
-  2. cert.p12   — PKCS#12 bundle (extract with empty passphrase)
-  3. cert.crt   — DER or PEM certificate
-
+The credential root MUST have been resolved by the blocking gate (Step 1) before this step runs. If the user provided a different credential set path, use that instead.
+Look for (in order of preference): 1. cert.pem — PEM-encoded certificate (no passphrase needed); 2. cert.p12 — PKCS#12 bundle (extract with empty passphrase); 3. cert.crt — DER or PEM certificate.
 If none found: skip verification, mark user identity as ⚠️ Unverified and continue."""@en .
 
-# ── Step 2: Verify user identity ─────────────────────────────────────────────
+# ── Step 3: Verify user identity ─────────────────────────────────────────────
 
 :step-verifyUserIdentity a schema:HowToStep ;
-    schema:position "2"^^xsd:integer ;
+    schema:position "3"^^xsd:integer ;
     schema:name "Verify user identity via cert modulus ↔ profile doc"@en ;
     schema:text """Verification procedure (run via Bash tool):
-
 1. Extract Subject Alternative Name URI from local cert:
      openssl x509 -noout -ext subjectAltName -in <dir>/cert.pem
-   Expected SAN URI:
-     https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/profile.ttl#identity
-
-2. Strip the fragment (#identity) → profile doc base URL:
-     https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/profile.ttl
-
+2. Strip the fragment (#identity) → profile doc base URL.
 3. Read published cert:modulus from the LOCAL profile.ttl in the credentials dir:
      grep 'cert:modulus' <dir>/profile.ttl | sed 's/.*"\\(.*\\)".*/\\1/' | tr '[:upper:]' '[:lower:]'
    (Optionally verify against the live URL with curl as a second check.)
-
 4. Extract local cert modulus:
      openssl x509 -noout -modulus -in <dir>/cert.pem | sed 's/Modulus=//' | tr '[:upper:]' '[:lower:]'
-
 5. Compare strings. Match → SAN URI + ✅. Mismatch or file absent → memory IRI + ⚠️ Unverified.
+Known-good values: see :workExample-userKnownValues."""@en .
 
-Known values (as of 2026-06-16):
-  SAN URI (from cert):   https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/index.html#netid
-  owl:sameAs (profile):  https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/profile.ttl#identity
-  Modulus prefix: c719382fd4beaea6...
-  Fingerprint (SHA-1): DE:9B:0F:1E:83:DB:2F:0E:A1:70:E5:35:05:29:CB:95:D4:E6:81:07"""@en .
-
-# ── Step 3: Locate agent certificate ─────────────────────────────────────────
+# ── Step 4: Locate agent certificate ─────────────────────────────────────────
 
 :step-locateAgentCert a schema:HowToStep ;
-    schema:position "3"^^xsd:integer ;
+    schema:position "4"^^xsd:integer ;
     schema:name "Locate agent credential file"@en ;
-    schema:text """Agent credentials directory (resolved by :step-resolveCredentialsRoot at session start):
+    schema:text """Agent credentials directory (resolved by :step-resolveCredentialsRoot):
   {resolved-credential-root}/Templates/YouID/link-in-bio-agent-credentials/
+The credential root MUST have been resolved by the blocking gate (Step 1) before this step runs.
+The agent certificate subject is: CN=Kingsley Idehen's Agent / emailAddress=kidehen@openlinksw.com / O=Personal Data Space.
+Same file-search order as Step 2: cert.pem → cert.p12 → cert.crt. If none found: mark agent identity as ⚠️ Unverified."""@en .
 
-The credential root MUST have been resolved by the blocking gate (Step 0) before this step runs.
-The agent certificate subject is:
-  CN=Kingsley Idehen's Agent / emailAddress=kidehen@openlinksw.com / O=Personal Data Space
-
-Same file-search order as Step 1: cert.pem → cert.p12 → cert.crt.
-If none found: mark agent identity as ⚠️ Unverified."""@en .
-
-# ── Step 4: Verify agent identity ────────────────────────────────────────────
+# ── Step 5: Verify agent identity ────────────────────────────────────────────
 
 :step-verifyAgentIdentity a schema:HowToStep ;
-    schema:position "4"^^xsd:integer ;
+    schema:position "5"^^xsd:integer ;
     schema:name "Verify agent identity via cert modulus ↔ profile doc"@en ;
-    schema:text """Identical procedure to Step 2, applied to the agent credentials dir.
+    schema:text "Identical procedure to Step 3, applied to the agent credentials dir. Expected SAN URI: https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/profile.ttl#identity ; profile doc base URL: https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/profile.ttl . Known-good values: see :workExample-agentKnownValues."@en .
 
-Expected SAN URI:
-  https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/profile.ttl#identity
+# ── Step 6: Delegator-side delegation check ──────────────────────────────────
 
-Profile doc base URL:
-  https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/profile.ttl
+:step-delegatorSideCheck a schema:HowToStep ;
+    schema:position "6"^^xsd:integer ;
+    schema:name "Check the delegator's profile for oplcert:hasIdentityDelegate"@en ;
+    schema:text """An On-Behalf-Of header is a self-declaration by the agent; corroboration starts with the delegator's grant. Check the delegator's local profile for:
+  oplcert:hasIdentityDelegate <agent-SAN-URI>
+Commands:
+  grep 'hasIdentityDelegate' {user-credentials-dir}/profile.ttl
+  grep 'hasIdentityDelegate' {user-credentials-dir}/index.html
+Match → delegation corroborated on delegator side ✅. No match → ⚠️ Delegation unconfirmed — delegator profile has no grant. Expected triple: see :workExample-expectedDelegationTriples."""@en .
 
-Known values (as of 2026-06-18):
-  SAN URI (from cert):   https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/index.html#netid
-  owl:sameAs (profile):  https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/profile.ttl#identity
-  Modulus prefix: da2b893263967cfc...
-  Fingerprint (SHA-1): B9:58:40:EF:17:45:B7:5E:FE:B9:1F:8B:CD:11:47:DE:98:6A:19:CD
-  Valid: 2026-06-18 → 2027-06-18"""@en .
+# ── Step 7: Agent-side delegation check ──────────────────────────────────────
 
-# ── Step 6: Verify reciprocal delegation claims ───────────────────────────────
+:step-agentSideCheck a schema:HowToStep ;
+    schema:position "7"^^xsd:integer ;
+    schema:name "Check the agent's profile for oplcert:onBehalfOf"@en ;
+    schema:text """Check the agent's local profile for:
+  oplcert:onBehalfOf <user-SAN-URI>
+Commands:
+  grep 'onBehalfOf' {agent-credentials-dir}/profile.ttl
+  grep 'onBehalfOf' {agent-credentials-dir}/index.html
+Match → delegation corroborated on agent side ✅. No match → ⚠️ Delegation unconfirmed — agent profile has no acknowledgement. Expected triple: see :workExample-expectedDelegationTriples."""@en .
+
+# ── Step 8: Corroboration verdict (local) ────────────────────────────────────
 
 :step-verifyDelegationClaims a schema:HowToStep ;
-    schema:position "6"^^xsd:integer ;
-    schema:name "Verify reciprocal delegation claims in both credential profiles"@en ;
-    schema:text """An On-Behalf-Of header is a self-declaration by the agent. It is only corroborated
-when the delegator's profile contains a matching oplcert:hasIdentityDelegate triple
-AND the agent's profile contains a matching oplcert:onBehalfOf triple.
+    schema:position "8"^^xsd:integer ;
+    schema:name "Full corroboration requires BOTH sides; fall back to live profiles when local files are absent"@en ;
+    schema:text "FULL CORROBORATION requires both the delegator-side match (Step 6) AND the agent-side match (Step 7). Either side missing → emit ⚠️ Delegation partially corroborated and state which side is missing. LOCAL-FIRST, REMOTE FALLBACK: if local credential files are absent for a party, fetch the live profile URL (from :userCredentials / :agentCredentials schema:url) and grep the raw Turtle for the triple. For EXPLICIT remote verification of live WebDAV profiles (not just fallback), proceed to Steps 9–11."@en .
 
-PROCEDURE (run via Bash tool after Steps 1–4):
+# ── Step 9: Fetch both remote profiles ───────────────────────────────────────
 
-1. DELEGATOR SIDE — check delegator's local profile.ttl for:
-     oplcert:hasIdentityDelegate <agent-SAN-URI>
-   Command:
-     grep 'hasIdentityDelegate' {user-credentials-dir}/profile.ttl
-     grep 'hasIdentityDelegate' {user-credentials-dir}/index.html
-   Match → delegation corroborated on delegator side ✅
-   No match → ⚠️ Delegation unconfirmed — delegator profile has no grant
+:step-remoteProfileFetch a schema:HowToStep ;
+    schema:position "9"^^xsd:integer ;
+    schema:name "Fetch each party's live remote profile.ttl (public read first, mTLS + On-Behalf-Of on 401/403)"@en ;
+    schema:text """Verify the published delegation state is in sync with what the agent holds locally.
+1. DELEGATOR: curl -sS -L '{userCredentials schema:url}' ; on HTTP 200 grep for hasIdentityDelegate. On 401/403 retry with the agent's PKCS#12 cert + On-Behalf-Of header:
+     curl -sS -L --cert-type P12 --cert '{agent-p12}:{MTLS_PKCS12_PW}' -H 'On-Behalf-Of: {delegator-WebID}' '{userCredentials schema:url}'
+2. AGENT: curl -sS -L '{agentCredentials schema:url}' ; on HTTP 200 grep for onBehalfOf. On 401/403 retry with the agent's PKCS#12 cert.
+Expected triples: see :workExample-expectedDelegationTriples. Remote URLs: see :workExample-remoteUrls."""@en .
 
-2. AGENT SIDE — check agent's local profile.ttl for:
-     oplcert:onBehalfOf <user-SAN-URI>
-   Command:
-     grep 'onBehalfOf' {agent-credentials-dir}/profile.ttl
-     grep 'onBehalfOf' {agent-credentials-dir}/index.html
-   Match → delegation corroborated on agent side ✅
-   No match → ⚠️ Delegation unconfirmed — agent profile has no acknowledgement
+# ── Step 10: Cross-serialization check ───────────────────────────────────────
 
-3. FULL CORROBORATION requires BOTH sides to match.
-   Either side missing → emit ⚠️ Delegation partially corroborated and state which side is missing.
+:step-crossSerializationCheck a schema:HowToStep ;
+    schema:position "10"^^xsd:integer ;
+    schema:name "Cross-check index.html so the delegation triple appears in every RDF serialization"@en ;
+    schema:text """Fetch each party's remote index.html and grep for delegation triples across all serializations (RDFa link, RDFa div rel, embedded JSON-LD, embedded Turtle):
+  curl -sS -L '{base-url}/index.html' | grep -n 'hasIdentityDelegate\\|onBehalfOf'
+The same triple should appear in every RDF representation on the page."""@en .
 
-4. LOCAL-FIRST, REMOTE FALLBACK:
-   If local credential files are absent for a party, fetch the live profile URL
-   (from :userCredentials schema:url or :agentCredentials schema:url in this file)
-   and grep the raw Turtle for the triple.
-
-5. For EXPLICIT remote verification of live WebDAV profiles (not just fallback),
-   proceed to Step 7.
-
-Known credential dirs (resolved by :step-resolveCredentialsRoot at session start):
-  Delegator (user):  {resolved-credential-root}/Templates/YouID/link-in-bio-credentials-5/
-  Delegate  (agent): {resolved-credential-root}/Templates/YouID/link-in-bio-agent-credentials/
-
-Expected corroborating triples:
-  Delegator profile.ttl line ~145:
-    oplcert:hasIdentityDelegate <https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/index.html#netid> .
-  Agent profile.ttl line ~117:
-    oplcert:onBehalfOf <https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/index.html#netid> ."""@en .
-
-# ── Step 7: Verify reciprocal delegation claims remotely ───────────────────────
+# ── Step 11: Remote verdict + optional verification service ──────────────────
 
 :step-verifyDelegationRemote a schema:HowToStep ;
-    schema:position "7"^^xsd:integer ;
-    schema:name "Verify reciprocal delegation claims against live remote profiles"@en ;
-    schema:text """Extends Step 6 by verifying delegation claims against the LIVE WebDAV-hosted profile
-documents, not just local copies. This confirms the published delegation state is in
-sync with what the agent holds locally.
+    schema:position "11"^^xsd:integer ;
+    schema:name "Emit the remote-delegation verdict; optionally exercise a WebID verification service end-to-end"@en ;
+    schema:text """OPTIONAL end-to-end test: present the agent certificate to a remote WebID verification service with the On-Behalf-Of header:
+  curl -sS -L --cert-type P12 --cert '{agent-p12}:{MTLS_PKCS12_PW}' -H 'On-Behalf-Of: {delegator-WebID}' 'https://ods-qa.openlinksw.com:5443/webid/?go=Verify'
+Note: the verification service validates the certificate-subject identity (agent) and accepts the On-Behalf-Of header, but does NOT independently verify the delegation chain by fetching the delegator's profile — that confirmation is a known feature gap; Steps 9–10 provide the corroboration.
+OUTPUT: ✅ Delegation corroborated remotely (both profiles live + cross-serialization) | ⚠️ Delegation remote mismatch (profile content differs from local — flag for user review) | ⚠️ Delegation unverifiable remotely (profiles unreachable even with auth)."""@en ;
+    rdfs:seeAlso <../preferences.ttl#step-verifyDelegationRemote>, <webid-verification-services.ttl>,
+        <agent-identity.ttl> .
 
-PROCEDURE (run via Bash tool after Step 6 local verification passes):
-
-1. FETCH DELEGATOR'S REMOTE profile.ttl (public read first):
-     curl -sS -L '{userCredentials schema:url}'
-   If HTTP 200 → grep for hasIdentityDelegate:
-     grep 'hasIdentityDelegate'
-   Expected:
-     oplcert:hasIdentityDelegate <https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/index.html#netid> .
-   If 401/403 → retry with agent's PKCS#12 cert + On-Behalf-Of header:
-     curl -sS -L --cert-type P12 --cert '{agent-p12}:{MTLS_PKCS12_PW}' \\
-       -H 'On-Behalf-Of: {delegator-WebID}' \\
-       '{userCredentials schema:url}'
-
-2. FETCH AGENT'S REMOTE profile.ttl (public read first):
-     curl -sS -L '{agentCredentials schema:url}'
-   If HTTP 200 → grep for onBehalfOf:
-     grep 'onBehalfOf'
-   Expected:
-     oplcert:onBehalfOf <https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/index.html#netid> .
-   If 401/403 → retry with agent's PKCS#12 cert:
-     curl -sS -L --cert-type P12 --cert '{agent-p12}:{MTLS_PKCS12_PW}' \\
-       '{agentCredentials schema:url}'
-
-3. CROSS-CHECK index.html for all RDF representations:
-   Fetch each party's remote index.html and grep for delegation triples across all
-   serializations (RDFa link, RDFa div rel, embedded JSON-LD, embedded Turtle):
-     curl -sS -L '{base-url}/index.html' | grep -n 'hasIdentityDelegate|onBehalfOf'
-   The same triple should appear in every RDF representation on the page.
-
-4. DELEGATION-HEADER VERIFICATION SERVICE (optional):
-   For an end-to-end test, present the agent certificate to a remote WebID verification
-    service (e.g. ods-qa.openlinksw.com:5443/webid/) with the On-Behalf-Of header:
-      curl -sS -L --cert-type P12 --cert '{agent-p12}:{MTLS_PKCS12_PW}' \\
-        -H 'On-Behalf-Of: {delegator-WebID}' \\
-        'https://ods-qa.openlinksw.com:5443/webid/?go=Verify'
-   Note: The verification service validates the certificate-subject identity (agent) and
-   accepts the On-Behalf-Of header, but does NOT independently verify the delegation
-   chain by fetching the delegator's profile. Confirmation of reciprocal delegation
-   from the remote service is a feature gap — for now, Steps 1–3 provide the
-   corroboration.
-
-KNOWN REMOTE URLs (from :userCredentials and :agentCredentials in this file):
-  Delegator remote profile.ttl: https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/profile.ttl
-  Delegator remote index.html:  https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/index.html
-  Agent remote profile.ttl:     https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/profile.ttl
-  Agent remote index.html:      https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/index.html
-
-OUTPUT:
-  ✅ Delegation corroborated remotely (both profiles live + cross-serialization)
-  ⚠️ Delegation remote mismatch (profile content differs from local — flag for user review)
-  ⚠️ Delegation unverifiable remotely (profiles unreachable even with auth)"""@en ;
-    rdfs:seeAlso <../preferences.ttl#step-verifyDelegationRemote>, <../howto/webid-verification-services.ttl>,
-        <../howto/agent-identity.ttl> .
-
-# ── Step 5: Assemble verified whoami response ─────────────────────────────────
+# ── Step 12: Assemble verified whoami response ────────────────────────────────
 
 :step-assembleVerifiedWhoami a schema:HowToStep ;
-    schema:position "5"^^xsd:integer ;
-    schema:name "Assemble the verified whoami response"@en ;
-    schema:text """After completing Steps 1–7, emit this response format.
-Substitute ✅ or ⚠️ Unverified per verification outcome.
-Fill runtime values (model, env, path, project) from current session context.
+    schema:position "12"^^xsd:integer ;
+    schema:name "Assemble the verified whoami response using the agent-identity templates"@en ;
+    schema:text "After completing Steps 1–11, emit the two-section response per the canonical template in agent-identity.ttl (:workExample-triggerAResponse), substituting ✅ or ⚠️ Unverified per verification outcome and filling runtime values (model, env, path, project) from the current session context. The cert-verified SAN URI is canonical for both the agent and the delegator (On-Behalf-Of). Delegation is fully corroborated only when BOTH profiles declare the relationship (Steps 6–8). If verification is skipped (cert files absent, openssl unavailable), emit all lines with ⚠️ Unverified and fall back to memory-known SAN URIs rather than omitting them."@en ;
+    rdfs:seeAlso <agent-identity.ttl#workExample-triggerAResponse>,
+        <agent-identity.ttl#step-emitUserSection>, <agent-identity.ttl#step-emitAgentSection> .
 
-**User (principal)**
-• Name: Kingsley Uyi Idehen
-• Email: kidehen@openlinksw.com
-• Role: Founder & CEO, OpenLink Software
-• WebID: {user SAN URI} {✅ | ⚠️ Unverified}
-• owl:sameAs: grep <link rel="me"> from user's WebID index.html and emit each as [Title](URL) — never prose platform-category descriptions
+# ── Worked Examples (reference data) ─────────────────────────────────────────
 
-**Agent (me)**
-• Model: {model name} ({llm-id used in session filenames})
-• Environment: {agent environment name}
-• Artifact output root: {canonical LLM output path from step-outputDirs} (rdf/, md/, webpages/)
-• Active project: {current task/project or 'none yet this session'}
-• Memory store: {absolute path to agent-rdf-memory/}
-• Behavioral contract: preferences.ttl ({count} standing instructions, incl. {notable recent additions})
-• Agent WebID: {agent SAN URI} {✅ | ⚠️ Unverified}
-• On-Behalf-Of: {user SAN URI} {✅ | ⚠️ Unverified}
-• Delegation: {✅ Corroborated (both profiles) | ⚠️ Partially corroborated ({which side} missing) | ⚠️ Unconfirmed}
+:workExample-userKnownValues a schema:CreativeWork ;
+    schema:name "User identity known-good values (as of 2026-06-16)"@en ;
+    schema:text """SAN URI (from cert):   https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/index.html#netid
+owl:sameAs (profile):  https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/profile.ttl#identity
+Modulus prefix: c719382fd4beaea6...
+Fingerprint (SHA-1): DE:9B:0F:1E:83:DB:2F:0E:A1:70:E5:35:05:29:CB:95:D4:E6:81:07"""@en .
 
-The cert-verified SAN URI is canonical for both the agent and the delegator (On-Behalf-Of).
-Delegation is fully corroborated only when BOTH profiles declare the relationship:
-  delegator profile.ttl: oplcert:hasIdentityDelegate <agent-webid>
-  agent profile.ttl:     oplcert:onBehalfOf <delegator-webid>
-If verification is skipped (cert files absent, openssl unavailable) emit all lines
-with ⚠️ Unverified and fall back to memory-known SAN URIs rather than omitting them."""@en .
+:workExample-agentKnownValues a schema:CreativeWork ;
+    schema:name "Agent identity known-good values (as of 2026-06-18)"@en ;
+    schema:text """SAN URI (from cert):   https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/index.html#netid
+owl:sameAs (profile):  https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/profile.ttl#identity
+Modulus prefix: da2b893263967cfc...
+Fingerprint (SHA-1): B9:58:40:EF:17:45:B7:5E:FE:B9:1F:8B:CD:11:47:DE:98:6A:19:CD
+Valid: 2026-06-18 → 2027-06-18"""@en .
+
+:workExample-expectedDelegationTriples a schema:CreativeWork ;
+    schema:name "Expected reciprocal delegation triples"@en ;
+    schema:text """Delegator profile.ttl (line ~145):
+  oplcert:hasIdentityDelegate <https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/index.html#netid> .
+Agent profile.ttl (line ~117):
+  oplcert:onBehalfOf <https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/index.html#netid> ."""@en .
+
+:workExample-remoteUrls a schema:CreativeWork ;
+    schema:name "Known remote URLs (from :userCredentials and :agentCredentials)"@en ;
+    schema:text """Delegator remote profile.ttl: https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/profile.ttl
+Delegator remote index.html:  https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-credentials-5/index.html
+Agent remote profile.ttl:     https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/profile.ttl
+Agent remote index.html:      https://kingsley.idehen.net/DAV/home/kidehen/Public/YouID/link-in-bio-agent-credentials/index.html"""@en .


### PR DESCRIPTION
## Summary

Follow-up to #72/#73. That pass fixed files with a single prose-blob step; this pass applies the same principle one level down — steps inside multi-step howtos whose `schema:text` bundled several independent requirements are now decomposed into individually SPARQL-addressable `schema:HowToStep` entities (~50 → ~110 steps across 10 files). Reference data (response templates, known-good values, mapping tables, category catalogs, URL lists) moved to `schema:workExample` entities that steps cite by fragment.

### Decomposed
| File | Steps |
|---|---|
| agent-identity | 3 → 10 (+3 workExamples) |
| verified-identity | 8 → 12 (+4 workExamples) |
| memory-protocol-gate | 6 → 12 (+3 workExamples) |
| session-governance | 9 → 15 |
| infographic-authoring | 5 → 8 (+1 workExample) |
| sparql-memory-loading | 5 → 7 (+1 workExample) |
| cross-document-local-term-reuse | 3 → 13 (+2 workExamples) |
| owl-property-characterization | 6 → 8 (+2 workExamples) |
| canonical-entity-iri-denotation | 3 → 8 (+2 workExamples) |
| skill-invocation | 4 → 8 |

### Structural bugs fixed in passing
- `agent-identity`: two steps both declared `schema:position 2`
- `verified-identity`: stale ordering — the assemble step sat at position 5 while its own text said "after Steps 1–7"
- `artifact-routing`: `:step-outputRootBlockingGate` (position 7) was defined but orphaned from the HowTo's `schema:step` list
- `verified-identity` whoami template de-duplicated — now cross-references `agent-identity.ttl#workExample-triggerAResponse`

### Rule extension
`howto-authoring-structure.ttl` (Step 137 companion) now covers within-file step granularity, reference-data slotting to workExample, cross-file workExample anchors, and no-orphan / no-duplicate-position step lists.

### Reviewed, intentionally unchanged
`entity-type-gate`, `harness-contract-compliance`, `delegation-insert-gate`, `remote-webdav-upload`, `kg-explorer-edge-property-typing` and other audit flags — single coherent procedures with paragraphs, which the rule permits.

## Verification
All 76 howto files parse under rdflib; every HowTo has sequential, duplicate-free integer positions; no step text exceeds 3,000 chars; existing step IRIs preserved wherever semantics carried over, keeping preferences.ttl anchors valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)