### PR TITLE
kg-generator: add Thesis/Framework, Social Post/Thread, and News+Commentary templates

### DIFF
--- a/kg-generator/SKILL.md
+++ b/kg-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kg-generator
-description: "Generate comprehensive Knowledge Graphs (RDF-Turtle by default, or JSON-LD and other RDF serializations on request) from content at file: or http(s): scheme URLs. Uses curated prompt templates: a Generic template for general web content (producing JSON-LD), and a Business and Market Analysis template for strategy/analysis content (producing RDF-Turtle with NAICS industry code identifiers, lightweight ontology, FAQ, glossary, and HowTo sections). Trigger when users ask to: generate a knowledge graph, generate RDF or RDF-Turtle, generate JSON-LD, convert a URL to structured semantic data, or extract schema.org data from a page or document."
+description: "Generate comprehensive Knowledge Graphs (RDF-Turtle by default, or JSON-LD and other RDF serializations on request) from content at file: or http(s): scheme URLs. Uses curated prompt templates: a Generic template for general web content (producing JSON-LD); a Business and Market Analysis template for strategy/analysis content (RDF-Turtle with NAICS codes, lightweight ontology, FAQ, glossary, HowTo); a Conference and Event Recap template for conference write-ups, panel summaries, and case-study-driven narrative articles (RDF-Turtle with case-study/panel/quotation ontology); a Thesis and Framework Article template for opinion pieces proposing a named framework, with optional agent-authored critical-perspective response; a Social Media Post and Comment Thread template for a post plus its full comment thread; and a News Article with Framework Commentary template for third-party news articles with an optional agent-authored framework-application lens. Trigger when users ask to: generate a knowledge graph, generate RDF or RDF-Turtle, generate JSON-LD, convert a URL to structured semantic data, or extract schema.org data from a page or document."
 ---
 
 # Knowledge Graph Generator Skill
@@ -76,10 +76,14 @@ When generating RDF from a documentation collection, manual, docs portal, sitema
 |---|---|---|
 | General articles, blog posts, documentation | Generic | JSON-LD |
 | Business strategy, market analysis, industry threads | Business & Market Analysis | RDF-Turtle |
+| Conference/event recaps, panel summaries, case-study-driven narrative articles | Conference & Event Recap | RDF-Turtle |
+| Opinion/thesis pieces proposing a named framework (pillars/practices), especially with an added critical-perspective response | Thesis & Framework Article | RDF-Turtle |
+| A single social media post plus its comment thread | Social Media Post & Comment Thread | RDF-Turtle |
+| Third-party news/magazine articles, optionally with an agent-authored framework-application commentary section | News Article with Framework Commentary | RDF-Turtle |
 | User requests JSON-LD explicitly | Generic | JSON-LD |
-| User requests RDF-Turtle explicitly | Business & Market Analysis | RDF-Turtle |
+| User requests RDF-Turtle explicitly | Whichever RDF-Turtle template's content shape fits (Business & Market Analysis, Conference & Event Recap, Thesis & Framework Article, Social Media Post & Comment Thread, or News Article with Framework Commentary) | RDF-Turtle |
 
-When uncertain, default to the **Generic** template and ask the user if they want the Business & Market Analysis variant.
+When uncertain, default to the **Generic** template and ask the user which RDF-Turtle variant fits better.
 
 ### RDF Format Elicitation
 
@@ -294,7 +298,7 @@ GATE: 0 FAIL required before delivery. Every numbered rule in this prompt has a 
 
 Use for business strategy posts, X/social threads, market analyses, and industry deep-dives.
 
-⛔ **PRE-BUILD CHECK**: Before producing RDF-Turtle, re-read the "Post-Generation Checklist" below and the "Compliance Self-Audit" in the prompt. Confirm: `@prefix :` = `{post-url}#`, `schema:` = `http://schema.org/` (HTTP), ontology with `schema:name` + `schema:description` + `schema:identifier`, all custom classes/properties have `rdfs:isDefinedBy :`, 12 FAQ + 10 glossary + 7 HowTo present, organization IRI priority (DBpedia 1st → Wikidata 2nd → LinkedIn `#this` 3rd → X `#this` 4th → Homepage `#this` 5th — primary subject must be canonical, not document-local; `owl:sameAs` for all remaining platform identities), concept/DefinedTerm IRI priority (standards-body/platform → DBpedia → Wikidata → document-local; document-local is default, `owl:sameAs` for external authorities), NAICS codes with `?input=&year=2022&details=` pattern, no blank nodes for `schema:Answer`, `prov:wasGeneratedBy` on `:analysis`, no `file:` IRIs, all string literals carry `@en` language tags. Build to pass every item — do not retro-fit.
+⛔ **PRE-BUILD CHECK**: Before producing RDF-Turtle, re-read the "Post-Generation Checklist" below and the "Compliance Self-Audit" in the prompt. Confirm: `@prefix :` = `{post-url}#`, `schema:` = `http://schema.org/` (HTTP), ontology with `schema:name` + `schema:description` + `schema:identifier`, all custom classes/properties have `rdfs:isDefinedBy :`, at least 12 FAQ + at least 10 glossary + all procedural steps present as HowTo — covering every distinct question-worthy claim and defined term in the source, never capped at a fixed number once reached, organization IRI priority (DBpedia 1st → Wikidata 2nd → LinkedIn `#this` 3rd → X `#this` 4th → Homepage `#this` 5th — primary subject must be canonical, not document-local; `owl:sameAs` for all remaining platform identities), concept/DefinedTerm IRI priority (standards-body/platform → DBpedia → Wikidata → document-local; document-local is default, `owl:sameAs` for external authorities), NAICS codes with `?input=&year=2022&details=` pattern, no blank nodes for `schema:Answer`, `prov:wasGeneratedBy` on `:analysis`, no `file:` IRIs, all string literals carry `@en` language tags. Build to pass every item — do not retro-fit.
 
 ### Placeholders
 
@@ -302,6 +306,7 @@ Use for business strategy posts, X/social threads, market analyses, and industry
 |---|---|
 | `{url}` | URL of the original post or content being analysed |
 | `{post-url}` | Used as the Turtle `@prefix :` base (append `#`) |
+| `{selected_text}` | Full extracted text content of the source (post + thread/replies, if any) |
 | `{current date}` | ISO 8601 date e.g. `2026-03-13` |
 
 > `{post-url}` and `{url}` are often the same value.
@@ -321,11 +326,38 @@ Glossary terms: [Vishing](https://x.com/Scobleizer/status/2053367142045847649#vi
 - HTML: Include `RDF: <a href="{source-url}">Resolver</a>` link in footer, plus link to Turtle file
 - MD: Include `**RDF Resolver:** [URL](URL)` in header, plus `#term` fragment links in glossary
 
+**Example — worked application of this template:** see "Example — Business Analysis Worked Example" below for a full illustration of how these generic instructions apply to a real source (a Julien Bek X-thread on AI "autopilots" disrupting services markets). That block is reference material only — do not copy its entity names, class names, or figures into an unrelated source's output.
+
+### Example — Business Analysis Worked Example
+
+This is a **worked illustration**, not part of the prompt the model executes. It shows how the generic instructions above resolve when applied to one specific source — a Julien Bek X-thread discussing AI-driven "autopilots" disrupting services markets by selling outcomes rather than tools, starting with outsourced intelligence-heavy tasks such as NDA drafting, insurance brokerage (~$140–200B labor TAM), and accounting (~$50–80B labor TAM), with structural shortages like the loss of ~340k U.S. accountants, data compounding enabling eventual judgment handling, debates around copilots vs. full autopilots, the innovator's dilemma, and founder collaboration opportunities.
+
+Applying step 3 (lightweight ontology) to this source produced:
+- Base class `:Industry` (the source's central recurring category — services verticals)
+- Subclasses `:InsuranceBrokerageIndustry` and `:AccountingIndustry` (the two verticals the source compares)
+- Custom properties `:hasLaborTAM` (range `xsd:string`) and `:hasAutomationReadiness` (range `xsd:string`) — the two recurring structured attributes the source assigns to each vertical
+- Instances `:insuranceBrokerageVertical` and `:accountingVertical` holding the concrete TAM, readiness, NAICS, and offer data
+
+Applying step 5 (core entities) to this source produced:
+- The main analysis (`:analysis`), author (`:grok`), original post reference (`:originalXPost`), and Julien Bek as the person entity
+- `:aiAutopilotDisruption` (Product), `:marketDisruptionAction`, `:servicesMarketDisruption` — the central phenomenon/thesis entities
+- `:ndaExample` as a concrete illustrative task
+- Organizations `:withCoverage` and `:rillet` and their respective autopilot products
+- `:shortageEvent` for the U.S. accountant shortage statistic
+- `:unitedStates` with its ISO code
+- `:threadReplies`, `:cursorExample`, `:scalingChallenges` for discussion/example entities raised in the thread
+- `:innovatorsDilemma` as a `CreativeWork` with `schema:isbn "9780060521998"`
+
+Applying step 7 (preserve original details) to this source meant retaining, verbatim: the `$140-200B` and `$50-80B` TAM ranges, "High" automation readiness for both verticals, the 340,000 accountant shortage figure, the data-compounding explanation, the "Outcome-as-a-Service" model name, the innovator's-dilemma framing, the copilot-to-autopilot transition debate, and the founder-collaboration call to action.
+
 ### Prompt
 
 ```
 You are an expert in semantic web modeling, RDF/Turtle serialization, and schema.org + lightweight ontology design.
-Given the post at {url} and its thread (which discusses AI-driven "autopilots" disrupting services markets by selling outcomes rather than tools, starting with outsourced intelligence-heavy tasks such as NDA drafting, insurance brokerage (~$140–200B labor TAM), and accounting (~$50–80B labor TAM), with structural shortages like the loss of ~340k U.S. accountants, data compounding enabling eventual judgment handling, debates around copilots vs. full autopilots, the innovator's dilemma, and founder collaboration opportunities),
+Given the post/content at {url} (and its thread or surrounding discussion, if any):
+"""
+{selected_text}
+"""
 produce a **comprehensive RDF/Turtle document** that represents the full business & strategy analysis.
 Follow ALL of these final design requirements exactly:
 1. Base URI: Use relative hash URIs grounded in {post-url} as the namespace prefix :
@@ -334,41 +366,29 @@ Follow ALL of these final design requirements exactly:
    - org: for organizations
    - dbo: for selected DBpedia cross-references (via rdfs:seeAlso)
    - rdfs: for class/property definitions
-3. Create a small custom lightweight ontology in the same namespace:
-   - Define :Industry as rdfs:Class (base class for verticals)
-   - Define two subclass rdfs:Class resources: :InsuranceBrokerageIndustry and :AccountingIndustry
-   - Define two custom properties on :Industry:
-     - :hasLaborTAM      (range xsd:string)
-     - :hasAutomationReadiness (range xsd:string)
-   - Create explicit instances of these classes (e.g. :insuranceBrokerageVertical a :InsuranceBrokerageIndustry ; ...) to hold concrete data (TAM values, readiness, NAICS, offers, DBpedia links). Do NOT put instance data directly on the class definitions.
+3. Create a small custom lightweight ontology in the same namespace, derived from the actual structure of the source:
+   - Identify the source's central recurring category (e.g., an industry, a technology domain, a product line, a comparison dimension) and define it as a base `rdfs:Class` in the local namespace.
+   - Define one subclass `rdfs:Class` resource for each distinct instance of that category the source discusses (e.g., if the source compares several industry verticals, define one subclass per vertical; if it compares several technologies, define one subclass per technology).
+   - Define custom properties on the base class for the recurring structured attributes the source assigns to each category instance (e.g., a size/market metric, a readiness/maturity rating, a status) — choose property names and `xsd:` ranges that fit what the source actually measures.
+   - Create explicit instances of these subclasses to hold the concrete data the source provides (figures, ratings, identifiers, cross-references). Do NOT put instance data directly on the class definitions.
+   - If the source has no natural category/vertical structure, a minimal ontology (base class + one or two properties, no subclasses) is acceptable — do not force an artificial hierarchy.
 4. Use low-redundancy schema.org identifier modeling (Option 3 style):
-   - Use dedicated properties when they exist: schema:naics (on industry instances), schema:isbn (on the book), schema:identifier with plain literal for unambiguous codes (e.g. "US" for ISO 3166-1 alpha-2)
-   - For NAICS codes, always pair schema:naics (plain code string) with schema:identifier using the Census Bureau canonical lookup URL: https://www.census.gov/naics/?input={code}&year=2022&details={code}
+   - Use dedicated properties when they exist: schema:naics (on industry instances), schema:isbn (on books), schema:identifier with a plain literal for unambiguous codes (e.g. an ISO 3166-1 alpha-2 country code)
+   - When the source discusses one or more industry verticals, pair schema:naics (plain code string) with schema:identifier using the Census Bureau canonical lookup URL: https://www.census.gov/naics/?input={code}&year=2022&details={code}
    - Avoid unnecessary schema:PropertyValue wrappers unless genuinely required for disambiguation or extra metadata
 5. Core entities that must be included:
    - The main analysis CreativeWork (:analysis)
-   - Author (:grok), original post reference (:originalXPost), Julien Bek
-   - :aiAutopilotDisruption (Product), :marketDisruptionAction, :servicesMarketDisruption
-   - Example task :ndaExample
-   - Concrete vertical instances :insuranceBrokerageVertical and :accountingVertical (with TAM, readiness, naics, offers WithCoverage/Rillet autopilots)
-   - Organizations :withCoverage and :rillet + their autopilots
-   - :shortageEvent (U.S. accountant shortage)
-   - :unitedStates with ISO code
-   - :threadReplies, :cursorExample, :scalingChallenges
-   - :innovatorsDilemma (CreativeWork with isbn "9780060521998")
-6. Mandatory structured sections (all must be present and complete):
-   - schema:FAQPage (:faqSection) with **exactly 12** schema:Question items (:q1–:q12)
-   - skos:ConceptScheme + schema:DefinedTermSet (:glossarySection) with **exactly 10** terms (:termAutopilot through :termVerticalMapping)
-   - schema:HowTo (:howtoSection) with **exactly 7** schema:HowToStep items (:step1–:step7)
+   - The author/speaker entity and the original post/document reference, using the person/organization IRI priority rules in item 13 below
+   - Identify the core entities, concepts, actions, and named things the source actually discusses (e.g., the central phenomenon or thesis being analyzed, any products/services named, any organizations named, any statistical/structural events cited, any countries or jurisdictions referenced, any books/works cited) and model each as an instance of the most specific applicable schema.org (or local ontology) class. Do not invent entities the source does not mention, and do not omit an entity the source treats as significant.
+6. Mandatory structured sections (all must be present and complete — counts are a floor covering every distinct question-worthy claim/term/step in the source, not a fixed target):
+   - schema:FAQPage (:faqSection) with **at least 12** schema:Question items (:q1, :q2, :q3, … numbered sequentially; extend the range as needed to cover every distinct question-worthy claim in the source)
+   - skos:ConceptScheme + schema:DefinedTermSet (:glossarySection) with **at least 10** terms (:term1, :term2, … or mnemonic fragments; extend as needed to cover every distinct term the source introduces or defines)
+   - schema:HowTo (:howtoSection) with schema:HowToStep items covering every procedural step in the source (:step1, :step2, … numbered sequentially)
 7. Include all original details:
-   - Labor TAM ranges exactly as stated ($140-200B insurance, $50-80B accounting)
-   - Automation readiness "High" for both
-   - 340,000 accountant shortage statistic
-   - Data compounding explanation
-   - Outcome-as-a-Service model
-   - Innovator's dilemma application
-   - Copilot → autopilot transition challenges
-   - Founder collaboration via tagging / datasets
+   - Preserve every quantitative detail exactly as stated in the source — statistics, monetary figures/ranges, dates, percentages, counts — do not paraphrase, round, or approximate them.
+   - Preserve every named claim, model, or framework the source references (e.g., a named business model, a named theory, a named transition or debate it describes) as a distinct entity or literal, not folded into generic prose.
+   - Preserve any concrete example, case, or anecdote the source uses to illustrate its argument.
+   - Preserve any call to action, collaboration opportunity, or forward-looking statement the source makes.
 8. Keep descriptions concise yet precise; avoid unnecessary verbosity in literals.
 9. Output **only** the complete, valid Turtle document inside a single code block. Do not include explanations, comments outside Turtle, or any other text before/after the code block.
 10. The main analysis CreativeWork (:analysis) MUST have schema:hasPart linking to :faqSection, :glossarySection, :howtoSection, and ALL other entity group sections (e.g., industry verticals, use cases, technologies).
@@ -389,9 +409,9 @@ Current date for metadata: {current date}.
 CRITICAL — Before outputting the Turtle, you MUST perform a compliance self-audit. Verify each item and report PASS or FAIL (with the violation fixed):
 1. schema: namespace is http://schema.org/ (not https://schema.org/)
 2. :analysis has schema:hasPart linking :faqSection, :glossarySection, :howtoSection
-3. :faqSection is a schema:FAQPage with schema:mainEntity listing all :q1–:q12
-4. :glossarySection is a schema:DefinedTermSet with schema:hasDefinedTerm listing all 10 terms
-5. :howtoSection is a schema:HowTo with schema:step listing all :step1–:step7
+3. :faqSection is a schema:FAQPage with schema:mainEntity listing at least 12 schema:Question items, covering every distinct question-worthy claim in the source (not capped at 12)
+4. :glossarySection is a schema:DefinedTermSet with schema:hasDefinedTerm listing at least 10 terms, covering every distinct term the source introduces or defines (not capped at 10)
+5. :howtoSection is a schema:HowTo with schema:step listing every procedural step in the source, numbered sequentially
 6. All DBpedia/Wikidata IRIs are fully expanded (not CURIEs)
 6a. All organization entities use the highest-priority canonical platform IRI as their primary subject (DBpedia 1st, Wikidata 2nd, LinkedIn `#this` 3rd, X `#this` 4th, Homepage `#this` 5th) — never a document-local IRI with `owl:sameAs` pointing to the canonical one. `owl:sameAs` links all remaining discovered platform identities.
 6b. Organization names match source document exactly — no fabricated legal names or suffixes
@@ -450,22 +470,21 @@ Always use **both** `schema:naics` and `schema:identifier` together on industry 
 - [ ] `@prefix :` set to `{post-url}#`
 - [ ] `schema:` namespace uses `http://schema.org/` (HTTP, not HTTPS)
 - [ ] `:analysis schema:hasPart :faqSection, :glossarySection, :howtoSection`
-- [ ] Lightweight ontology present: `:Industry`, two subclasses, two custom properties
+- [ ] Lightweight ontology present: base class derived from the source's central category, subclasses per distinct instance of that category (or none, if the source has no natural category structure), and custom properties for the source's recurring structured attributes
 - [ ] Instance data on instances only — not on class definitions
-- [ ] Both `schema:naics` and `schema:identifier` (Census URL) on each vertical instance
-- [ ] Exactly 12 FAQ questions (`:q1`–`:q12`) wrapped in `schema:FAQPage` with `schema:mainEntity`
+- [ ] Both `schema:naics` and `schema:identifier` (Census URL) on each industry vertical instance, when the source discusses industry verticals
+- [ ] At least 12 FAQ questions (numbered sequentially, extended if the source supports more distinct questions) wrapped in `schema:FAQPage` with `schema:mainEntity` — count covers every distinct question-worthy claim, not capped once 12 is reached
 - [ ] Each FAQ question has `schema:isPartOf :faqSection` linking back to the FAQ section
-- [ ] Exactly 10 glossary terms wrapped in `schema:DefinedTermSet` with `schema:hasDefinedTerm`
-- [ ] Exactly 7 HowTo steps (`:step1`–`:step7`) wrapped in `schema:HowTo` with `schema:step`
-- [ ] Each HowTo step has `schema:isPartOf :howtoSection` linking back to the HowTo section
+- [ ] At least 10 glossary terms (extended if more distinct terms exist) wrapped in `schema:DefinedTermSet` with `schema:hasDefinedTerm` — count covers every distinct term, not capped once 10 is reached
+- [ ] All procedural steps present as HowTo steps (numbered sequentially) wrapped in `schema:HowTo` with `schema:step`
 - [ ] Each HowTo step has `schema:isPartOf :howtoSection` linking back to the HowTo section
 - [ ] All DBpedia/Wikidata IRIs fully expanded (not CURIEs)
 - [ ] Organization IRIs follow priority: DBpedia → Wikidata → LinkedIn → X → homepage → hash fallback. The highest-priority IRI is the primary subject — not a document-local IRI with `owl:sameAs`. `owl:sameAs` for all remaining discovered platform identities.
 - [ ] Organization names match source exactly — no fabricated legal names
 - [ ] Concept/DefinedTerm IRIs follow priority: standards-body/platform → DBpedia → Wikidata → document-local hash. When a standards-body/platform IRI exists, it is the primary subject; otherwise document-local is the primary subject with `owl:sameAs` for confirmed DBpedia/Wikidata equivalents.
-- [ ] TAM values exact: `"$140-200B"` and `"$50-80B"`
-- [ ] `schema:isbn "9780060521998"` on `:innovatorsDilemma`
-- [ ] `schema:identifier "US"` on `:unitedStates`
+- [ ] All quantitative details (statistics, monetary figures/ranges, dates, percentages, counts) preserved exactly as stated in the source — not paraphrased, rounded, or approximated
+- [ ] `schema:isbn` present on any book/work entity the source cites with an ISBN
+- [ ] `schema:identifier` present with the appropriate plain-literal code (e.g. ISO 3166-1 alpha-2) on any country entity the source references
 - [ ] NAICS URLs use `?input=&year=2022&details=` pattern (not `?code=`)
 - [ ] All string literals carry `@en` language tags (e.g., `"text"@en`)
 - [ ] No `file:` scheme IRIs anywhere
@@ -475,6 +494,485 @@ Always use **both** `schema:naics` and `schema:identifier` together on industry 
 - [ ] Output is the Turtle code block only — no surrounding text
 - [ ] `owl:sameAs` never has the same IRI in both subject and object (including www/non-www variants of the same platform)
 - [ ] Entity canonical IRI priority ladders enforced: Organization (DBpedia 1st → Wikidata 2nd → vendor site `#this` 3rd → LinkedIn `#this` 4th → X `#this` 5th → document-local), SoftwareApplication (vendor `#this` 1st → DBpedia 2nd → Wikidata 3rd → document-local), Concept/DefinedTerm (standards-body/platform 1st → DBpedia 2nd → Wikidata 3rd → document-local)
+
+---
+
+## Template 3 — Conference & Event Recap (RDF-Turtle)
+
+Use for conference/event recaps, multi-speaker panel summaries, case-study-driven narrative articles, and "takeaways" or "lessons learned" write-ups organized around sessions, speakers, and organizations.
+
+⛔ **PRE-BUILD CHECK**: Before producing RDF-Turtle, re-read the "Post-Generation Checklist" below and the "Compliance Self-Audit" in the prompt. Confirm: `@prefix :` = `{post-url}#`, `schema:` = `http://schema.org/` (HTTP), ontology with `schema:name` + `schema:description` + `schema:identifier`, all custom classes/properties have `rdfs:isDefinedBy :`, at least 12 FAQ + at least 10 glossary — covering every distinct question-worthy claim and defined term in the source, never capped at a fixed number once reached, organization IRI priority (DBpedia 1st → Wikidata 2nd → LinkedIn `#this` 3rd → X `#this` 4th → Homepage `#this` 5th — primary subject must be canonical, not document-local; `owl:sameAs` for all remaining platform identities), person IRI priority (LinkedIn → X → Substack → Reddit → other platforms → hash fallback), concept/DefinedTerm IRI priority (standards-body/platform → DBpedia → Wikidata → document-local), every quote/case-study/panel/question entity typed with its specific local class (never left as a bare `schema:CreativeWork` when a more specific local class applies), no blank nodes for `schema:Answer`, `prov:wasGeneratedBy` on the main article, no `file:` IRIs, all string literals carry `@en` language tags. Build to pass every item — do not retro-fit.
+
+### Placeholders
+
+| Placeholder | Value |
+|---|---|
+| `{url}` | URL of the original article/post being analysed |
+| `{post-url}` | Used as the Turtle `@prefix :` base (append `#`) |
+| `{selected_text}` | Full extracted text content of the source article |
+| `{current date}` | ISO 8601 date e.g. `2026-03-13` |
+
+> `{post-url}` and `{url}` are often the same value.
+
+**Example — worked application of this template:** see "Example — Conference & Event Recap Worked Example" below for a full illustration of how these generic instructions apply to a real source (Juan Sequeda's "CDOIQ 2026: My Honest, No-BS Takeaways" Substack recap). That block is reference material only — do not copy its entity names, class names, or figures into an unrelated source's output.
+
+### Example — Conference & Event Recap Worked Example
+
+This is a **worked illustration**, not part of the prompt the model executes. It shows how the generic instructions below resolve when applied to one specific source — Juan Sequeda's CDOIQ 2026 conference recap, structured as five narrative parts covering foundational governance case studies (Nationwide, KeyBank, Leidos, Farm Credit Services of America), a tech-vs-non-tech contrast (ADP, Capital One), a CDO panel on the changing role (Humana, Ford, Lowe's), an agentic-AI reality-check panel (CVS, CSL, The Hartford, JPMorgan Chase), and a closing section on semantics as infrastructure ending in three strategic questions for data executives.
+
+Applying the ontology step to this source produced a base set of local classes and properties reusable for any conference/event recap:
+- `:CaseStudy` — an organizational case study or initiative presented at the event, with `:hasOutcome` (measured/reported result) and `:featuresOrganization` (the org profiled)
+- `:PanelSession` — a multi-speaker panel, with `:hasModerator` and `:hasPanelist` (both range `schema:Person`)
+- `:Quotation` — a direct or closely paraphrased statement attributed to a named speaker (modeled as `schema:CreativeWork` subtype with `schema:creator` and `schema:text`)
+- `:StrategicQuestion` — one of a closing set of questions the author poses to readers (included only because this source ends with exactly that; omit this class for sources that don't)
+
+Applying the "identify the source's narrative structure" step produced one `schema:Event` (`:cdoiqConference`) for the conference itself, one `schema:Article` (`:article`) as the main entity, and six `schema:CreativeWork` part-sections (`:partOneSection` … `:partFiveSection`, `:closingSection`) each linked via `schema:hasPart` to the case studies, panel sessions, and quotations discussed in that part — e.g. `:partOneSection schema:hasPart :nationwideCaseStudy, :keyBankCaseStudy, :leidosCaseStudy, :farmCreditCaseStudy`.
+
+Applying the "preserve original details" step meant retaining, verbatim: each case study's measured outcome (e.g. "Writing time cut roughly in half; estimated 20,000-24,000 hours saved per year"), each named speaker's role and organization, each direct quotation's exact wording, and the three closing strategic questions exactly as posed.
+
+### Prompt
+
+```
+You are an expert in semantic web modeling, RDF/Turtle serialization, and schema.org + lightweight ontology design.
+Given the article/post at {url}:
+"""
+{selected_text}
+"""
+produce a **comprehensive RDF/Turtle document** that represents the full conference/event recap as a knowledge graph.
+Follow ALL of these final design requirements exactly:
+1. Base URI: Use relative hash URIs grounded in {post-url} as the namespace prefix :
+2. Use schema.org as the primary vocabulary — use http://schema.org/ (HTTP, not HTTPS) as the schema: namespace URI — supplemented by:
+   - skos: for glossary/concept definitions
+   - rdfs: for class/property definitions
+   - prov: for generation provenance
+3. Create a small custom lightweight ontology in the same namespace, derived from the actual structure of the source. Typical recurring local classes for this content type (define only the ones the source actually uses; do not force unused classes into the ontology):
+   - `:CaseStudy` — an organizational case study or initiative discussed in the source, with a custom property `:hasOutcome` (range `xsd:string`) for its measured/reported result and `:featuresOrganization` (range `schema:Organization`) for the org it profiles
+   - `:PanelSession` — a multi-speaker panel or discussion, with custom properties `:hasModerator` and `:hasPanelist` (both range `schema:Person`)
+   - `:Quotation` — a direct or closely paraphrased statement attributed to a named speaker (use `schema:creator` for the speaker and `schema:text` for the exact wording)
+   - `:StrategicQuestion` (or a source-appropriate equivalent name) — an author-posed question directed at readers, only if the source actually closes with or poses such questions
+   - If the source's narrative introduces a different recurring structured pattern not covered above (e.g., a recurring "lesson," "prediction," or "recommendation" unit), define a local class for it following the same pattern: a class plus whatever custom properties capture its recurring structured attributes.
+   - Create explicit instances of these classes to hold the concrete data (organization, outcome, speaker, exact wording). Do NOT put instance data directly on the class definitions.
+   - Every quote/case-study/panel/question entity in the graph MUST be typed with its specific local class, not left as a generic `schema:CreativeWork`.
+4. Identify the source's own narrative structure (its sections/parts, however the source itself divides them) and represent each as a `schema:CreativeWork` linked from the main article via `schema:hasPart`, with each part in turn linking to the case studies, panel sessions, quotations, and other entities discussed within it.
+5. If the source discusses a named conference, summit, or event, model it as a `schema:Event` with `schema:name` and, where stated, `schema:startDate`/`schema:location`. Link the main article to it via `schema:about`.
+6. Core entities that must be included — identify the core entities the source actually discusses and model each as an instance of the most specific applicable class:
+   - The main analysis `schema:Article` (:article), its author, and the original post/document reference, using the person/organization IRI priority rules in item 11 below
+   - Every organization named as the subject of a case study or panel discussion
+   - Every named speaker, panelist, or moderator quoted or attributed
+   - Every distinct case study, panel session, and quotation the source presents
+   - Any closing questions, calls to action, or forward-looking statements the source poses to its readers
+   - Do not invent entities the source does not mention, and do not omit an entity the source treats as significant.
+7. Mandatory structured sections (all must be present and complete — counts are a floor covering every distinct question-worthy claim/term in the source, not a fixed target):
+   - schema:FAQPage (:faqSection) with **at least 12** schema:Question items (:q1, :q2, :q3, … numbered sequentially; extend as needed to cover every distinct question-worthy claim in the source)
+   - skos:ConceptScheme + schema:DefinedTermSet (:glossarySection) with **at least 10** terms (extend as needed to cover every distinct term the source introduces or defines)
+   - schema:HowTo is OPTIONAL for this content type — include it only if the source contains genuine procedural steps; a narrative recap with no procedural content does not need one.
+8. Include all original details:
+   - Preserve every quantitative outcome exactly as stated in the source — statistics, counts, percentages, time/cost savings — do not paraphrase, round, or approximate them.
+   - Preserve every direct or closely paraphrased quotation's exact wording, attributed to its speaker via `schema:creator`.
+   - Preserve every named speaker's role and organization exactly as the source states them.
+   - Preserve any closing questions or calls to action exactly as posed.
+9. Keep descriptions concise yet precise; avoid unnecessary verbosity in literals.
+10. Output **only** the complete, valid Turtle document inside a single code block. Do not include explanations, comments outside Turtle, or any other text before/after the code block.
+11. For every person entity: use the highest-priority platform profile URL found in the source as the primary person IRI with `#this` appended, in this order: (a) LinkedIn profile URL → `{linkedin-url}#this`; (b) X/Twitter profile URL → `{x-url}#this`; (c) Substack author profile URL → `{substack-url}#this`; (d) Reddit user profile URL → `{reddit-url}#this`; (e) other social media or blog platform author/profile URL → `{platform-url}#this`; (f) otherwise derive a hash-based IRI from {post-url}. Add `schema:url` pointing to the bare profile URL and `schema:identifier` with the canonical profile URL. ALL discovered platform identities MUST be linked via owl:sameAs.
+    11a. **NEVER fabricate person names.** Use names exactly as they appear in the source.
+    11b. **Actively search for LinkedIn profiles.** When no platform profile URL is in the source for a named speaker/panelist, search for their LinkedIn via web search using their exact name and organizational context before falling back to a hash-based IRI.
+    11c. **Actively resolve organization identities.** For every named organization, use the highest-priority identity in this order as the PRIMARY SUBJECT IRI: (a) DBpedia resource IRI; (b) Wikidata entity IRI; (c) LinkedIn company page URL `#this`; (d) X/Twitter org account URL `#this`; (e) official homepage URL `#this`; (f) otherwise derive a hash-based IRI from {post-url}. Add `owl:sameAs` for all remaining discovered platform identities.
+    11d. **NEVER fabricate organization names.** Use names exactly as they appear in the source document.
+    11e. **Reconcile LinkedIn www and non-www forms** with `owl:sameAs` in both directions.
+12. All DBpedia references MUST use fully expanded IRIs (e.g., http://dbpedia.org/resource/...) — never CURIEs or prefixed names. All Wikidata references MUST use fully expanded IRIs.
+13. The lightweight ontology MUST be named and described using schema:name and schema:description alongside rdfs:label/rdfs:comment, with schema:identifier carrying the canonical source URL. Every class and property MUST have rdfs:isDefinedBy : linking it to the ontology.
+14. You MUST NOT use blank nodes for schema:Answer instances. Every schema:Answer MUST be a named entity with its own hash-based IRI (e.g., :a1, :a2) connected via schema:acceptedAnswer :aN.
+15. For every directional relationship you assert (e.g., schema:isPartOf), you MUST also assert its inverse on the target entity (e.g., schema:hasPart).
+16. The main article MUST include prov:wasGeneratedBy linking to a schema:SoftwareApplication entity representing the kg-generator skill. Declare @prefix prov: <http://www.w3.org/ns/prov#> . The skill entity IRI MUST be <https://github.com/OpenLinkSoftware/ai-agent-skills/tree/main/kg-generator#this>, with schema:name "kg-generator skill", schema:url <https://github.com/OpenLinkSoftware/ai-agent-skills/tree/main/kg-generator>, and schema:description.
+Current date for metadata: {current date}.
+
+CRITICAL — Before outputting the Turtle, you MUST perform a compliance self-audit. Verify each item and report PASS or FAIL (with the violation fixed):
+1. schema: namespace is http://schema.org/ (not https://schema.org/)
+2. The main article has schema:hasPart linking every narrative section, :faqSection, and :glossarySection
+3. :faqSection is a schema:FAQPage with schema:mainEntity listing at least 12 schema:Question items, covering every distinct question-worthy claim in the source
+4. :glossarySection is a schema:DefinedTermSet with schema:hasDefinedTerm listing at least 10 terms, covering every distinct term the source introduces or defines
+5. All DBpedia/Wikidata IRIs are fully expanded (not CURIEs)
+5a. All organization entities use the highest-priority canonical platform IRI as their primary subject (DBpedia 1st, Wikidata 2nd, LinkedIn `#this` 3rd, X `#this` 4th, Homepage `#this` 5th)
+5b. Organization names match source document exactly — no fabricated legal names or suffixes
+6. No file: scheme IRIs exist anywhere
+7. Ontology has schema:name + schema:description + schema:identifier; all custom classes/properties have rdfs:isDefinedBy :
+8. No blank nodes for schema:Answer — every answer is a named entity (:aN) with schema:acceptedAnswer :aN
+9. Inverse relationships explicit: every schema:isPartOf has a corresponding schema:hasPart
+10. prov:wasGeneratedBy links the main article to a skill entity using the canonical IRI <https://github.com/OpenLinkSoftware/ai-agent-skills/tree/main/kg-generator#this>, with schema:name, schema:url (GitHub without #this), and schema:description
+11. Every case study, panel session, quotation, and closing-question entity is typed with its specific local class — none is left as a bare schema:CreativeWork
+12. owl:sameAs never has the same IRI in both subject and object positions — including www/non-www variants of the same platform
+13. Every entity type category uses the correct canonical IRI priority ladder as its primary subject: Organization (DBpedia → Wikidata → vendor site `#this` → LinkedIn `#this` → X `#this` → document-local), Concept/DefinedTerm (standards-body/platform → DBpedia → Wikidata → document-local)
+Report: "COMPLIANCE SELF-AUDIT: X/13 passed. [list any FAIL items, already fixed]. Output follows."
+
+GATE: 0 FAIL required before delivery. Every numbered rule in this prompt has a corresponding check in this audit. No rule without verification — unchecked rules are aspirational, not enforceable.```
+
+### Post-Generation Checklist
+
+- [ ] `@prefix :` set to `{post-url}#`
+- [ ] `schema:` namespace uses `http://schema.org/` (HTTP, not HTTPS)
+- [ ] Main article `schema:hasPart` links every narrative section, `:faqSection`, and `:glossarySection`
+- [ ] Lightweight ontology present, derived from the source's own recurring structure (e.g. `:CaseStudy`, `:PanelSession`, `:Quotation`, `:StrategicQuestion` where applicable) — no unused classes forced in, no needed class omitted
+- [ ] Instance data on instances only — not on class definitions
+- [ ] Every case study/panel/quotation/question entity typed with its specific local class, not a bare `schema:CreativeWork`
+- [ ] If the source names a conference/event, it is modeled as `schema:Event` and linked from the article via `schema:about`
+- [ ] At least 12 FAQ questions (numbered sequentially, extended if the source supports more distinct questions) wrapped in `schema:FAQPage` with `schema:mainEntity`
+- [ ] Each FAQ question has `schema:isPartOf :faqSection` linking back to the FAQ section
+- [ ] At least 10 glossary terms (extended if more distinct terms exist) wrapped in `schema:DefinedTermSet` with `schema:hasDefinedTerm`
+- [ ] All DBpedia/Wikidata IRIs fully expanded (not CURIEs)
+- [ ] Organization IRIs follow priority: DBpedia → Wikidata → LinkedIn → X → homepage → hash fallback
+- [ ] Organization names match source exactly — no fabricated legal names
+- [ ] Person IRIs derived from LinkedIn/X/Substack/Reddit/other-platform profile URLs where found; all platform identities linked via `owl:sameAs`
+- [ ] Every quantitative outcome preserved exactly as stated in the source — not paraphrased, rounded, or approximated
+- [ ] Every quotation's exact wording preserved, attributed via `schema:creator`
+- [ ] No `file:` scheme IRIs anywhere
+- [ ] All string literals carry `@en` language tags
+- [ ] `prov:wasGeneratedBy` links the main article to a skill entity using the canonical IRI `<https://github.com/OpenLinkSoftware/ai-agent-skills/tree/main/kg-generator#this>`, with `schema:name`, `schema:url` (GitHub without `#this`), `schema:description`
+- [ ] Ontology has `schema:name` + `schema:description` + `schema:identifier`; all classes/properties have `rdfs:isDefinedBy :`
+- [ ] Output is the Turtle code block only — no surrounding text
+- [ ] `owl:sameAs` never has the same IRI in both subject and object (including www/non-www variants of the same platform)
+
+---
+
+## Template 4 — Thesis & Framework Article (RDF-Turtle)
+
+Use for opinion/thesis articles that propose a named framework — a small, ordered set of named pillars, principles, or practices — especially when the response should include an agent-authored critical-perspective section that engages the thesis on its merits, potentially reusing ontology terms already minted in companion Knowledge Graphs on a related topic.
+
+⛔ **PRE-BUILD CHECK**: Before producing RDF-Turtle, re-read the "Post-Generation Checklist" below and the "Compliance Self-Audit" in the prompt. Confirm: `@prefix :` = `{post-url}#`, `schema:` = `http://schema.org/` (HTTP), ontology with `schema:name` + `schema:description` + `schema:identifier`, all custom classes/properties have `rdfs:isDefinedBy :`, at least 12 FAQ + at least 10 glossary + HowTo present if the thesis implies actionable steps, organization/person IRI priority ladders, any critical-perspective entity's `schema:author` set to the generating skill (never the human principal directly) with `schema:accountablePerson` on the principal's WebID, reused external ontology terms referenced via their own namespace prefix (never re-minted locally), no blank nodes for `schema:Answer`, `prov:wasGeneratedBy`, no `file:` IRIs, all string literals carry `@en` language tags. Build to pass every item — do not retro-fit.
+
+### Placeholders
+
+| Placeholder | Value |
+|---|---|
+| `{url}` | URL of the original article/post being analysed |
+| `{post-url}` | Used as the Turtle `@prefix :` base (append `#`) |
+| `{selected_text}` | Full extracted text content of the source article |
+| `{current date}` | ISO 8601 date e.g. `2026-03-13` |
+| `{principal-webid}` | The human principal's canonical WebID IRI (e.g. `https://www.linkedin.com/in/kidehen#this`), used for `schema:accountablePerson`/`prov:actedOnBehalfOf` on any agent-authored critical-perspective entity |
+
+> `{post-url}` and `{url}` are often the same value.
+
+**Example — worked application of this template:** see "Example — Thesis & Framework Article Worked Example" below for a full illustration of how these generic instructions apply to a real source (sn scratchpad's "The Reverse Information Paradox"). That block is reference material only — do not copy its entity names, class names, or figures into an unrelated source's output.
+
+### Example — Thesis & Framework Article Worked Example
+
+This is a **worked illustration**, not part of the prompt the model executes. It shows how the generic instructions below resolve when applied to one specific source — sn scratchpad's "The Reverse Information Paradox," which argues AI inverts Kenneth Arrow's Information Paradox (the buyer, not the seller, now risks giving away proprietary knowledge) and prescribes a named five-part framework — Control, Capability, Choice, Cost, Compound — as the trust boundary enterprises need.
+
+Applying the ontology step to this source produced:
+- Base class `:TrustBoundaryPillar` (the source's named framework unit) with custom property `:addressesRisk` (range `xsd:string`) capturing the specific risk each pillar mitigates
+- Five instances (`:controlPillar` … `:compoundPillar`), each `schema:position`-ordered, each linked via a reused custom property `:standardsBasedMechanism` to existing open-standard/Linked-Data concepts
+
+Applying the "critical perspective" step to this source produced a distinct `:criticalPerspectivesSection`, containing `:standardsAlreadySolveTrustBoundary` — typed with an **externally reused** class, `karp:CriticalPerspective`, minted in a prior companion Knowledge Graph on a related topic (theCUBE Research's Alex Karp analysis), rather than re-minting an equivalent local class. That entity's `schema:author` is set to the kg-generator skill entity (not the human principal directly), with `schema:accountablePerson` pointing to the principal's WebID — the correct delegation pattern for agent-synthesized commentary (see the `kg-curation-attribution` pattern: never set `schema:author` of agent-authored content directly to the principal). The critical perspective also reused `avc:enterpriseKnowledgeGraph`, `avc:abac`, and `avc:reasoningLearningSeparation` — concepts already minted in a different companion KG (`ai-value-capture-response`) — via their own namespace prefix, linked with `rdfs:seeAlso` back to both companion documents, rather than duplicating those definitions locally.
+
+Applying the "preserve original details" step meant retaining, verbatim: each pillar's exact description and risk statement, the direct quotations from Kenneth Arrow's NBER paper and Alex Karp's social post (each modeled as `schema:Quotation` with `schema:citation` to its source), and the five-layer "Operating Environment" (Identity, Identification, Authentication, Authorization, Storage) the critical perspective proposes as the concrete mechanism.
+
+### Prompt
+
+```
+You are an expert in semantic web modeling, RDF/Turtle serialization, and schema.org + lightweight ontology design.
+Given the article/post at {url}:
+"""
+{selected_text}
+"""
+produce a **comprehensive RDF/Turtle document** that represents the full thesis article as a knowledge graph.
+Follow ALL of these final design requirements exactly:
+1. Base URI: Use relative hash URIs grounded in {post-url} as the namespace prefix :
+2. Use schema.org as the primary vocabulary — use http://schema.org/ (HTTP, not HTTPS) as the schema: namespace URI — supplemented by:
+   - skos: for glossary/concept definitions
+   - rdfs: for class/property definitions
+   - prov: for generation provenance
+   - Any namespace prefix needed to reuse an existing external ontology term (see item 3c)
+3. Create a small custom lightweight ontology in the same namespace, derived from the actual structure of the source:
+   a. Identify the source's central named framework — the ordered set of pillars, principles, or practices it prescribes — and define a base `rdfs:Class` for it (e.g. `:TrustBoundaryPillar`). Define one custom property capturing the risk, benefit, or rationale the source assigns to each framework element, with an appropriate `xsd:` range.
+   b. Create explicit `schema:position`-ordered instances of that class, one per named framework element, holding the source's own description and rationale for each. Do NOT put instance data on the class definition.
+   c. **Before minting any new class or property for a concept the source discusses, check whether an equivalent term already exists in a companion Knowledge Graph on a related topic.** If the source's argument responds to, cites, or is thematically continuous with a topic already modeled elsewhere (a prior thesis, a prior rebuttal, a prior glossary), reuse that term via its own namespace prefix bound to the companion document's URL — do not re-mint a document-local alias for a term that already has a canonical home. Link back to the companion document via `rdfs:seeAlso`.
+4. If, and only if, the user has asked for (or the source clearly calls for) an agent-authored critical-perspective response to the thesis:
+   a. Model it as a distinct `schema:CreativeWork` section, separate from the main article summary, containing one or more perspective entities.
+   b. If a reusable `CriticalPerspective`-style class already exists in a companion KG from prior critical-response work, reuse it via its namespace prefix rather than minting a new local class for the same concept.
+   c. Every critical-perspective entity's `schema:author` MUST be the generating skill entity (e.g. the kg-generator `schema:SoftwareApplication`/`prov:SoftwareAgent`), NEVER the human principal's WebID directly. Add `schema:accountablePerson` pointing to `{principal-webid}` to record whose perspective/accountability the commentary represents. This is agent-synthesized content, not a transcription of something the principal personally wrote — the delegation chain must say so.
+   d. Reuse any external concepts the critical perspective invokes (open standards, prior companion-KG terms) via their own namespace prefix rather than re-describing them locally.
+5. Identify every direct or closely paraphrased quotation the source cites and model each as a `schema:Quotation` with `schema:text` (exact wording) and `schema:citation` pointing to a `schema:CreativeWork`/`schema:ScholarlyArticle`/`schema:SocialMediaPosting` entity describing its source (author, URL, description).
+6. Core entities that must be included — identify the core entities the source actually discusses and model each as an instance of the most specific applicable class: the main analysis (`:analysis`), its author and publisher, every named person and organization the source discusses, every concept the source coins or invokes, and any structural mechanism the source describes (e.g. a proposed layered architecture) as a set of `schema:position`-ordered part entities. Do not invent entities the source does not mention.
+7. Mandatory structured sections (all must be present and complete — counts are a floor covering every distinct question-worthy claim/term in the source, not a fixed target):
+   - schema:FAQPage (:faqSection) with **at least 12** schema:Question items (:q1, :q2, :q3, … numbered sequentially; extend as needed)
+   - skos:ConceptScheme + schema:DefinedTermSet (:glossarySection) with **at least 10** terms (extend as needed) — include both document-local coined terms and reused external terms (each `schema:isPartOf :glossarySection` regardless of which namespace its subject IRI lives in)
+   - schema:HowTo (:howtoSection) with schema:HowToStep items, one per framework element from item 3, if the source's framework implies a sequence of actions the reader should take; omit if the framework is descriptive/critical rather than actionable
+8. Include all original details:
+   - Preserve every framework element's exact description and stated rationale/risk — do not paraphrase, generalize, or compress them into a shorter summary.
+   - Preserve every quotation's exact wording, attributed to its source.
+   - Preserve any named prior work, economist, theory, or precedent the source explicitly invokes to ground its argument.
+9. Keep descriptions concise yet precise; avoid unnecessary verbosity in literals.
+10. Output **only** the complete, valid Turtle document inside a single code block. Do not include explanations, comments outside Turtle, or any other text before/after the code block.
+11. The main analysis (:analysis) MUST have schema:hasPart linking to :faqSection, :glossarySection, the framework-pillars section, the critical-perspectives section (if present), and ALL other entity group sections.
+12. All DBpedia references MUST use fully expanded IRIs. All Wikidata references MUST use fully expanded IRIs.
+13. For every person entity: use the highest-priority platform profile URL found in the source as the primary person IRI with `#this` appended, in this order: (a) LinkedIn → (b) X/Twitter → (c) Substack → (d) Reddit → (e) other platform → (f) hash-based fallback from {post-url}. ALL discovered platform identities MUST be linked via owl:sameAs. For every organization: DBpedia → Wikidata → LinkedIn `#this` → X `#this` → homepage `#this` → hash fallback, as the primary subject IRI. NEVER fabricate names — use them exactly as they appear in the source.
+14. The lightweight ontology MUST be named and described using schema:name and schema:description alongside rdfs:label/rdfs:comment, with schema:identifier carrying the canonical source URL. Every locally-minted class and property MUST have rdfs:isDefinedBy : linking it to the ontology. Reused external terms (item 3c, 4b, 4d) do NOT get a local rdfs:isDefinedBy — they keep their own provenance.
+15. You MUST NOT use blank nodes for schema:Answer instances. Every schema:Answer MUST be a named entity connected via schema:acceptedAnswer :aN.
+16. For every directional relationship you assert (e.g., schema:isPartOf), you MUST also assert its inverse (e.g., schema:hasPart).
+17. The main analysis (:analysis) MUST include prov:wasGeneratedBy linking to a schema:SoftwareApplication entity representing the kg-generator skill, with schema:name, schema:url, and schema:description. If a critical-perspective section is present, it separately carries its own prov:wasGeneratedBy to the same skill entity per item 4c.
+Current date for metadata: {current date}.
+
+CRITICAL — Before outputting the Turtle, you MUST perform a compliance self-audit. Verify each item and report PASS or FAIL (with the violation fixed):
+1. schema: namespace is http://schema.org/ (not https://schema.org/)
+2. :analysis has schema:hasPart linking :faqSection, :glossarySection, the framework-pillars section, and the critical-perspectives section (if present)
+3. :faqSection is a schema:FAQPage with schema:mainEntity listing at least 12 schema:Question items
+4. :glossarySection is a schema:DefinedTermSet with schema:hasDefinedTerm listing at least 10 terms, including both locally-coined and reused external terms
+5. All DBpedia/Wikidata IRIs are fully expanded (not CURIEs)
+5a. Organization/person entities use the highest-priority canonical platform IRI as their primary subject; names match the source exactly
+6. No file: scheme IRIs exist anywhere
+7. Ontology has schema:name + schema:description + schema:identifier; all LOCALLY-MINTED classes/properties have rdfs:isDefinedBy : — reused external terms do not
+8. No blank nodes for schema:Answer
+9. Inverse relationships explicit: every schema:isPartOf has a corresponding schema:hasPart
+10. prov:wasGeneratedBy links :analysis (and any critical-perspective section) to the kg-generator skill entity
+11. Every critical-perspective entity's schema:author is the generating skill entity, NEVER the human principal's WebID directly; schema:accountablePerson is set to {principal-webid}
+12. Before minting any new class/property, an existing companion-KG term was checked for and reused via its own prefix where one exists — no duplicate re-minting of an already-canonical term
+13. Every quotation is a schema:Quotation with exact schema:text and a schema:citation to its source entity
+14. owl:sameAs never has the same IRI in both subject and object positions
+Report: "COMPLIANCE SELF-AUDIT: X/14 passed. [list any FAIL items, already fixed]. Output follows."
+
+GATE: 0 FAIL required before delivery. Every numbered rule in this prompt has a corresponding check in this audit. No rule without verification — unchecked rules are aspirational, not enforceable.```
+
+### Post-Generation Checklist
+
+- [ ] `@prefix :` set to `{post-url}#`
+- [ ] `schema:` namespace uses `http://schema.org/` (HTTP, not HTTPS)
+- [ ] `:analysis schema:hasPart` links `:faqSection`, `:glossarySection`, the framework-pillars section, and the critical-perspectives section (if present)
+- [ ] Lightweight ontology present: base class for the source's named framework, custom property for its per-element rationale/risk, `schema:position`-ordered instances
+- [ ] Instance data on instances only — not on class definitions
+- [ ] Existing companion-KG terms checked for and reused via their own namespace prefix before minting a new local term for the same concept
+- [ ] If a critical-perspective section is present: `schema:author` is the generating skill entity (never the principal's WebID directly); `schema:accountablePerson` is `{principal-webid}`
+- [ ] At least 12 FAQ questions wrapped in `schema:FAQPage` with `schema:mainEntity`
+- [ ] Each FAQ question has `schema:isPartOf :faqSection`
+- [ ] At least 10 glossary terms (local + reused external) wrapped in `schema:DefinedTermSet` with `schema:hasDefinedTerm`
+- [ ] HowTo present only if the framework implies actionable steps; each step maps to a framework element
+- [ ] All DBpedia/Wikidata IRIs fully expanded (not CURIEs)
+- [ ] Organization/person IRIs follow the standard priority ladders; names match source exactly
+- [ ] Every quotation modeled as `schema:Quotation` with exact wording and a `schema:citation` to its source
+- [ ] No `file:` scheme IRIs anywhere
+- [ ] All string literals carry `@en` language tags
+- [ ] `prov:wasGeneratedBy` links `:analysis` to the kg-generator skill entity
+- [ ] Ontology has `schema:name` + `schema:description` + `schema:identifier`; locally-minted classes/properties have `rdfs:isDefinedBy :` — reused external terms do not
+- [ ] Output is the Turtle code block only — no surrounding text
+- [ ] `owl:sameAs` never has the same IRI in both subject and object
+
+---
+
+## Template 5 — Social Media Post & Comment Thread Collection (RDF-Turtle)
+
+Use for a single social media post (LinkedIn, X, etc.) plus its comment thread — full or a curated sampling — including interaction counters, an analytical thesis/argument restructuring of the post, and any reference links surfaced in the thread.
+
+⛔ **PRE-BUILD CHECK**: Before producing RDF-Turtle, re-read the "Post-Generation Checklist" below and the "Compliance Self-Audit" in the prompt. Confirm: `@prefix :` (or a `post:` prefix bound to `{post-url}#`) is used consistently, `schema:` = `http://schema.org/` (HTTP), the post's `schema:text` is reproduced verbatim (not paraphrased), every comment is a `schema:Comment` with `schema:parentItem` correctly threaded and `schema:position` sequential across the whole thread, every quoted spec/code example is reproduced verbatim and marked as such, at least 12 FAQ + at least 10 glossary, person IRI priority ladder, no blank nodes for `schema:Answer`, `prov:wasGeneratedBy`, no `file:` IRIs, all string literals carry `@en` language tags. Build to pass every item — do not retro-fit.
+
+### Placeholders
+
+| Placeholder | Value |
+|---|---|
+| `{url}` | URL of the original social media post |
+| `{post-url}` | Used as the Turtle `@prefix :` base (append `#`) |
+| `{selected_text}` | Full extracted text of the post plus every comment to be included, in thread order |
+| `{current date}` | ISO 8601 date e.g. `2026-03-13` |
+| `{principal-webid}` | The human principal's canonical WebID IRI, used for `schema:author`/`schema:accountablePerson` on this curated collection document itself |
+
+**Example — worked application of this template:** see "Example — Social Media Post & Comment Thread Worked Example" below for a full illustration of how these generic instructions apply to a real source (Tony Seale's LinkedIn post on YAML-LD and Vault-LD, with its full comment thread). That block is reference material only — do not copy its entity names or comment content into an unrelated source's output.
+
+### Example — Social Media Post & Comment Thread Worked Example
+
+This is a **worked illustration**, not part of the prompt the model executes. It shows how the generic instructions below resolve when applied to one specific source — Tony Seale's LinkedIn post "This week YAML-LD advanced down the W3C standards track," reproduced verbatim as `schema:text` on a `schema:SocialMediaPosting` entity, with 24 threaded comments (Kingsley Uyi Idehen's multi-part comment thread featured first, followed by a sampling of other public comments), each modeled as a `schema:Comment` with `schema:parentItem` (linking to the post or to the comment it replies to) and a thread-wide sequential `schema:position`.
+
+Applying the "analytical restructuring" step to this source produced a `:thesisSection` (one-sentence statement of the post's core claim) and an `:argumentSection` typed as `schema:ItemList`, whose `schema:itemListElement` is a `schema:position`-ordered sequence of `schema:CreativeWork` evidence entities (the objection, the overlooked asset, the precedent, the move, the principle, the implication) — a structured restructuring of the post's own argument, not the verbatim text itself.
+
+Applying the "verbatim example reproduction" step to this source meant reproducing the W3C YAML-LD spec's own introductory example (the Proxima Centauri b example) exactly as published, as a `schema:SoftwareSourceCode` entity with `schema:programmingLanguage "YAML"` and `rdfs:comment` explicitly noting it is reproduced verbatim from the spec, not invented — including using the spec's own real, dereferenceable DBpedia/schema.org IRIs rather than substituting placeholder `urn:` identifiers.
+
+Applying the "reference links" step to this source meant modeling the in-thread `SeeAlso` links one commenter posted as a `:referenceLinksSection` (`schema:ItemList`), each entry a `schema:position`-ordered `schema:CreativeWork`/`schema:SoftwareApplication` entity with its own URL, author, and description — preserving them as first-class, separately citable entities rather than folding them into the comment's prose alone.
+
+Applying interaction-counter modeling meant giving the post (and any comment with visible reactions) a `schema:interactionStatistic` pointing to one or more `schema:InteractionCounter` entities (`schema:interactionType schema:LikeAction`/`schema:CommentAction`, `schema:userInteractionCount` as an integer) — preserving the exact counts shown, not estimating them.
+
+### Prompt
+
+```
+You are an expert in semantic web modeling, RDF/Turtle serialization, and schema.org + lightweight ontology design.
+Given the social media post at {url} and its comment thread:
+"""
+{selected_text}
+"""
+produce a **comprehensive RDF/Turtle document** that represents the post and its comment thread as a knowledge graph.
+Follow ALL of these final design requirements exactly:
+1. Base URI: Use relative hash URIs grounded in {post-url} as the namespace prefix :
+2. Use schema.org as the primary vocabulary — use http://schema.org/ (HTTP, not HTTPS) as the schema: namespace URI — supplemented by rdfs:, skos:, owl:, and prov: as needed.
+3. Model the post itself as a `schema:SocialMediaPosting` with `schema:author`, `schema:datePublished`, and `schema:text` reproduced **verbatim** — do not paraphrase, summarize, or truncate the post's own wording in this field. Add `schema:headline` as a short label for the post.
+4. Model every comment to be included as a `schema:Comment` with:
+   - `schema:author` (the commenter's person IRI, per item 11)
+   - `schema:parentItem` pointing to the post (top-level comments) or to the specific comment it is replying to (threaded replies)
+   - `schema:position` as a sequential integer across the WHOLE thread in display order (not reset per branch)
+   - `schema:text` reproduced verbatim
+   - If a comment continues across multiple LinkedIn/X-style posted parts by the same author, model each part as its own `schema:Comment` linked back to the first part of that same author's turn via `schema:isPartOf`, in addition to `schema:parentItem` pointing to the post/parent comment.
+   - `rdfs:comment` noting if the source marks the comment as edited.
+5. If the post is one of several by the same author on related themes, model the author's blog/channel as a `schema:Blog` (or appropriate type) with `schema:hasPart` linking any other referenced posts by the same author, even if only briefly cited.
+6. Restructure the post's own argument analytically (do not simply repeat the verbatim text): create a `:thesisSection` (a one-sentence statement of the post's core claim) and an `:argumentSection` typed `schema:ItemList`, whose `schema:itemListElement` is a `schema:position`-ordered sequence of `schema:CreativeWork` entities, one per distinct logical step in the post's argument (e.g., the objection it addresses, the evidence it offers, the precedent it cites, the move it proposes, the underlying principle, the implication).
+7. If the post or thread reproduces or references a formal specification, standard, or code example verbatim, reproduce it exactly as a `schema:SoftwareSourceCode` (or appropriate type) entity, with `rdfs:comment` explicitly stating it is reproduced verbatim from its named source — never invent a substitute or simplified example when a real one is available and named in the source.
+8. If a commenter posts a curated list of reference links (a "SeeAlso" or "further reading" list), model it as its own `:referenceLinksSection` (`schema:ItemList`), with each entry a `schema:position`-ordered entity carrying its own URL, name, author, and description — not folded only into the comment's prose text.
+9. Model interaction statistics (likes, comment counts) wherever visibly shown in the source, via `schema:interactionStatistic` pointing to `schema:InteractionCounter` entities with `schema:interactionType` and `schema:userInteractionCount` as an integer — use the exact counts shown, never estimate.
+10. Core entities that must be included: the post, every included comment, every named commenter and any person mentioned within a comment (via `schema:mentions`), any spec/standard/code example reproduced, and any reference links surfaced in the thread.
+11. For every person entity: use the highest-priority platform profile URL found in the source as the primary person IRI with `#this` appended, in this order: (a) LinkedIn → (b) X/Twitter → (c) Substack → (d) Reddit → (e) other platform → (f) hash-based fallback from {post-url}. ALL discovered platform identities MUST be linked via owl:sameAs. NEVER fabricate names.
+12. All DBpedia/Wikidata references MUST use fully expanded IRIs.
+13. Mandatory structured sections (counts are a floor, not a fixed target):
+    - schema:FAQPage (:faqSection) with **at least 12** schema:Question items, covering the post's and thread's distinct question-worthy claims
+    - skos:ConceptScheme + schema:DefinedTermSet (:glossarySection) with **at least 10** terms the post/thread introduces or invokes
+    - schema:HowTo (:howtoSection) with schema:HowToStep items, if the post/thread implies an actionable sequence (e.g. a migration path or adoption pattern); omit if purely descriptive
+14. Keep descriptions concise yet precise; avoid unnecessary verbosity in literals not reproduced verbatim.
+15. Output **only** the complete, valid Turtle document inside a single code block. Do not include explanations, comments outside Turtle, or any other text before/after the code block.
+16. This curated collection document itself carries prov:wasGeneratedBy linking to the kg-generator/rdf-infographic-skill entity as applicable, with schema:author set to the generating skill and schema:accountablePerson set to {principal-webid} — never schema:author set to the principal directly for the act of curation, since the principal did not write the post or comments being collected.
+17. You MUST NOT use blank nodes for schema:Answer instances. Every schema:Answer MUST be a named entity connected via schema:acceptedAnswer :aN.
+18. For every directional relationship you assert (e.g., schema:isPartOf), you MUST also assert its inverse (e.g., schema:hasPart), except schema:parentItem (a comment-threading property with no required inverse).
+Current date for metadata: {current date}.
+
+CRITICAL — Before outputting the Turtle, you MUST perform a compliance self-audit. Verify each item and report PASS or FAIL (with the violation fixed):
+1. schema: namespace is http://schema.org/ (not https://schema.org/)
+2. The post's schema:text is reproduced verbatim, not paraphrased or truncated
+3. Every comment is a schema:Comment with schema:parentItem correctly threaded and a sequential schema:position across the whole thread
+4. Any reproduced spec/code example is verbatim and marked as such via rdfs:comment
+5. :faqSection is a schema:FAQPage with schema:mainEntity listing at least 12 schema:Question items
+6. :glossarySection is a schema:DefinedTermSet with schema:hasDefinedTerm listing at least 10 terms
+7. All DBpedia/Wikidata IRIs are fully expanded (not CURIEs)
+8. No file: scheme IRIs exist anywhere
+9. No blank nodes for schema:Answer
+10. Inverse relationships explicit except schema:parentItem
+11. prov:wasGeneratedBy present; schema:author on the collection document is the generating skill, schema:accountablePerson is {principal-webid} — never schema:author set to the principal for content the principal did not author
+12. Interaction counters use exact shown counts, modeled via schema:InteractionCounter
+13. owl:sameAs never has the same IRI in both subject and object positions
+Report: "COMPLIANCE SELF-AUDIT: X/13 passed. [list any FAIL items, already fixed]. Output follows."
+
+GATE: 0 FAIL required before delivery. Every numbered rule in this prompt has a corresponding check in this audit. No rule without verification — unchecked rules are aspirational, not enforceable.```
+
+### Post-Generation Checklist
+
+- [ ] `@prefix :` set to `{post-url}#`
+- [ ] `schema:` namespace uses `http://schema.org/` (HTTP, not HTTPS)
+- [ ] Post modeled as `schema:SocialMediaPosting` with `schema:text` reproduced verbatim
+- [ ] Every comment is `schema:Comment` with correct `schema:parentItem` threading and a sequential `schema:position` across the whole thread
+- [ ] Multi-part same-author comment turns linked via `schema:isPartOf` in addition to `schema:parentItem`
+- [ ] Edited comments flagged via `rdfs:comment`
+- [ ] `:thesisSection` and `:argumentSection` (ItemList) present as an analytical restructuring, not a repeat of verbatim text
+- [ ] Any reproduced spec/code example is verbatim and explicitly marked as such
+- [ ] Any in-thread reference-link list modeled as its own `:referenceLinksSection` (ItemList) with position-ordered entries
+- [ ] Interaction counters modeled via `schema:InteractionCounter` with exact shown counts
+- [ ] At least 12 FAQ questions wrapped in `schema:FAQPage` with `schema:mainEntity`
+- [ ] At least 10 glossary terms wrapped in `schema:DefinedTermSet` with `schema:hasDefinedTerm`
+- [ ] HowTo present only if the post/thread implies an actionable sequence
+- [ ] All DBpedia/Wikidata IRIs fully expanded (not CURIEs)
+- [ ] Person IRIs follow the standard priority ladder; names match source exactly; all platform identities linked via `owl:sameAs`
+- [ ] No `file:` scheme IRIs anywhere
+- [ ] All string literals (other than verbatim reproductions) carry `@en` language tags
+- [ ] `prov:wasGeneratedBy` present; `schema:author` on the collection is the generating skill, `schema:accountablePerson` is `{principal-webid}`
+- [ ] Output is the Turtle code block only — no surrounding text
+- [ ] `owl:sameAs` never has the same IRI in both subject and object
+
+---
+
+## Template 6 — News Article with Agent-Authored Framework Commentary (RDF-Turtle)
+
+Use for third-party news/magazine articles (a `schema:NewsArticle` from an identifiable publisher), optionally extended with an agent-authored analytical section that applies a named external framework (e.g., a book's thesis) as critical commentary on the article's claims — added only when the user requests that lens, kept clearly delegated and separate from the article's own reported content.
+
+⛔ **PRE-BUILD CHECK**: Before producing RDF-Turtle, re-read the "Post-Generation Checklist" below and the "Compliance Self-Audit" in the prompt. Confirm: `@prefix :` = `{post-url}#`, `schema:` = `http://schema.org/` (HTTP), the article is `schema:NewsArticle` with publisher/author/dates faithfully captured, every direct quotation attributed to its named speaker, related/companion coverage linked as separate `schema:NewsArticle` entities (not just bare URLs), any agent-authored framework-commentary section has `schema:author` set to the generating skill (never the principal directly) with `schema:accountablePerson` on the principal, at least 12 FAQ + at least 10 glossary + HowTo if the article supports actionable takeaways, no blank nodes for `schema:Answer`, `prov:wasGeneratedBy`, no `file:` IRIs, all string literals carry `@en` language tags. Build to pass every item — do not retro-fit.
+
+### Placeholders
+
+| Placeholder | Value |
+|---|---|
+| `{url}` | URL of the original news/magazine article |
+| `{post-url}` | Used as the Turtle `@prefix :` base (append `#`) |
+| `{selected_text}` | Full extracted text of the article |
+| `{current date}` | ISO 8601 date e.g. `2026-03-13` |
+| `{framework-name}` | Optional — name of the external framework/book to apply as commentary, only if the user requests this lens |
+| `{principal-webid}` | The human principal's canonical WebID IRI, used for `schema:accountablePerson` on any agent-authored commentary section |
+
+**Example — worked application of this template:** see "Example — News Article with Framework Commentary Worked Example" below for a full illustration of how these generic instructions apply to a real source (The Atlantic's "Generative AI Is an Engineering Disaster," with an added Blitzscaling-framework commentary lens). That block is reference material only — do not copy its entity names or figures into an unrelated source's output.
+
+### Example — News Article with Framework Commentary Worked Example
+
+This is a **worked illustration**, not part of the prompt the model executes. It shows how the generic instructions below resolve when applied to one specific source — The Atlantic's "Generative AI Is an Engineering Disaster," a `schema:NewsArticle` by staff writer Alex Reisner arguing that generative AI's quadratic (not merely large-scale) resource growth is driving a memory shortage and price spikes, part of The Atlantic's "AI Watchdog" `schema:CreativeWorkSeries`.
+
+Applying the "core article modeling" step to this source produced content sections for cost/scarcity, the scaling problem, industry efficiency claims, market saturation, and expert quotes — each a `schema:CreativeWork` with `schema:abstract`, linked from the main article via `schema:hasPart` — plus a `:relatedCoverageSection` modeling each companion Atlantic article as its own `schema:NewsArticle` entity (headline, URL, publisher), not a bare `schema:relatedLink` string.
+
+Applying the "agent-authored framework commentary" step to this source — added because the user explicitly asked for a Blitzscaling-framework lens on the article — produced a distinct `:blitzscalingSection`, containing four `schema:CreativeWork` argument entities (the brute-force bet as a blitzscaling choice, externalized cost, inverted marginal-cost returns, bubble-economy risk) that connect the article's own reported facts and quotations (via `schema:mentions`/`schema:about`) to concepts from Reid Hoffman and Chris Yeh's book "Blitzscaling" (modeled as a `schema:Book` with `schema:isbn`). Critically, `:blitzscalingSection`'s `schema:author` is the kg-generator skill entity, with `schema:accountablePerson` on the principal's WebID and its own `prov:wasGeneratedBy` — kept structurally distinct from the article's own `schema:author` (Alex Reisner) so the commentary is never misattributed as something the article's actual author wrote or endorsed.
+
+Applying the "verbatim quotations" step to this source meant modeling each expert quote (Sam Altman, Ilya Sutskever, Alexia Jolicoeur-Martineau, Yann LeCun) as its own `schema:CreativeWork` with exact `schema:text` and `schema:author`, grouped under an `:expertVoicesSection`.
+
+### Prompt
+
+```
+You are an expert in semantic web modeling, RDF/Turtle serialization, and schema.org + lightweight ontology design.
+Given the news/magazine article at {url}:
+"""
+{selected_text}
+"""
+produce a **comprehensive RDF/Turtle document** that represents the article as a knowledge graph.
+Follow ALL of these final design requirements exactly:
+1. Base URI: Use relative hash URIs grounded in {post-url} as the namespace prefix :
+2. Use schema.org as the primary vocabulary — use http://schema.org/ (HTTP, not HTTPS) as the schema: namespace URI — supplemented by rdfs:, skos:, owl:, and prov: as needed.
+3. Model the article as a `schema:NewsArticle` with `schema:headline`, `schema:abstract`, `schema:datePublished`/`schema:dateModified`, `schema:author` (the byline), `schema:publisher`, and `schema:url`/`schema:mainEntityOfPage`. If the article belongs to a named ongoing series/column, model that series as a `schema:CreativeWorkSeries` with `schema:hasPart` linking the article.
+4. Identify the article's own section structure (however the source itself organizes its argument — by topic, by claim, by chronology) and represent each as a `schema:CreativeWork` with `schema:abstract`, linked from the main article via `schema:hasPart`.
+5. Model every direct quotation from a named speaker as its own `schema:CreativeWork` (or `schema:Quotation`) with exact `schema:text` and `schema:author`, grouped under an expert-voices or quotations section if the article features multiple.
+6. If the article links to companion/related coverage (its own outlet's other articles on the same or adjacent topics), model each as its own `schema:NewsArticle` entity with `schema:headline` and `schema:url` — do not reduce them to bare `schema:relatedLink` URL strings when the article names them.
+7. If, and only if, the user has explicitly requested applying a named external framework (`{framework-name}`) as a commentary lens on the article:
+   a. Model it as a distinct `schema:CreativeWork` section, structurally separate from the article's own reported sections.
+   b. Model the framework's source (e.g. a book) as its own entity (`schema:Book` with `schema:isbn` if applicable, or the appropriate type) with its author(s).
+   c. Create one commentary entity per distinct point the framework-lens analysis makes, each connecting specific facts/quotations already modeled elsewhere in the graph (via `schema:mentions`/`schema:about`) to a concept from the framework — do not simply restate the article's own claims under a new heading.
+   d. This section's `schema:author` MUST be the generating skill entity, NEVER the article's own byline and NEVER the human principal's WebID directly — it is agent-synthesized commentary, not part of the article and not something the principal personally wrote. Add `schema:accountablePerson` set to `{principal-webid}` and give the section its own `prov:wasGeneratedBy`.
+   e. Do not add a framework-commentary section unless requested — an unrequested critical lens misrepresents a third-party news article's own reported content.
+8. Core entities that must be included: the article, its author and publisher, every named person quoted or discussed, every named organization discussed, any companion/related coverage, and (only if requested) the framework-commentary section and the framework's source work.
+9. For every person entity: use the highest-priority platform profile URL found in the source as the primary person IRI with `#this` appended, in this order: (a) LinkedIn → (b) X/Twitter → (c) Substack → (d) Reddit → (e) other platform → (f) hash-based fallback from {post-url}. For the article's own byline, also add `schema:identifier` pointing to the outlet's own author-bio page if named in the source. ALL discovered platform identities MUST be linked via owl:sameAs. NEVER fabricate names.
+10. All DBpedia/Wikidata references MUST use fully expanded IRIs.
+11. Mandatory structured sections (counts are a floor, not a fixed target):
+    - schema:FAQPage (:faqSection) with **at least 12** schema:Question items covering every distinct question-worthy claim in the article
+    - skos:ConceptScheme + schema:DefinedTermSet (:glossarySection) with **at least 10** terms the article introduces or relies on
+    - schema:HowTo (:howtoSection) with schema:HowToStep items, if the article supports actionable reader takeaways (e.g. how to evaluate a claim it discusses); omit if purely descriptive reporting with no actionable angle
+12. Keep descriptions concise yet precise; avoid unnecessary verbosity in literals.
+13. Output **only** the complete, valid Turtle document inside a single code block. Do not include explanations, comments outside Turtle, or any other text before/after the code block.
+14. The main article MUST have schema:hasPart linking to every content section, :faqSection, :glossarySection, and the framework-commentary section if present.
+15. The article itself carries prov:wasGeneratedBy linking to the kg-generator skill entity, with schema:name, schema:url, and schema:description. A framework-commentary section (if present) carries its own prov:wasGeneratedBy per item 7d.
+16. You MUST NOT use blank nodes for schema:Answer instances. Every schema:Answer MUST be a named entity connected via schema:acceptedAnswer :aN.
+17. For every directional relationship you assert (e.g., schema:isPartOf), you MUST also assert its inverse (e.g., schema:hasPart).
+Current date for metadata: {current date}.
+
+CRITICAL — Before outputting the Turtle, you MUST perform a compliance self-audit. Verify each item and report PASS or FAIL (with the violation fixed):
+1. schema: namespace is http://schema.org/ (not https://schema.org/)
+2. Article is schema:NewsArticle with publisher, byline author, and dates captured; series membership modeled if applicable
+3. The main article has schema:hasPart linking every content section, :faqSection, :glossarySection, and the framework-commentary section if present
+4. Every direct quotation is attributed to its named speaker with exact wording
+5. Companion/related coverage modeled as distinct schema:NewsArticle entities, not bare relatedLink strings, where the source names them
+6. :faqSection is a schema:FAQPage with schema:mainEntity listing at least 12 schema:Question items
+7. :glossarySection is a schema:DefinedTermSet with schema:hasDefinedTerm listing at least 10 terms
+8. All DBpedia/Wikidata IRIs are fully expanded (not CURIEs)
+9. No file: scheme IRIs exist anywhere
+10. If present, the framework-commentary section's schema:author is the generating skill entity — NEVER the article's byline and NEVER the principal's WebID directly; schema:accountablePerson is {principal-webid}; it was added only because explicitly requested
+11. No blank nodes for schema:Answer
+12. Inverse relationships explicit: every schema:isPartOf has a corresponding schema:hasPart
+13. prov:wasGeneratedBy present on the article and on the framework-commentary section (if present)
+14. owl:sameAs never has the same IRI in both subject and object positions
+Report: "COMPLIANCE SELF-AUDIT: X/14 passed. [list any FAIL items, already fixed]. Output follows."
+
+GATE: 0 FAIL required before delivery. Every numbered rule in this prompt has a corresponding check in this audit. No rule without verification — unchecked rules are aspirational, not enforceable.```
+
+### Post-Generation Checklist
+
+- [ ] `@prefix :` set to `{post-url}#`
+- [ ] `schema:` namespace uses `http://schema.org/` (HTTP, not HTTPS)
+- [ ] Article modeled as `schema:NewsArticle` with publisher, byline, dates; series modeled as `schema:CreativeWorkSeries` if applicable
+- [ ] Article's own section structure represented as `schema:hasPart`-linked `schema:CreativeWork` entities with `schema:abstract`
+- [ ] Every direct quotation modeled with exact wording and attributed author
+- [ ] Companion/related coverage modeled as distinct `schema:NewsArticle` entities where named in the source
+- [ ] Framework-commentary section present ONLY if explicitly requested; structurally separate from the article's own sections
+- [ ] If present: framework-commentary `schema:author` is the generating skill entity (never the article's byline, never the principal directly); `schema:accountablePerson` is `{principal-webid}`; framework's source work (e.g. book) modeled as its own entity
+- [ ] At least 12 FAQ questions wrapped in `schema:FAQPage` with `schema:mainEntity`
+- [ ] At least 10 glossary terms wrapped in `schema:DefinedTermSet` with `schema:hasDefinedTerm`
+- [ ] HowTo present only if the article supports actionable reader takeaways
+- [ ] All DBpedia/Wikidata IRIs fully expanded (not CURIEs)
+- [ ] Person/organization IRIs follow the standard priority ladders; names match source exactly
+- [ ] No `file:` scheme IRIs anywhere
+- [ ] All string literals carry `@en` language tags
+- [ ] `prov:wasGeneratedBy` present on the article and on the framework-commentary section (if present)
+- [ ] Output is the Turtle code block only — no surrounding text
+- [ ] `owl:sameAs` never has the same IRI in both subject and object
 
 ---
 


### PR DESCRIPTION
## Summary

- Refactored Template 2 (Business & Market Analysis) to be genuinely parameterized like Template 1 — the Julien Bek "AI autopilots" content is no longer hard-coded into the prompt instructions the model is told to follow "exactly"; it now lives in a separate, clearly-labeled worked-example block.
- Added **Template 3 — Conference & Event Recap** (worked example: Juan Sequeda's CDOIQ 2026 conference takeaways — case studies, panel sessions, quotations, strategic questions).
- Added **Template 4 — Thesis & Framework Article** (worked example: sn scratchpad's "The Reverse Information Paradox" — a named five-pillar framework plus an agent-authored critical-perspective response that reuses ontology terms already minted in companion Knowledge Graphs rather than re-minting them).
- Added **Template 5 — Social Media Post & Comment Thread Collection** (worked example: Tony Seale's LinkedIn post on YAML-LD/Vault-LD with its full threaded comment collection, interaction counters, and verbatim spec-example reproduction).
- Added **Template 6 — News Article with Agent-Authored Framework Commentary** (worked example: The Atlantic's "Generative AI Is an Engineering Disaster" with an optional Blitzscaling-framework commentary lens, kept structurally and attribution-wise separate from the article's own reported content).
- Updated the Template Selection table and the skill's frontmatter `description` to reflect all six templates.

All six templates now follow the same shape: a generically parameterized prompt (`{selected_text}`, `{post-url}`, etc.), a separated "Example" block containing the real worked content, a compliance self-audit, and a post-generation checklist. Agent-authored commentary/critical-perspective entities consistently use the delegation pattern (`schema:author` = generating skill, `schema:accountablePerson` = human principal) rather than attributing agent-synthesized content directly to the principal.

## Test plan

- [x] Verified Markdown structure (`## Template N` / `### Placeholders` / `### Example` / `### Prompt` / `### Post-Generation Checklist`) is consistent across all six templates.
- [x] Verified every new Turtle code fence opens/closes correctly (matches the existing `GATE: ...enforceable.\`\`\`` inline-close convention used by Templates 1–2).
- [ ] No live RDF generation run against the new templates yet — recommend a smoke test generating one document per new template before relying on them in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)