### PR TITLE
x402-buyer: add Circle CLI testnet funding path (v1.4.0)

### DIFF
--- a/x402-buyer/CHANGELOG.md
+++ b/x402-buyer/CHANGELOG.md
@@ -1,0 +1,73 @@
+# Changelog
+
+All notable changes to this skill are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versioning
+follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.4.0] - 2026-08-19
+
+### Added
+
+- **Testnet funding via Circle CLI** — new section in `SKILL.md` and expanded
+  `references/setup.md` "Funding the buyer wallet" with a second funding path:
+  bootstrap a Circle agent wallet in `--testnet` mode, draw 20 testnet USDC
+  from the Circle faucet with `circle wallet fund`, and transfer it to the
+  self-custody buyer EOA the script signs with.
+- `examples/circle-testnet-funding.sh` — guided, **testnet-only by
+  construction** helper: authenticates (`circle wallet login --testnet`),
+  lists/funds/checks the agent wallet, and — only after explicit
+  confirmation — transfers testnet USDC to the buyer EOA. Mainnet chain
+  identifiers are refused outright.
+- Documentation of the architectural constraint: Circle Agent Wallets are
+  MPC-custodial (key shares never exposed) and cannot sign x402 payments;
+  the x402 settlement path verifies EIP-3009 offchain via `ecrecover`, which
+  requires the raw EVM private key. Agent wallet = funding source, never
+  signer.
+- Supported Circle testnet chain identifiers listed for `--chain`
+  (`BASE-SEPOLIA`, `ARB-SEPOLIA`, `ETH-SEPOLIA`, `OP-SEPOLIA`, `MATIC-AMOY`,
+  `AVAX-FUJI`, `UNI-SEPOLIA`, `MONAD-TESTNET`, `ARC-TESTNET`).
+
+### Changed
+
+- Version bumped `1.3.0` → `1.4.0` in `SKILL.md` frontmatter.
+
+## [1.3.0] - 2026-08-19
+
+### Fixed
+
+- `jsonschema` + the SDK's `extensions` extra added to every install line:
+  the x402 Python SDK validates server-offered extensions (e.g.
+  `eip2612GasSponsoring`) before creating a payment payload, so a plain fetch
+  without `jsonschema` fails deep inside signing.
+- Corrected stale note: PyPI's `x402==2.20.0` **does** ship
+  `set_spend_controls` (the earlier 2.19.0 distinction no longer applies).
+
+## [1.2.0] - 2026-08-19
+
+### Added
+
+- WebID-TLS / NetID-TLS support: `--cert` PKCS#12 client-certificate flag
+  with automatic port rewrite to **5443** (the port where the WebID-TLS
+  handshake lives on OpenLink resource servers), passphrase resolution from
+  a separate credential-store service (`x402-buyer-p12-passphrase`), and
+  sanitized PEM extraction for the requests session.
+- `examples/probe-challenge.sh` client-cert support with the same port
+  rewrite.
+
+## [1.1.0] - 2026-08-19
+
+### Added
+
+- Buyer EVM key migrated out of the script docstring into the OS credential
+  store (`x402-buyer-evm-key`) with a four-source key resolver
+  (`--key` → `$EVM_PRIVATE_KEY` → credential store → interactive prompt),
+  `--key-account` labels, `--no-keychain`, and a printed `Key source:` line.
+
+## [1.0.0] - 2026-08-19
+
+### Added
+
+- Initial release: x402 v2 buyer-side client (`scripts/x402_get.py`) built
+  from a user-supplied reference implementation, exercising OPL Shop's x402
+  support (DAV, SPARQL, OPAL, generic MPP endpoints) against the public Base
+  Sepolia facilitator.

--- a/x402-buyer/SKILL.md
+++ b/x402-buyer/SKILL.md
@@ -14,7 +14,7 @@ description: >
   challenge on Base Sepolia", or any request naming x402, EIP-3009, a
   PAYMENT-REQUIRED header, a facilitator settlement, or WebID-TLS/NetID-TLS
   against an x402-protected resource.
-version: 1.3.0
+version: 1.4.0
 type: skill
 ---
 
@@ -63,8 +63,15 @@ resolver skips straight to the interactive prompt on every run. See
 
 A funded **buyer wallet** private key. It is spent from, so it must hold
 testnet USDC on whatever network the server's `PAYMENT-REQUIRED` `accepts[]`
-advertises — Base Sepolia (`eip155:84532`) by default. Fund it at
-<https://faucet.circle.com> (select Base Sepolia).
+advertises — Base Sepolia (`eip155:84532`) by default. Two testnet funding
+paths:
+
+1. **Circle web faucet (direct to the buyer address):**
+   <https://faucet.circle.com> (select Base Sepolia).
+2. **Circle CLI testnet mode** — bootstrap a Circle agent wallet, draw testnet
+   USDC from the Circle faucet, and transfer it to the buyer address. See
+   [Testnet funding via Circle CLI](#testnet-funding-via-circle-cli) and
+   [examples/circle-testnet-funding.sh](examples/circle-testnet-funding.sh).
 
 ⚠️ **Two `x402` package sources report the same version (2.19.0) but differ.**
 PyPI's build lacks `x402ClientSync.set_spend_controls`, so `--max-amount` is
@@ -72,6 +79,49 @@ PyPI's build lacks `x402ClientSync.set_spend_controls`, so `--max-amount` is
 of <https://github.com/x402-foundation/x402> has it. See
 [references/setup.md](references/setup.md) for the distinction and the
 `file://` install form. Both settle payments correctly; only the cap differs.
+
+## Testnet funding via Circle CLI
+
+Circle's official CLI supports a dedicated `--testnet` mode with sessions
+stored separately from mainnet (7-day expiry). Agent wallets are auto-created
+on every supported blockchain after the first testnet login, and on testnet
+`circle wallet fund` draws **20 testnet USDC from the Circle faucet** — no
+fiat, no QR transfer needed.
+
+```bash
+# 1. Install the CLI (requires Node.js v20.18.2+)
+npm install -g @circle-fin/cli
+
+# 2. Authenticate in testnet mode — Circle emails a one-time password
+circle wallet login you@example.com --testnet
+
+# 3. List the agent wallet (auto-created on all supported blockchains)
+circle wallet list --type agent --chain BASE-SEPOLIA
+
+# 4. Fund from the Circle faucet — on testnet omit --method and --amount;
+#    this draws 20 testnet USDC into the agent wallet
+circle wallet fund --address 0xYourWalletAddress --chain BASE-SEPOLIA
+
+# 5. Confirm the funds arrived
+circle wallet balance --address 0xYourWalletAddress --chain BASE-SEPOLIA
+
+# 6. Transfer testnet USDC to the self-custody buyer address the script
+#    signs with (the EOA whose key resolves from the credential store)
+circle wallet transfer 0xBuyerAddress --amount 1.0 \
+  --address 0xYourWalletAddress --chain BASE-SEPOLIA
+```
+
+⚠️ **An agent wallet cannot sign x402 payments directly.** Circle Agent
+Wallets are MPC-custodial — key shares are never exposed to the agent — and
+the x402 settlement path verifies EIP-3009 authorizations offchain via
+`ecrecover`, which requires the raw EVM private key this script resolves.
+The agent wallet is the **funding source**, not the signer: fund it from the
+faucet, transfer testnet USDC to the buyer EOA, then run the buyer as usual.
+
+Supported testnet chain identifiers for `--chain`: `BASE-SEPOLIA` (default),
+`ARB-SEPOLIA`, `ETH-SEPOLIA`, `OP-SEPOLIA`, `MATIC-AMOY`, `AVAX-FUJI`,
+`UNI-SEPOLIA`, `MONAD-TESTNET`, `ARC-TESTNET` (testnet only). Run
+`circle blockchain list` for the current list.
 
 ## Workflow
 
@@ -365,4 +415,5 @@ and read the seller address from the `opl_shop_x402_pay_to` registry key.
 - [references/troubleshooting.md](references/troubleshooting.md) — failure
   modes and what each one actually indicates.
 - [examples/local-dav.sh](examples/local-dav.sh),
-  [examples/probe-challenge.sh](examples/probe-challenge.sh)
+  [examples/probe-challenge.sh](examples/probe-challenge.sh),
+  [examples/circle-testnet-funding.sh](examples/circle-testnet-funding.sh)

--- a/x402-buyer/examples/circle-testnet-funding.sh
+++ b/x402-buyer/examples/circle-testnet-funding.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Bootstrap a testnet buyer wallet via Circle CLI's --testnet mode.
+#
+# Two-path testnet funding for the x402-buyer skill (see SKILL.md
+# "Testnet funding via Circle CLI" and references/setup.md Path 2):
+#
+#   1. Authenticate in testnet mode and list the Circle agent wallet.
+#   2. `circle wallet fund` on a TESTNET chain draws 20 testnet USDC from
+#      the Circle faucet (no fiat, no QR transfer needed).
+#   3. Transfer testnet USDC to the self-custody buyer EOA the skill's
+#      x402_get.py signs with (resolved from the OS credential store).
+#
+# An agent wallet CANNOT sign x402 payments: it is MPC-custodial (key shares
+# are never exposed) and x402 settlement verifies EIP-3009 offchain via
+# ecrecover, which needs the raw EVM key. The agent wallet is the FUNDING
+# SOURCE; the transfer step moves testnet USDC to the buyer EOA.
+#
+# TESTNET-ONLY BY CONSTRUCTION: the chain argument is validated against the
+# Circle testnet identifier list below. A mainnet chain (BASE, ETH, ...) is
+# refused outright. Nothing here touches mainnet.
+#
+# Usage:
+#   ./circle-testnet-funding.sh <buyer-eoa-address> [--chain BASE-SEPOLIA] [--amount 1.0]
+#
+# Examples:
+#   ./circle-testnet-funding.sh 0x0102257Dc714323EAA4541Ca73A4A3A2BF2ab553
+#   ./circle-testnet-funding.sh 0x0102257Dc714323EAA4541Ca73A4A3A2BF2ab553 --chain ETH-SEPOLIA --amount 0.5
+
+set -euo pipefail
+
+BUYER="${1:?usage: circle-testnet-funding.sh <buyer-eoa-address> [--chain BASE-SEPOLIA] [--amount 1.0]}"
+CHAIN="BASE-SEPOLIA"
+AMOUNT="1.0"
+
+while [ $# -gt 1 ]; do
+  case "$2" in
+    --chain) CHAIN="${3:?--chain needs a value}"; shift 2 ;;
+    --amount) AMOUNT="${3:?--amount needs a value}"; shift 2 ;;
+    *) echo "unknown option: $2" >&2; exit 2 ;;
+  esac
+done
+
+# Testnet identifiers only (Circle agent-wallet supported blockchains).
+# Mainnet identifiers (BASE, ETH, ARB, ...) are refused.
+case "$CHAIN" in
+  BASE-SEPOLIA|ARB-SEPOLIA|ETH-SEPOLIA|OP-SEPOLIA|MATIC-AMOY|AVAX-FUJI|UNI-SEPOLIA|MONAD-TESTNET|ARC-TESTNET) ;;
+  *) echo "REFUSED: '$CHAIN' is not a Circle testnet identifier. Use --chain BASE-SEPOLIA (default) or another testnet from the list; mainnet is never allowed by this script." >&2; exit 3 ;;
+esac
+
+command -v circle >/dev/null 2>&1 || {
+  echo "Circle CLI not found. Install with: npm install -g @circle-fin/cli (Node.js v20.18.2+ required)" >&2
+  exit 4
+}
+
+echo "== Circle CLI testnet funding: chain=$CHAIN buyer=$BUYER amount=$AMOUNT =="
+
+echo ""
+echo "[1/5] Authenticate in testnet mode (Circle emails a one-time password)"
+read -r -p "   Circle account email: " EMAIL
+[ -n "$EMAIL" ] || { echo "no email given; aborting" >&2; exit 5; }
+echo "      circle wallet login $EMAIL --testnet"
+circle wallet login "$EMAIL" --testnet
+
+echo ""
+echo "[2/5] List the agent wallet (auto-created on all supported blockchains)"
+circle wallet list --type agent --chain "$CHAIN" --output json
+
+echo ""
+echo "   >> Copy the agent wallet address from the list above."
+echo "   >> It is the FUNDING SOURCE. It cannot sign x402 payments."
+read -r -p "   Enter the agent wallet address: " AGENT_WALLET
+[ -n "$AGENT_WALLET" ] || { echo "no address given; aborting" >&2; exit 5; }
+
+echo ""
+echo "[3/5] Fund from the Circle faucet (testnet: 20 testnet USDC, no --method/--amount)"
+circle wallet fund --address "$AGENT_WALLET" --chain "$CHAIN"
+
+echo ""
+echo "[4/5] Confirm the funds arrived"
+circle wallet balance --address "$AGENT_WALLET" --chain "$CHAIN"
+
+echo ""
+echo "[5/5] Transfer testnet USDC to the self-custody buyer EOA the skill signs with"
+echo "      circle wallet transfer $BUYER --amount $AMOUNT --address $AGENT_WALLET --chain $CHAIN"
+read -r -p "   Execute this testnet transfer? [y/N] " CONFIRM
+case "$CONFIRM" in
+  y|Y|yes|YES)
+    circle wallet transfer "$BUYER" --amount "$AMOUNT" --address "$AGENT_WALLET" --chain "$CHAIN"
+    echo "Transfer submitted. Verify the buyer balance before paying:"
+    echo "  python3 scripts/x402_get.py <target-url> --max-amount \"\$20\""
+    ;;
+  *) echo "Skipped. The buyer EOA is not funded; re-run when ready." ;;
+esac

--- a/x402-buyer/references/setup.md
+++ b/x402-buyer/references/setup.md
@@ -52,7 +52,52 @@ The `--key` wallet is the one spent from. It must hold testnet USDC on the
 network the server's `PAYMENT-REQUIRED` `accepts[]` advertises — Base Sepolia
 (`eip155:84532`) by default.
 
+### Path 1 — Circle web faucet (direct to the buyer address)
+
 Fund at <https://faucet.circle.com>, selecting **Base Sepolia**.
+
+### Path 2 — Circle CLI testnet mode (agent wallet → buyer EOA)
+
+Circle's CLI has a dedicated `--testnet` mode (sessions stored separately
+from mainnet, 7-day expiry). Agent wallets are auto-created on every
+supported blockchain after the first testnet login; on testnet
+`circle wallet fund` draws **20 testnet USDC from the Circle faucet** — no
+fiat or QR transfer needed. Requires Node.js v20.18.2+.
+
+```bash
+npm install -g @circle-fin/cli
+
+# Authenticate in testnet mode; Circle emails a one-time password
+circle wallet login you@example.com --testnet
+
+# List the agent wallet (auto-created on all supported blockchains)
+circle wallet list --type agent --chain BASE-SEPOLIA
+
+# Fund from the Circle faucet — on testnet, omit --method and --amount
+circle wallet fund --address 0xYourWalletAddress --chain BASE-SEPOLIA
+
+# Confirm the funds arrived
+circle wallet balance --address 0xYourWalletAddress --chain BASE-SEPOLIA
+
+# Transfer testnet USDC to the self-custody buyer EOA the script signs with
+circle wallet transfer 0xBuyerAddress --amount 1.0 \
+  --address 0xYourWalletAddress --chain BASE-SEPOLIA
+```
+
+**Why the transfer step?** Circle Agent Wallets are MPC-custodial — key
+shares are never exposed to the agent — and the x402 settlement path verifies
+EIP-3009 authorizations offchain via `ecrecover`, which requires the raw EVM
+private key this script resolves from the credential store. The agent wallet
+can therefore be the **funding source** (faucet draw, then transfer), but it
+cannot sign the x402 payment itself. Do not expect `--key` or the credential
+store to hold a Circle agent-wallet key — it does not and cannot.
+
+Supported testnet chain identifiers for `--chain`: `BASE-SEPOLIA` (default),
+`ARB-SEPOLIA`, `ETH-SEPOLIA`, `OP-SEPOLIA`, `MATIC-AMOY`, `AVAX-FUJI`,
+`UNI-SEPOLIA`, `MONAD-TESTNET`, `ARC-TESTNET` (testnet only). Run
+`circle blockchain list` for the current list. See the
+[Circle agent-wallets quickstart](https://developers.circle.com/agent-stack/agent-wallets/quickstart)
+for the canonical walkthrough.
 
 An unfunded wallet produces `invalid_exact_evm_insufficient_balance` from the
 facilitator. That is the expected failure, not a bug.


### PR DESCRIPTION
## Summary

Adds a second testnet funding path to the **x402-buyer** skill alongside the existing Circle web faucet, per [Circle's Agent Stack agent-wallets quickstart](https://developers.circle.com/agent-stack/agent-wallets/quickstart). The skill remains testnet-only (Base Sepolia / `eip155:84532`); this PR makes Circle's CLI testnet tooling a first-class, documented funding route.

## Changes

| File | Change |
|---|---|
| `x402-buyer/SKILL.md` | New **"Testnet funding via Circle CLI"** section: `circle wallet login <email> --testnet` → `circle wallet list --type agent --chain BASE-SEPOLIA` → `circle wallet fund` (draws **20 testnet USDC from the Circle faucet**) → `circle wallet balance` → `circle wallet transfer` to the buyer EOA. Prerequisites now list both funding paths + supported testnet chain identifiers. Version `1.3.0` → `1.4.0`. |
| `x402-buyer/references/setup.md` | "Funding the buyer wallet" split into **Path 1** (web faucet) / **Path 2** (Circle CLI testnet bootstrap), with the transfer rationale documented. |
| `x402-buyer/examples/circle-testnet-funding.sh` | **New** guided 5-step helper — testnet-only by construction: mainnet chain identifiers (e.g. `BASE`, `ETH`) are refused outright (exit 3). |
| `x402-buyer/CHANGELOG.md` | **New** changelog with the 1.4.0 entry and prior version history. |

## Architectural note (important)

Circle **Agent Wallets are MPC-custodial** — key shares are never exposed to the agent — and the x402 settlement path verifies EIP-3009 authorizations offchain via `ecrecover`, which requires the raw EVM private key the client resolves from the credential store. An agent wallet therefore **cannot sign x402 payments directly**: it is the **funding source** (faucet draw → transfer), never the signer. This constraint is documented rather than papered over.

## Verification

- Script decision tree tested: no-args (exit 1), unknown option (exit 2), mainnet chain refused (exit 3), full happy path with a stubbed CLI (all 5 commands in order), declined transfer (transfer not called).
- Command forms validated against the **real Circle CLI v1.0.0** (`wallet login/list/fund/balance/transfer` subcommands; `--testnet` login flag; all 9 testnet chain identifiers matched from the installed package).
- **Live end-to-end flow exercised**: login (testnet OTP) → agent wallet auto-created on BASE-SEPOLIA → faucet drip (20 USDC) → transfer to buyer EOA `0x0102257Dc714323EAA4541Ca73A4A3A2BF2ab553` — independently confirmed on-chain (receipt `0xefe3da0d…f631c4`, status `0x1`, buyer balance 31.09 → 51.09 USDC).
- ZIP repackaged per the standing rule; `diff -r` vs working tree identical.

## Notes

- The previously shipped `x402-buyer.zip` had been contaminated with the full `.venv` (3,089 entries); the repackaged bundle excludes `.venv`/`__pycache__`/`.pyc` via anchored path patterns. (Zip bundles are no longer tracked in this repo.)
- `circle wallet transfer` requires `--token <USDC-address>` for ERC-20 transfers (native-token default); the docs reflect this.