### PR TITLE
Land pending prior-session work: storytelling persona, Piper fallback, memory corpus

### DIFF
--- a/agent-rdf-memory/howto/ported-template-measured-defect-sweep.ttl
+++ b/agent-rdf-memory/howto/ported-template-measured-defect-sweep.ttl
@@ -1,0 +1,97 @@
+@prefix : <#> .
+@prefix schema: <http://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix onto: <../ontology.ttl#> .
+
+<> a schema:HowTo ;
+    schema:name "Measured-Defect Sweep on a Ported HTML Template"@en ;
+    schema:description "Three checks that must be MEASURED in a live browser — never read off the CSS or inferred from a green validator — before delivering an HTML infographic whose shell was ported from a prior artifact: token contrast in both themes, the floating nav's full expand/resize/hide/restore lifecycle, and document-level horizontal overflow at a phone width. Each check exists because it caught a real defect that both validate-harness-contract.py and validate-kg-compliance.sh passed on either side of the fix."@en ;
+    schema:dateCreated "2026-08-24T00:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-08-24T00:00:00Z"^^xsd:dateTime ;
+    schema:author <https://linkedin.com/in/kidehen#this> ;
+    schema:about :portedTemplateDefectSweep ;
+    schema:step :step-measureTokenContrastBothThemes,
+        :step-exerciseNavLifecycle,
+        :step-measureOverflowAtPhoneWidth,
+        :step-clippedFlexOverflowIsInvisibleToScrollWidth,
+        :step-compositeAlphaBeforeJudgingContrast,
+        :step-scopeRepairsToThisPage ;
+    rdfs:seeAlso <../preferences.ttl#step-portedTemplateMeasuredDefectSweep>,
+        <generator-script-output-not-a-substitute-for-contract-check.ttl>,
+        <checker-context-isolation.ttl>,
+        <prior-artifact-footer-polish-gate.ttl>,
+        <fixed-background-color-pinning.ttl>,
+        <nav-panel-localstorage-race.ttl>,
+        <openlink-brand-color-scheme.ttl> .
+
+:portedTemplateDefectSweep a schema:Thing ;
+    schema:name "Measured-defect sweep for ported HTML template shells"@en ;
+    schema:description "A ported shell inherits its source's defects along with its proven behaviour. These three defects are invisible to every static check in the harness because they live in rendered geometry and computed colour, not in required content."@en .
+
+# ── Step 1: contrast, computed and composited, in BOTH themes ────────────────
+
+:step-measureTokenContrastBothThemes a schema:HowToStep ;
+    schema:position "1"^^xsd:integer ;
+    schema:name "Compute the real contrast ratio of every text-bearing colour token against its actual ground, in BOTH themes — a token that is correct in one theme is not thereby correct in the other"@en ;
+    schema:text """Incident 2026-08-24, virtuoso-opentofu collection, shell ported from neo4j-graph-technology-vs-virtuoso-rdf-claude_opus_5-1.html generated the same day: the palette set --accent to #00b4ff on bare :root AND left it bright in the dark blocks. That is correct on the dark ground and required by the bright-accent dark-mode rule — but --accent is also the entity-hyperlink colour (.entity-link{color:var(--accent)}), so on the light theme's white page every entity link on the page measured 2.34:1, well under the 4.5:1 AA floor. The sheet's own header comment already said '--primary = entity-hyperlink colour; --accent = supporting accent only' and '--on-accent: #ffffff ... (every accent is dark)', both of which the light --accent value contradicted. Nobody had measured it.
+
+PROCEDURE: in the live page, for each text-bearing token usage, read getComputedStyle(el).color and the composited background, then compute the WCAG relative-luminance ratio in the browser. Do not eyeball a screenshot and do not reason from the hex value. Repeat after flipping the theme — and flip it by reloading with the persisted preference set, not by setAttribute alone, because the style bridge can return a stale computed value read in the same task as the attribute change (observed repeatedly in this incident, and the reason an intermediate 3.33:1 reading looked like a cascade bug that did not exist).
+
+FIX SHAPE: move only the failing theme's value. A light-only repair declared on bare :root is safe next to the usual dark selectors, because html[data-theme="dark"] is (0,1,1) and :root:not([data-theme="light"]) is (0,2,0) against :root's (0,1,0) — both outrank it, so the dark palette survives in the explicit-toggle and the OS-preference path alike."""@en ;
+    onto:hasTrigger onto:triggerBehaviorGapIdentified , onto:triggerArtifactGeneration .
+
+# ── Step 2: the whole nav lifecycle, with real input ─────────────────────────
+
+:step-exerciseNavLifecycle a schema:HowToStep ;
+    schema:position "2"^^xsd:integer ;
+    schema:name "Exercise the floating nav's full lifecycle with real input — expand, resize, manual hide, ambient movement, marker restore — because the contract's five nav behaviours are implemented in four separate places and a template can carry four of them"@en ;
+    schema:text """Same incident: the ported shell carried the manual-hide button, the inactivity fade, the manuallyHidden guard that makes the hide stick through ambient mousemove, and the dynamically-created reactivation marker — everything the two nav rules describe — but contained no `resize` declaration for the nav at all, in any block. The nav simply could not be resized, and no static check notices an absent CSS property.
+
+PROCEDURE: click the toggle with real input (a programmatic .click() plus a same-task getComputedStyle read reports a stale max-height and will make a working nav look broken), then assert resize/overflow/max-height in the expanded state and `resize:none` in the collapsed one; click the hide control, then move the mouse for real and confirm the nav STAYS hidden; click the marker and confirm it returns in the state it left.
+
+FIX SHAPE: the toggle puts .open on #nav-links, not a class on the nav, so scope the expanded-state rule with #floating-nav:has(#nav-links.open). Raise the max-height cap in the same rule — a tight cap silently defeats the native resize handle even when resize:both is set."""@en ;
+    onto:hasTrigger onto:triggerBehaviorGapIdentified , onto:triggerArtifactGeneration .
+
+# ── Step 3: overflow at a phone width, measured on the document ──────────────
+
+:step-measureOverflowAtPhoneWidth a schema:HowToStep ;
+    schema:position "3"^^xsd:integer ;
+    schema:name "Measure document.documentElement.scrollWidth minus clientWidth at ~390px and require 0 — then attribute any excess to a specific element, excluding SVG children, whose rects legitimately exceed a scrolling wrapper"@en ;
+    schema:text """Same incident: 199px of document-level horizontal overflow at 390px, from two elements the validators cannot see. First, the workbench's sample-query `pre.sparql-code` — the ported sheet applies overflow-wrap/word-break protection only to `.footer-attribution .sparql-code` and `#sparql-explorer-code`, so a plain pre.sparql-code elsewhere in the workbench kept a 475px unbroken run of IRI text. Second, #sparqlRecipe: a native `select` sizes itself to its widest OPTION LABEL, and question-shaped recipe names ran the document to a 589px scrollWidth inside a 390px viewport. This is the long-token overflow gate recurring in two new element kinds — the rule was already written; only the selectors were new.
+
+MEASUREMENT NOTE: filter SVG descendants out of the per-element sweep. getBoundingClientRect ignores clipping, so every child of an overflow-x:auto figure wrapper reports a rect past the viewport and drowns the real culprits. Also confirm the pane actually has a width first — a hidden or unsized Browser pane reports clientWidth 0 and a meaningless scrollWidth, which reads exactly like page overflow."""@en ;
+    onto:hasTrigger onto:triggerBehaviorGapIdentified , onto:triggerArtifactGeneration .
+
+
+# ── Step 3b: overflow hidden by an ancestor's overflow:hidden ────────────────
+
+:step-clippedFlexOverflowIsInvisibleToScrollWidth a schema:HowToStep ;
+    schema:position "4"^^xsd:integer ;
+    schema:name "document.scrollWidth == clientWidth does NOT prove nothing overflows — inside a flex container with overflow:hidden, a wide child silently pushes its siblings off-screen and the document scroll stays clean"@en ;
+    schema:text """Incident 2026-08-24, same collection, found while adding a signature hero figure: the hero is `display:flex` centring a `.hero-content` item, and the new figure's SVG carried `min-width:660px` so it would stay legible inside its own scrolling wrapper. A flex item defaults to `min-width:auto`, so `.hero-content` grew to that 660px min-content width — at a 390px viewport the eyebrow, heading, tagline and meta were all pushed out past the viewport and clipped by `.hero{overflow:hidden}`. The page-level overflow check reported 0 the whole time, because the clipping ancestor absorbed it.
+
+PROCEDURE: alongside the document-level scrollWidth check, sweep per element for `getBoundingClientRect().right > clientWidth` and read the results even when the document check is clean. Excluding SVG descendants (whose rects legitimately exceed a scrolling wrapper) leaves the real offenders visible — here, `.hero-content` and every one of its text children reporting right:525 in a 390px viewport.
+
+FIX SHAPE: `min-width:0` on the flex item so it may shrink below its min-content width, plus `max-width:100%` and `overflow-x:auto` on the wide child's own wrapper, so the figure scrolls in its box rather than resizing its parent."""@en ;
+    onto:hasTrigger onto:triggerBehaviorGapIdentified , onto:triggerArtifactGeneration .
+
+# ── Step 3c: alpha compositing before any contrast verdict ──────────────────
+
+:step-compositeAlphaBeforeJudgingContrast a schema:HowToStep ;
+    schema:position "5"^^xsd:integer ;
+    schema:name "A contrast ratio computed from an rgba() colour without compositing it against its actual ground is meaningless — and it fails OPTIMISTICALLY, reporting a pass for text that fails"@en ;
+    schema:text """Incident 2026-08-24: a first contrast sweep over a hero band whose text uses `rgba(255,255,255,.62)` and `rgba(255,255,255,.58)` returned 16.3:1 for all three text roles, because the helper read only the first three numbers of the colour string and dropped the alpha — effectively measuring pure white on the dark band. Every value looked identical and implausibly high, which is the tell. Compositing each colour against the hero gradient's lighter stop before computing luminance gave the true figures: 7.23, 6.48, and 5.06 in dark and light respectively — all still passing, but by a margin four to eleven points smaller than the bogus reading, and a slightly more transparent token would have failed while still reporting 16.3.
+
+RULE: parse the alpha, composite `fg.a * fg + (1 - fg.a) * bg` against the real background, and for a gradient ground use whichever stop is *closest in luminance to the text* as the worst case. Identical ratios across several different-looking colours means the alpha was dropped, not that the palette is unusually consistent."""@en ;
+    onto:hasTrigger onto:triggerBehaviorGapIdentified , onto:triggerArtifactGeneration .
+
+# ── Step 4: repair scope ────────────────────────────────────────────────────
+
+:step-scopeRepairsToThisPage a schema:HowToStep ;
+    schema:position "6"^^xsd:integer ;
+    schema:name "Repair the delivered page in an appended, commented override block; propagating the fix back into the source template or the generator is a separate, user-visible decision"@en ;
+    schema:text """A defect found this way lives in a shared ancestor — the prior artifact, and often the generator's own styles.css behind it. Fixing it at the generator is usually right (that is the standing lesson from the palette and theme-guard incidents), but it changes every future page and is not implied by a request to produce one collection. Apply the repair to the page being delivered as an appended override block, comment each rule with what was measured and why, and report the upstream implication to the user rather than editing the skill unasked.
+
+Keep the ported block byte-identical when you do this. An override appended after it is auditable — a diff against the source template shows exactly what this page changed and nothing else — whereas an in-place edit makes the port and the repair indistinguishable to the next session that greps the template lineage."""@en ;
+    onto:hasTrigger onto:triggerBehaviorGapIdentified .

--- a/agent-rdf-memory/howto/ui-ux-expert-persona.ttl
+++ b/agent-rdf-memory/howto/ui-ux-expert-persona.ttl
@@ -7,24 +7,25 @@
 # ── Self-describing document entity ──────────────────────────────────────────
 
 <> a schema:CreativeWork ;
-    schema:name "HowTo: UI/UX Expert Persona — Standing Behavioral Default"@en ;
-    schema:description "Companion howto document for preferences.ttl Step 44. Specifies that the agent must apply expert-level UI/UX judgment to all visual artifacts without per-session activation. Cross-references the color design token system, hyperlink conventions, accordion patterns, and section title behavior established across multiple infographic sessions."@en ;
+    schema:name "HowTo: UI/UX, Visual Communication, and Storytelling Expert Persona — Standing Behavioral Default"@en ;
+    schema:description "Companion howto document for preferences.ttl Step 44. Specifies that the agent must apply expert-level UI/UX, visual-communication, and storytelling judgment to all visual artifacts without per-session activation. Cross-references narrative structure, evidence-led visual selection, the color design token system, hyperlink conventions, accordion patterns, and section title behavior established across multiple infographic sessions."@en ;
     schema:dateCreated "2026-06-14T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-06-14T00:00:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-08-24T00:00:00Z"^^xsd:dateTime ;
     schema:about :HowToUiUxExpertPersona .
 
 # ── HowTo: UI/UX Expert Persona ──────────────────────────────────────────────
 
 :HowToUiUxExpertPersona a schema:HowTo ;
-    schema:name "Operate as a UI/UX Expert When Producing Visual Artifacts"@en ;
-    schema:description "Standing behavioral default (Step 44): apply expert-level UI/UX judgment to all HTML pages, infographics, dashboards, and interactive artifacts without requiring per-session reminders. Treat deviations from the established design token system as contract violations."@en ;
+    schema:name "Operate as a UI/UX, Visual Communication, and Storytelling Expert When Producing Visual Artifacts"@en ;
+    schema:description "Standing behavioral default (Step 44): apply expert-level UI/UX, visual-communication, and storytelling judgment to all HTML pages, infographics, dashboards, and interactive artifacts without requiring per-session reminders. Treat a missing reader journey, weak evidence hierarchy, decorative rather than explanatory visuals, inaccessible interaction, or deviation from the established design token system as contract violations."@en ;
     schema:step :stepColorSystemDiscipline,
                 :stepHyperlinkConsistency,
                 :stepLabelPrecision,
                 :stepSectionHeadingTreatment,
                 :stepAccordionToggleLinks,
                 :stepCrossSessionConsistency,
-                :stepNoRawUrlDump .
+                :stepNoRawUrlDump,
+                :stepVisualStorytelling .
 
 # ── Steps ─────────────────────────────────────────────────────────────────────
 
@@ -100,9 +101,14 @@ Instead, render it as a compact styled affordance consistent with the design tok
   - the label text stays static; only the href updates on refresh — never overwrite textContent with the raw URL
 Failure mode observed: the rdf-infographic-skill SPARQL-workbench template (copied verbatim from a prior session's HTML as a structural base) rendered `preview.textContent = btn.href` — a raw ~500-character percent-encoded URL wrapped as plain muted text under the Refresh/Copy buttons. This is a template-inherited flaw, not a one-off: check every reused template section against the design system rather than assuming prior output was already compliant."""@en .
 
+:stepVisualStorytelling a schema:HowToStep ;
+    schema:position 8 ;
+    schema:name "Build an evidence-led visual story and reader journey"@en ;
+    schema:text """Before implementation, define the reader's starting question, the central contrast or tension, the evidence sequence, the decisive insight, and the action or exploration surface that resolves the story. Every section must advance that arc. Use visual forms according to communication purpose: tables for exact comparisons, flows for sequence and causality, diagrams for architecture, charts for quantitative patterns, and prose for interpretation. Prefer RDF-derived figures and live query results over decorative illustration. A technically valid page that is a uniform stack of prose cards, buries its thesis, or treats SPARQL as a footer ornament rather than an explanatory interaction fails this gate."""@en .
+
 # ── Why This HowTo Was Created ────────────────────────────────────────────────
 
 :OriginContext a schema:CreativeWork ;
     schema:name "Origin context for UI/UX Expert Persona rule"@en ;
-    schema:description "The user had to request UI/UX expert behavior explicitly across multiple sessions to fix: (1) glossary term links using purple --accent2 instead of blue --accent; (2) FAQ accordion toggle links unstyled/inherited; (3) section headings mislabeled. User stated: 'I don't want to keep on requesting that re aesthetics.' This rule codifies the standing expectation."@en ;
+    schema:description "The user had to request UI/UX expert behavior explicitly across multiple sessions to fix: (1) glossary term links using purple --accent2 instead of blue --accent; (2) FAQ accordion toggle links unstyled/inherited; (3) section headings mislabeled. The user later clarified that the standing behavior must also cover visual communications and storytelling, including live-query HTML documents whose interaction carries the narrative. This rule codifies the complete standing expectation."@en ;
     schema:dateCreated "2026-06-14T00:00:00Z"^^xsd:dateTime .

--- a/agent-rdf-memory/howto/virtuoso-license-manager-restart-order.ttl
+++ b/agent-rdf-memory/howto/virtuoso-license-manager-restart-order.ttl
@@ -1,0 +1,24 @@
+@prefix : <#> .
+@prefix schema: <http://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix onto: <../ontology.ttl#> .
+
+<> a schema:HowTo ;
+    schema:name "Virtuoso license-manager restart order"@en ;
+    schema:description "Diagnosing LI100 'Number of licensed connections exceeded' and similar license-manager-contact failures on a Virtuoso server that is otherwise healthy: the fix is restarting the Virtuoso server itself, not just the license manager daemon."@en ;
+    schema:dateCreated "2026-08-23T18:30:00Z"^^xsd:dateTime ;
+    rdfs:seeAlso <../preferences.ttl#step-virtuosoLicenseManagerRestartOrder> .
+
+:step-diagnoseLI100 a schema:HowToStep ;
+    schema:position 1 ;
+    schema:name "LI100 / 'Unable to contact the OpenLink License Manager' on an otherwise-healthy Virtuoso instance is almost always a stale license grant from server startup, not a real capacity or licensing problem"@en ;
+    schema:description "User correction, 2026-08-23: 'this kind of issue is typically due to the fact that the Virtuoso server wasn't restarted following a license manager restart to incorporate new licenses (Virtuoso or UDA).' Prior to this, the agent misdiagnosed the symptom as the whole Virtuoso instance being down and began restarting oplmgr (the OpenLink License Manager daemon) as a first move — overreach the user flagged, since the instance's HTTP/SPARQL endpoint (port 8890) was answering 200 the whole time. Restarting oplmgr alone does NOT clear the error: Virtuoso checks out its license grant once at its own process startup and caches that state for the life of the process. If oplmgr was restarted (or new/updated .lic files were dropped into the license directory) AFTER Virtuoso last started, Virtuoso keeps using its stale in-memory license state and continues failing new SQL/ISQL-protocol (port 1111-class) connections with LI100, even though oplmgr itself is now healthy and the license file is well within its limits (verified in this incident: 20 connections licensed, only 1 actually open, no expiry set)."@en ;
+    schema:workExample """Correct diagnostic order for LI100 / license-manager-contact failures:
+1. Confirm the instance is actually healthy via a non-ISQL path first (curl the HTTP/SPARQL endpoint, e.g. `curl -s -o /dev/null -w '%{http_code}' http://localhost:8890/sparql` should be 200). If it is, this is NOT a full-outage — say so, don't escalate to daemon restarts.
+2. Check whether oplmgr (or the Virtuoso instance's license files) were touched/restarted more recently than the Virtuoso server process itself (compare `ps -o etime` / process start time against oplmgr restart time or .lic file mtimes).
+3. If oplmgr is newer than the Virtuoso server process, the fix is to restart the VIRTUOSO SERVER ITSELF (the specific instance hitting the error, e.g. the 'shop-database' instance on port 1111/8890/443), not to keep restarting oplmgr. Restarting oplmgr again when it is already running and reachable does nothing for an already-stale Virtuoso process.
+4. Only restart oplmgr first if oplmgr itself is confirmed down/unreachable (e.g. not in `ps aux`, or not listening on its port) — and even then, still expect to restart the Virtuoso server afterward if the server had ever connected under the old license state.
+5. A Virtuoso server restart is service-affecting (drops open connections, briefly interrupts the SPARQL/HTTP endpoint too) — confirm with the user before doing it, same as any other service-affecting action.""" ;
+    onto:hasTrigger onto:triggerUserCorrection ;
+    rdfs:seeAlso <../preferences.ttl#step-virtuosoLicenseManagerRestartOrder> .

--- a/agent-rdf-memory/index.ttl
+++ b/agent-rdf-memory/index.ttl
@@ -6,7 +6,7 @@
 <> a schema:CreativeWork ;
     schema:name "Agent Session Index"@en ;
     schema:description "Index of all agent sessions with references to session files."@en ;
-    schema:dateModified "2026-08-19T23:59:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-08-24T22:42:44Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:about :sessionIndex .
 
@@ -1548,3 +1548,72 @@
     schema:description "Generated an RDF-Turtle + HTML infographic collection (Turtle only per Step 165; no MD requested) from Kingsley Uyi Idehen's Medium post 'Conceptual Relational Data Virtualization, using Existing Open Standards' (2018-04-27). Content captured via r.jina.ai reader proxy (Cloudflare blocked curl and PinchTab; Wayback snapshot also confirmed). 679-triple TTL: TechArticle, 7 sections, 8 concepts, 3 IntegrationApproach x 8 cdx:ComparisonDimension (corpus-canonical class reused), 12 FAQ, 12-term primary-DBpedia glossary, 7-step HowTo with absolute post: IRIs, 4 SPARQL recipes (2 are the article's own virtrdf Quad Map + URIBurner R2RML queries), distinct owl:Ontology, prov chain. HTML per Intelligence Network Editorial Aesthetic (Step 244 standing default): Relational-Graph Bridge hero SVG, 4-tier layered-pipeline HowTo SVG, dual-presentation 3x8 comparison, animated FAQ, glossary grid, D3 v7 KG Explorer (35 nodes/46 edges, 0 orphans), open-by-default SPARQL workbench, glass nav, theme toggle, 8-item attribution. Gates: validate-harness-contract.py 0 failures, validate-kg-compliance.sh 19/19, node --check clean, shot-scraper browser verification at 1440px/390px (dual-presentation switch, zero horizontal overflow after .wb-row min-width:0 + overflow-x:hidden CSS patch). Builder suite forked to _build/conceptual-data-virtualization/. :ArchitecturalTier and :IntegrationApproach registered as corpus re-mints in entities/ontology-terms.ttl. Deliverables: rdf/conceptual-data-virtualization-sql-rdf-deepseek_v4flash-1.ttl, webpages/conceptual-data-virtualization-sql-rdf-deepseek_v4flash-1.html."@en .
 
 :sessionIndex schema:itemListElement :session20260821DeepSeekV4FlashConceptualVirtualization .
+
+# ── 2026-08-22: Gemini 3.7 Flash + Antigravity — Beyond the Agent Marketplace (Granular Digital Commodities) ──
+
+:session20260822GeminiDigitalCommodities a schema:ListItem ;
+    schema:position 1145 ;
+    schema:item <sessions/2026-08-22-gemini_3_7_flash-antigravity.ttl> ;
+    schema:name "Session 2026-08-22 (Gemini 3.7 Flash + Antigravity — Beyond the Agent Marketplace: Granular Digital Commodities Collection)"@en ;
+    schema:description "Synthesized and generated a complete Knowledge Graph, Markdown companion, and interactive HTML Infographic collection on expanding the Agent Marketplace into a decentralized Digital Commodities Marketplace for Data, Information, and Knowledge. Grounded in x402 micropayments (EIP-3009), Circle batching middleware, and Linked Open Agentic Commerce (LOAC). Explicitly detailed the 3 Digital Commodity classes: (1) Protected Files (documents, datasets, skill bundles), (2) Service Endpoints (stateless API routes, analytical solvers), and (3) Named Graphs (graph DBMS hosted knowledge graphs, SPARQL query slices, and reasoning axioms). Deliverables placed in /Users/kidehen/Documents/LLMs/Google Gemini Generated/ (rdf/, md/, webpages/)."@en .
+
+:sessionIndex schema:itemListElement :session20260822GeminiDigitalCommodities .
+
+# ── 2026-08-24: Gemini 3.7 Flash + Antigravity — Scaling AI for the Enterprise (Control Plane, Last-Mile Security, RDF Memory Meshup) ──
+
+:session20260824GeminiControlPlaneLastMileMeshup a schema:ListItem ;
+    schema:position 1146 ;
+    schema:item <sessions/2026-08-24-gemini_3_7_flash-antigravity.ttl> ;
+    schema:name "Session 2026-08-24 (Gemini 3.7 Flash + Antigravity — Scaling AI for the Enterprise: Control Plane Architecture, Last-Mile Security, and RDF Memory Meshup)"@en ;
+    schema:description "Generated a comprehensive RDF Knowledge Graph, interactive HTML Infographic with D3.js v7 KG Explorer & SPARQL Workbench, and companion Markdown document synthesizing Suvankar Mazumder's 'Scaling AI in the Enterprise' series overview and 'Part 2: Securing the Last Mile' with OpenLink Software's Agent RDF Memory harness. Mapped out how Agent RDF Memory operationalizes Mazumder's 5 Pillars of the Enterprise AI Control Plane (Approval Gates, Scoped Permissions, Audit Trails, State Rollback, and Evaluation Harness) and secures inference transactions using WebID-TLS cryptographic delegation and SPARQL query governance. Deliverables placed in /Users/kidehen/Documents/LLMs/Google Gemini Generated/ (rdf/, md/, webpages/). Passed validate-harness-contract.py with 0 failures."@en .
+
+:sessionIndex schema:itemListElement :session20260824GeminiControlPlaneLastMileMeshup .
+
+:session20260824DeepSeekV4ProPiDavUpload a schema:ListItem ;
+    schema:position 1147 ;
+    schema:item <sessions/2026-08-24-deepseek_v4pro-pi.ttl> ;
+    schema:name "Session 2026-08-24 (DeepSeek V4 Pro + pi — URIBurner DAV publication of conceptual-data-virtualization-semantic-layers-gpt5-codex-1 collection)"@en ;
+    schema:description "Uploaded the gpt5-codex conceptual-data-virtualization-semantic-layers HTML + Turtle collection to the URIBurner DAV publication location (https://linkeddata.uriburner.com:5443/DAV/demos/daas/) via mTLS/WebID-TLS PUT with principal link-in-bio-credentials-5 cert.p12 (passphrase from macOS Keychain item uriburner-p12, never printed). First batch hit a transient DAV issue (HTML PUT 201 yet public GET 404; TTL PUT 500) — re-PUT both to 201 and confirmed public :443 GET 200 byte-exact (HTML 381,779 B; TTL 88,789 B). Lesson: always re-verify with a public GET after DAV PUT, since 201 does not guarantee immediate readability."@en .
+
+:sessionIndex schema:itemListElement :session20260824DeepSeekV4ProPiDavUpload .
+
+
+# ── 2026-08-24-2: DeepSeek V4 Flash + dsh — Scaling AI in the Enterprise x Agent RDF Memory Control Plane Alignment Meshup ──
+
+:session20260824DeepSeekV4FlashControlPlaneMeshup a schema:ListItem ;
+    schema:position 1147 ;
+    schema:item <sessions/2026-08-24-deepseek_v4flash-dsh-2.ttl> ;
+    schema:name "Session 2026-08-24-2 (DeepSeek V4 Flash + dsh — Scaling AI in the Enterprise x Agent RDF Memory Control Plane Alignment Meshup)"@en ;
+    schema:description "Generated an RDF-Turtle + HTML infographic meshup collection meshing Suvankar Mazumder's 'Scaling AI in the Enterprise' series (Series Overview + Part 2: Securing the Last Mile, captured via the author's RSS feed after Cloudflare blocked curl and PinchTab's daemon could not create its profile dir under the sandbox) with the agent-rdf-memory skill. Critical requirement delivered as explicit RDF: 13 ControlPlaneAlignment instances mapping the 5 control-plane pillars, 3 inference vulnerabilities, and 5 last-mile security layers to concrete agent-rdf-memory components (preferences.ttl elicitation gates, WebID-TLS identity + delegated PKCS#12 credentials, session files + index ledger, durable memory checkpoints, scripts/ compliance gates, retrieval protocol, secret-hygiene storage rules, per-task scoped authorization). 1074-triple TTL (validate-kg-compliance.sh 19/19) + harness-validated 415KB HTML (validate-harness-contract.py 0 failures) with dual-presentation blueprint-vs-implementation matrix (9 cdx:ComparisonDimension aspects), 13 alignment sections, 15 FAQ, 14-term glossary (5 DBpedia primaries), 7-step HowTo, 222-node/693-link KG Explorer, single Turtle format tab. Deliverables: rdf/scaling-ai-enterprise-control-plane-meshup-deepseek_v4flash-1.ttl, webpages/scaling-ai-enterprise-control-plane-meshup-deepseek_v4flash-1.html."@en .
+
+:sessionIndex schema:itemListElement :session20260824DeepSeekV4FlashControlPlaneMeshup .
+
+# ── 2026-08-24-2: ox-alpha + OpenCode — Scaling AI x Agent RDF Memory Control Plane Alignment Meshup (ox-alpha edition) ──
+
+:session20260824OxAlphaControlPlaneMeshup a schema:ListItem ;
+    schema:position 1148 ;
+    schema:item <sessions/2026-08-24-ox_alpha-opencode-2.ttl> ;
+    schema:name "Session 2026-08-24-2 (ox-alpha + OpenCode — Scaling AI in the Enterprise x Agent RDF Memory Control Plane Alignment Meshup)"@en ;
+    schema:description "ox-alpha edition of the same-day Scaling AI control-plane meshup brief (DeepSeek V4 Flash sibling edition recorded at position 1147). LLM-Direct-authored RDF-Turtle (984 triples) under the Intelligence Network Editorial Aesthetic standing default (Step 244), meshing the Series Overview and Part 2 with agent-rdf-memory via eight typed AlignmentMapping instances (cdx:ComparisonDimension subclass) each carrying Control Plane / memory-harness / shared-principle columns plus alignsWithPillar and implementedBy links to eight MemoryComponent entities; arm:this reused via bound prefix per grok-bot precedent. Content captured via r.jina.ai retry ladder after Cloudflare 403s (Wayback empty, freedium unreachable); Intel TDX page unverifiable so modeled without schema:url. HTML: token-flow hero bridge, dual-presentation eight-row alignment matrix, layered-pipeline HowTo SVG across five defense bands, 14 FAQ, 25-term glossary (11 authority-primary subjects incl. dbr:Prompt_injection, RFC 9449 DPoP, W3C Turtle/SPARQL), 45-node/50-link KG Explorer zero orphans, SPARQL workbench open-by-default. validate-harness-contract.py PASS after generator-level fixes (JSON-LD prov:actedOnBehalfOf; SVG ampersand XML validity). Deliverables: {LLM_ROOT}/Ox Alpha/rdf|webpages/scaling-ai-enterprise-agent-rdf-memory-meshup-ox_alpha-1.{ttl,html}; project memory in projects/scaling-ai-agent-rdf-memory-control-plane-meshup.ttl."@en .
+
+:sessionIndex schema:itemListElement :session20260824OxAlphaControlPlaneMeshup .
+
+# ── 2026-08-24-11: DeepSeek V4 Flash + dsh — virtuoso-opentofu RDF + HTML Collection ──
+
+:session20260824DeepSeekV4FlashVirtuosoOpentofu a schema:ListItem ;
+    schema:position 1149 ;
+    schema:item <sessions/2026-08-24-deepseek_v4flash-dsh-11.ttl> ;
+    schema:name "Session 2026-08-24-11 (DeepSeek V4 Flash + dsh — virtuoso-opentofu RDF + HTML Collection)"@en ;
+    schema:description "Generated RDF-Turtle + JSON-LD (592 triples, rdflib-verified equivalent) and harness-validated HTML infographic (134 KB) for OpenLinkSoftware/virtuoso-opentofu — self-managed OpenTofu deployment scripts for Virtuoso Universal Server across AWS, Azure, and Google Cloud. Source: GitHub API metadata + README.md (repo created 2026-08-24). 4 provider schema:Service baselines (aws/, azure/, azure/aci/ experimental, gcp/), DBpedia-first org/software denotation (11 IRIs verified 200), OpenTofu homepage #this, 6 cdx:ComparisonDimension aspects reused via bound prefix with 18 approach leaves under a distinct owl:Ontology, 8-step HowTo with absolute post: IRIs, 14 FAQ, 16-term glossary, 4 SPARQL recipes, full prov chain with prov:actedOnBehalfOf. HTML: dual-presentation 3x6 comparison matrix, D3 v7 KG Explorer (50 nodes / 70 links / 0 orphans), SPARQL workbench, floating nav, theme toggle, hero-meta delegation line all parties hyperlinked. Gates: validate-harness-contract.py PASS 0 failures, node --check clean, HTMLParser clean, zero %2523 double-encodings, grep gates passed. Deliverables: rdf/virtuoso-opentofu-deepseek_v4flash-1.{ttl,jsonld}, webpages/virtuoso-opentofu-deepseek_v4flash-1.html."@en .
+
+:sessionIndex schema:itemListElement :session20260824DeepSeekV4FlashVirtuosoOpentofu .
+
+# ── 2026-08-24: Claude Opus 5 + Claude Code — virtuoso-opentofu RDF + HTML + MD Collection ──
+
+:session20260824ClaudeOpus5VirtuosoOpentofu a schema:ListItem ;
+    schema:position 1150 ;
+    schema:item <sessions/2026-08-24-claude_opus_5-claude_code.ttl> ;
+    schema:name "Session 2026-08-24 (Claude Opus 5 + Claude Code — virtuoso-opentofu RDF + HTML + MD Collection)"@en ;
+    schema:description "Claude Opus 5 edition of the OpenLinkSoftware/virtuoso-opentofu collection (a DeepSeek V4 Flash edition was generated separately the same day, session 2026-08-24-11, routed to DeepSeek/). 765-triple Turtle, zero blank nodes, one owl:Ontology entity distinct from and differently named to the document entity. DOAP adopted for the repository after the ontology-discovery gate ran with prefix.cc unreachable (HTTP 000) — namespace dereferenced and its 58 terms inspected directly, then presented for accept/reject. Reused cdx:ComparisonDimension, kpx:KeyPrinciple, and oqx:OpenQuestion by bound prefix; minted 5 classes + 6 properties for the deployment-baseline domain, each fully characterised with a verified external cross-reference. 14 FAQ, 16 glossary terms, 8 HowTo steps, 6 sample queries. HTML ported from the newest same-model artifact (neo4j-graph-technology-vs-virtuoso-rdf-claude_opus_5-1.html, same day) with only kgData (202 nodes / 436 links), the sample queries, and the body new, built by a Python pipeline that derives both from the companion TTL. THREE inherited template defects found by live browser measurement while both validators stayed green: --accent at #00b4ff in BOTH themes gave every entity link 2.34:1 on the light page (fixed to #0b6fa4, 5.49:1 light / 10.42:1 dark); the floating nav had the manual-hide, fade, manuallyHidden guard and reactivation marker but no resize rule at all; and 199px of horizontal overflow at 390px from an unprotected pre.sparql-code and a native select sized to its longest option label. validate-harness-contract.py PASS; validate-kg-compliance.sh 19/20 with the single FAIL being the Step 212 documented CURIE false positive, left unexpanded. Deliverables: rdf/, webpages/, md/ virtuoso-opentofu-self-managed-deployments-claude_opus_5-1.{ttl,html,md}. Companion TTL not yet uploaded to the URIBurner DAV collection."@en .
+
+:sessionIndex schema:itemListElement :session20260824ClaudeOpus5VirtuosoOpentofu .

--- a/kg-generator/SKILL.md
+++ b/kg-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: kg-generator
-description: "Generate comprehensive Knowledge Graphs (RDF-Turtle by default, or JSON-LD and other RDF serializations on request) from content at file: or http(s): scheme URLs. Uses curated prompt templates: a Generic template for general web content (producing JSON-LD); a Business and Market Analysis template for strategy/analysis content (RDF-Turtle with NAICS codes, lightweight ontology, FAQ, glossary, HowTo); a Conference and Event Recap template for conference write-ups, panel summaries, and case-study-driven narrative articles (RDF-Turtle with case-study/panel/quotation ontology); a Thesis and Framework Article template for opinion pieces proposing a named framework, with optional agent-authored critical-perspective response; a Social Media Post and Comment Thread template for a post plus its full comment thread; and a News Article with Framework Commentary template for third-party news articles with an optional agent-authored framework-application lens. Trigger when users ask to: generate a knowledge graph, generate RDF or RDF-Turtle, generate JSON-LD, convert a URL to structured semantic data, or extract schema.org data from a page or document."
+description: "Generate comprehensive Knowledge Graphs from file: or http(s): sources, using RDF-Turtle by default or another requested RDF serialization. Supports general documents, business and market analysis, event recaps, thesis and framework articles, social-media threads, and news commentary. Use when asked to generate a knowledge graph, create RDF or JSON-LD, convert a URL to semantic data, or extract schema.org data from a page or document."
 ---
 
 # Knowledge Graph Generator Skill
@@ -25,6 +25,12 @@ Generate comprehensive, standards-compliant Knowledge Graphs from any `file:` or
 This skill is a Knowledge Graph generation entry point. For document/source-to-RDF requests, interpret the request through the `document-to-kg-skill` **Document-to-KG Harness Mode** contract when that skill is available. For requests that also ask for HTML, Markdown, an infographic, or a KG Explorer, hand off to the `rdf-infographic-skill` **RDF Infographic Harness Mode** after RDF generation.
 
 Do not let this skill drift into standalone HTML generation, source summarization, or manually invented graph visualization. RDF remains the source of truth, and companion HTML/Markdown artifacts must satisfy the RDF/HTML/MD pairing contract in `rdf-infographic-skill`.
+
+### Narrative and Visual-Communication Contract
+
+When the RDF will drive a reader-facing document, model a coherent evidence-backed narrative spine rather than an undifferentiated fact inventory. Preserve the source's thesis, contrasts, causal chain, quantitative evidence, limitations, and conclusion as ordered, queryable entities and relationships. Model comparison dimensions, metric observations, claims, provenance, and SPARQL recipes explicitly so the companion document can communicate them through the most appropriate visual form.
+
+For any visual or interactive companion, operate as a UI/UX expert, visual-communications designer, and storyteller, and inherit the full `rdf-infographic-skill` operating modality. The reader journey must determine hierarchy and pacing; tables serve exact comparisons, flows serve sequence or causality, diagrams serve architecture, charts serve quantitative patterns, and prose serves interpretation. Live SPARQL interaction is part of the story surface when it lets readers test or extend the document's claims; it must not be relegated to decorative or disconnected query text.
 
 If this skill produces or templates any HTML directly, it must inherit the `rdf-infographic-skill` open-tab contract: every generated HTML `<a>` whose `href` is not a same-page fragment (`#section`) uses `target="_blank" rel="noopener noreferrer"`, while same-page fragment navigation remains same-tab. Attribution links must hyperlink the attributed label itself, not generic labels such as `Visit` or `Learn more`.
 

--- a/rdf-infographic-skill/SKILL.md
+++ b/rdf-infographic-skill/SKILL.md
@@ -8,11 +8,14 @@ license: MIT
 
 ## Operating Modality — Read This First
 
-**You are a modern UI/UX expert and visual designer** for the duration of any task that uses this skill. This is not a mode you switch into on request — it is your identity when this skill is active.
+**You are a modern UI/UX expert, visual-communications designer, and storyteller** for the duration of any task that uses this skill. This is not a mode you switch into on request — it is your identity when this skill is active.
 
 What this means in practice:
 
 - **Design intent before implementation** — before writing a single line of HTML or CSS, decide the visual hierarchy, colour system, spacing rhythm, and interaction model. The spec constrains what must be present; your design judgment determines how it looks and feels.
+- **Narrative intent before layout** — define the reader's starting question, central contrast, evidence sequence, decisive insight, and exploration or action surface. Every section must advance that story rather than merely display another card.
+- **Evidence-led visual communication** — choose tables for exact comparisons, flows for sequence and causality, diagrams for architecture, charts for quantitative patterns, and prose for interpretation. Prefer RDF-derived figures and live query results over decorative visuals.
+- **Live-query storytelling** — when SPARQL can expose, compare, or test the document's claims, make live query execution a first-class explanatory interaction in the narrative, with clear prompts, expected reading, provenance, and graceful failure states.
 - **Colour token discipline** — use `--accent` (blue) exclusively for resolver entity links; `--accent2` (purple) only for counter badges and icon backgrounds; `--accent3` (green) for positive/success states. Never use accent colours interchangeably.
 - **Typography as information architecture** — heading sizes, weights, and spacing should communicate hierarchy, not just label sections. Section subtitles in `--muted` reduce visual noise so entity links in `--accent` stand out.
 - **Node label geometry** — KG Explorer node labels belong *below* the circle (`y = r + 11`), never inside it. Text width at any readable font size exceeds a small circle diameter. Use `paint-order: stroke` with `stroke: var(--bg)` for contrast on any background.

--- a/screencast-recorder/SKILL.md
+++ b/screencast-recorder/SKILL.md
@@ -175,6 +175,23 @@ Default voice for male narration is **onyx**; use **coral** (or another OpenAI T
 
 The script requires `OPENAI_API_KEY` and the Python `openai` package. If local Python dependencies are broken, tell the user clearly and either repair the environment with approval or ask them to provide an externally generated MP3.
 
+#### Fallback: local/offline narration via Piper
+
+If OpenAI TTS is unreachable (no API key, out of quota, network down) and the user wants to proceed without waiting, offer `scripts/screencast-piper-voiceover.py` as a local, offline alternative. It is an **optional dependency** -- nothing installs at skill-load time. The script installs `piper-tts` (pip) and downloads the requested voice model (one-time, ~50-120MB depending on quality tier) only when actually run, and only if not already cached under `~/.cache/piper-voices/`.
+
+```bash
+python3 scripts/screencast-piper-voiceover.py \
+  --text-file narration.txt \
+  --output "{SCREENCAST_DIR}/{filename}-voiceover.mp3" \
+  --voice en_US-ryan-high
+```
+
+Default voice for male narration is **en_US-ryan-high** (highest quality tier). Other male options: `en_US-norman-medium`, `en_US-bryce-medium`, `en_US-hfc_male-medium`, `en_GB-alan-medium`, `en_GB-northern_english_male-medium`. Full voice list: https://huggingface.co/rhasspy/piper-voices/tree/main/en
+
+**Known limitation, state this to the user before using it:** Piper has no style/instructions prompt -- it is fixed-voice, fixed-prosody synthesis. There is no way to ask for "steady, unhurried power" or any other delivery style the way the OpenAI path's `--instructions` allows. The script's defaults (`--length-scale 1.05`, `--noise-scale 0.5`, `--noise-w-scale 0.6`, all tuned down/up from Piper's own stock defaults of 1.0/0.667/0.8) are the closest numeric PROXY for a steady, measured delivery -- flatter variation and a touch slower pace -- but this is an approximation, not real style control. It cannot add emphasis, warmth, urgency, or any other directed quality; the voice choice itself carries most of the tone. If the user needs precise, describable style control, OpenAI TTS (or another cloud provider) remains the better fit -- Piper is for when a narration is needed and no cloud TTS is reachable, not a drop-in style-equivalent replacement.
+
+The upstream project (`OHF-Voice/piper1-gpl`) is GPL-3.0 licensed. That is not a practical concern for local, personal use of the installed tool, but do not bundle/redistribute the package or voice models as part of a shipped product without checking license compatibility first.
+
 After the user approves the MP3, mux it into the MP4 while preserving captions:
 
 ```bash

--- a/screencast-recorder/scripts/screencast-piper-voiceover.py
+++ b/screencast-recorder/scripts/screencast-piper-voiceover.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Generate an MP3 voice-over for a screencast using Piper (local, offline TTS).
+
+Optional dependency: nothing installs at skill-load time. This script installs
+`piper-tts` (pip) and downloads the requested voice model (one-time, ~50-120MB
+depending on quality tier) only when actually run -- and only if not already
+present. Use this as a fallback when OpenAI TTS is unreachable or out of quota.
+
+Trade-off vs. the OpenAI path: Piper has no style/instructions prompt. It is
+fixed-voice, fixed-prosody synthesis -- only speed (--length-scale), variation
+(--noise-scale / --noise-w-scale), and volume are tunable. There is no way to
+ask for "steady, unhurried power" the way screencast-openai-voiceover.py's
+--instructions can.
+
+This script's defaults are tuned as the closest numeric PROXY for a steady,
+measured, "in-control" delivery -- flatter variation (lower noise scales) and
+a touch slower than Piper's stock defaults (noise_scale=0.667, noise_w_scale=
+0.8, length_scale=1.0). It is an approximation, not real style control: it
+cannot add emphasis, warmth, urgency, or any other directed quality. If the
+narration needs a genuinely different delivery style, that requires a cloud
+TTS with a style prompt (OpenAI, ElevenLabs, Azure's SSML express-as, etc.),
+not a Piper flag change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import wave
+from pathlib import Path
+
+DEFAULT_VOICE = "en_US-ryan-high"
+VOICE_CACHE_DIR = Path.home() / ".cache" / "piper-voices"
+
+
+def read_text(value: str | None, file_path: str | None) -> str:
+    if value and file_path:
+        raise SystemExit("Use either --text or --text-file, not both.")
+    if file_path:
+        return Path(file_path).read_text(encoding="utf-8").strip()
+    if value:
+        return value.strip()
+    raise SystemExit("Provide narration with --text or --text-file.")
+
+
+def ensure_piper_installed() -> None:
+    try:
+        import piper  # noqa: F401
+        return
+    except ImportError:
+        pass
+    print("piper-tts not installed -- installing now (pip install piper-tts)...", file=sys.stderr)
+    subprocess.run([sys.executable, "-m", "pip", "install", "--quiet", "piper-tts"], check=True)
+
+
+def ensure_voice_downloaded(voice: str, data_dir: Path) -> Path:
+    model_path = data_dir / f"{voice}.onnx"
+    config_path = data_dir / f"{voice}.onnx.json"
+    if model_path.exists() and config_path.exists():
+        return model_path
+    data_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Voice model {voice} not found in {data_dir} -- downloading now...", file=sys.stderr)
+    subprocess.run(
+        [sys.executable, "-m", "piper.download_voices", voice, "--data-dir", str(data_dir)],
+        check=True,
+    )
+    if not model_path.exists():
+        raise SystemExit(f"Download completed but {model_path} still missing -- check voice name.")
+    return model_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate an MP3 narration track for a screencast using local Piper TTS."
+    )
+    parser.add_argument("--text", help="Narration text to synthesize.")
+    parser.add_argument("--text-file", help="UTF-8 file containing narration text.")
+    parser.add_argument("--output", required=True, help="Output MP3 path.")
+    parser.add_argument(
+        "--voice",
+        default=DEFAULT_VOICE,
+        help=f"Piper voice name, e.g. en_US-ryan-high, en_US-norman-medium, "
+             f"en_GB-alan-medium (default: {DEFAULT_VOICE}).",
+    )
+    parser.add_argument(
+        "--data-dir",
+        default=str(VOICE_CACHE_DIR),
+        help=f"Directory to cache/download voice models (default: {VOICE_CACHE_DIR}).",
+    )
+    parser.add_argument(
+        "--length-scale",
+        type=float,
+        default=1.05,
+        help="Speed multiplier; >1.0 is slower, <1.0 is faster "
+             "(default: 1.05 -- a touch slower than Piper's stock 1.0, for a more "
+             "deliberate/steady pace; not real style control, see module docstring).",
+    )
+    parser.add_argument(
+        "--noise-scale",
+        type=float,
+        default=0.5,
+        help="Pitch/audio variation; lower is flatter/steadier "
+             "(default: 0.5, down from Piper's stock 0.667, for an evener delivery).",
+    )
+    parser.add_argument(
+        "--noise-w-scale",
+        type=float,
+        default=0.6,
+        help="Speaking-rate variation; lower is more even/metronomic "
+             "(default: 0.6, down from Piper's stock 0.8).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    narration = read_text(args.text, args.text_file)
+    output = Path(args.output).expanduser().resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    if shutil.which("ffmpeg") is None:
+        raise SystemExit("ffmpeg is required to convert Piper's WAV output to MP3.")
+
+    ensure_piper_installed()
+
+    from piper import PiperVoice
+    from piper.config import SynthesisConfig
+
+    data_dir = Path(args.data_dir).expanduser()
+    model_path = ensure_voice_downloaded(args.voice, data_dir)
+
+    voice = PiperVoice.load(str(model_path))
+    syn_config = SynthesisConfig(
+        length_scale=args.length_scale,
+        noise_scale=args.noise_scale,
+        noise_w_scale=args.noise_w_scale,
+    )
+
+    wav_path = output.with_suffix(".wav")
+    with wave.open(str(wav_path), "wb") as wav_file:
+        voice.synthesize_wav(narration, wav_file, syn_config=syn_config)
+
+    subprocess.run(
+        ["ffmpeg", "-y", "-i", str(wav_path), "-codec:a", "libmp3lame", "-qscale:a", "2",
+         str(output), "-loglevel", "error"],
+        check=True,
+    )
+    wav_path.unlink()
+
+    print(
+        f"Wrote {output}  (voice={args.voice}, length_scale={args.length_scale}, "
+        f"noise_scale={args.noise_scale}, noise_w_scale={args.noise_w_scale} -- "
+        f"numeric proxy for steady delivery, not real style control; see module docstring)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/wc2026-match-report/SKILL.md
+++ b/wc2026-match-report/SKILL.md
@@ -1,8 +1,13 @@
+---
+name: wc2026-match-report
+description: "Generate a complete single-file HTML intelligence report for the FIFA World Cup 2026 from live Knowledge Graph data. Three report types: match report (a fixture, Team A vs Team B), player report (a single player across the tournament), and analytics scatter report (tournament-wide player comparisons). Pick the player report for single-person requests and the analytics scatter report for cross-player metric comparisons; everything else defaults to the match report."
+version: 1.2.0
+license: AGPL-3.0
+---
+
 # FIFA World Cup 2026 Match Intelligence Report Skill
 
-**Name:** `wc2026-match-report`  
-**Version:** 1.2.0  
-**Description:** Generate a complete single-file HTML intelligence report for the FIFA World Cup 2026 from live Knowledge Graph data. Three report types:
+Three report types:
 
 | Type | Subject | Script |
 |---|---|---|


### PR DESCRIPTION
Three unrelated bodies of work that had accumulated uncommitted in the working tree from sessions on 2026-08-22 through 2026-08-24, across several models. Kept as three separate commits — each is independently reviewable and they share nothing but the fact that they were pending.

### 1. `ac85821` — Step 44 persona widened to visual communication and storytelling

Retitles the standing default and adds `:stepVisualStorytelling` (position 8): define the reader's starting question, the central contrast, the evidence sequence, the decisive insight, and the action surface *before* implementation, rather than laying facts out and hoping a narrative emerges.

The memory rule and the two skills that enact it are changed **together** — `rdf-infographic-skill/SKILL.md` (persona sentence) and `kg-generator/SKILL.md` (new Narrative and Visual-Communication Contract). Splitting them would leave the corpus asserting one definition of the persona and the skills another.

### 2. `8767fb6` — screencast-recorder offline Piper TTS fallback

Adds `scripts/screencast-piper-voiceover.py` for when OpenAI TTS is unreachable, with `en_US-ryan-high` as the default male voice.

The script and the SKILL.md section documenting it are committed together — the docs were written in a prior session but the script was never `git add`ed, so landing the docs alone would have shipped a reference to a file absent from the repo.

Two limitations are documented rather than glossed: Piper is fixed-voice, fixed-prosody with no style prompt, so the tone direction OpenAI TTS accepts simply isn't available; and upstream `OHF-Voice/piper1-gpl` is GPL-3.0, fine for local personal use but not to be bundled or redistributed.

### 3. `2e54a54` — memory corpus growth + wc2026 frontmatter

Seven `index.ttl` session records (Gemini 3.7 Flash, DeepSeek V4 Pro/Flash, ox-alpha, Claude Opus 5), two new howtos, and a `wc2026-match-report/SKILL.md` change moving name/description/version/license into YAML frontmatter so the metadata is machine-readable.

---

All five touched `.ttl` files parse-validated via rdflib. None of the four affected skills has a `.zip` bundle in the repo, so no bundles needed repackaging.

Related: the Ox Alpha output path, also pending from this batch, went to #103 instead — its companion `core.ttl` entry was already committed there and the two halves belong together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)