### PR TITLE
Resolve 5 schema:position collisions in preferences.ttl

### DIFF
--- a/agent-rdf-memory/preferences.ttl
+++ b/agent-rdf-memory/preferences.ttl
@@ -3074,7 +3074,7 @@ If any check fails, port the CURRENT pattern from the newest compliant file in t
 # position collisions are found and resolved.)
 
 :step-awkIgnorecaseNotPortable a schema:HowToStep ;
-    schema:position 249 ;
+    schema:position 261 ;
     schema:name "Never rely on awk's IGNORECASE variable for case-insensitive matching in a shell pipeline meant to run cross-platform — use grep -i instead"@en ;
     schema:text "2026-08-19: found live-testing the x402-buyer WebID-TLS probe flow — awk 'BEGIN{IGNORECASE=1}/^payment-required:/{...}' had been silently non-functional on macOS since first written. BSD/nawk awk (macOS's default) treats IGNORECASE as an ordinary uninitialized variable with no special meaning; the match stays case-sensitive and never fires against curl's uppercase PAYMENT-REQUIRED: header. No error — just an empty result that reads exactly like 'no such header present,' a false negative for a real, present header. Fixed by replacing with grep -i '^header:' | cut -d: -f2- | tr -d ' \\r' — no GNU-awk dependency. This is a general authoring rule, not a one-off fix: audit any awk BEGIN{IGNORECASE=1} usage authored for a skill meant to run on a user's actual machine." ;
     onto:hasTrigger onto:triggerBehaviorGapIdentified, onto:triggerArtifactGeneration ;
@@ -3088,7 +3088,7 @@ If any check fails, port the CURRENT pattern from the newest compliant file in t
 # found and resolved.)
 
 :step-hyperlinkSparqlUrls a schema:HowToStep ;
-    schema:position 250 ;
+    schema:position 262 ;
     schema:name "Whenever a SPARQL query URL is generated, present it as a clickable hyperlink — never as bare unlinked text"@en ;
     schema:text "2026-08-19: user directive after the llm-routing-skill SPARQL endpoint URL was shown as a long raw string. Rule: every generated SPARQL query URL MUST be emitted as a Markdown/HTML hyperlink with a short human label (e.g. 'Run: code-generation frontier (cheapest first)'), and the URL must be verified to return results before it is presented. FORMAT: SELECT SPARQL URLs use the data-twingler convention — format=text/x-html+tr (percent-encoded as text%2Fx-html%2Btr, since '+' in a raw URL decodes to space), e.g. http://localhost:8890/sparql?default-graph-uri=&query=...&format=text%2Fx-html%2Btr — NOT format=json. Applies to chat responses, generated documents, and skill output alike. See llm-routing-skill SKILL.md SPARQL Query Templates for the query corpus this rule governs."@en ;
     onto:hasTrigger onto:triggerPreferencesUpdate ;
@@ -3108,28 +3108,28 @@ If any check fails, port the CURRENT pattern from the newest compliant file in t
     onto:hasTrigger onto:triggerBehaviorGapIdentified, onto:triggerArtifactGeneration ;
     rdfs:seeAlso <howto/webid-tls-port-5443-default.ttl#step-bash32EmptyArrayBug> .
 
-# ── Step 243: the WebID-TLS redirect-to-402 hop is not universal — some resource types answer 402 directly ──
+# ── Step 258: the WebID-TLS redirect-to-402 hop is not universal — some resource types answer 402 directly ──
 
 :step-webidTlsRedirectNotUniversal a schema:HowToStep ;
-    schema:position 243 ;
+    schema:position 258 ;
     schema:name "Do not assume every WebID-TLS-gated x402 resource 302-redirects through a ?k=... URL before its 402 — a /sparql/ query endpoint answered 402 directly at :5443 with no redirect at all"@en ;
     schema:text "2026-08-19: confirmed with a live probe of an ods-qa.openlinksw.com SPARQL query endpoint (urn:jch:test named graph) — cert accepted on :5443 went straight to 402, no 302/?k= hop, unlike the DAV file resource probed earlier in the same session. A redirect-follow (curl -L) handles both shapes correctly as a no-op when nothing needs following; don't build detection logic that treats an absent redirect as a failure signal." ;
     onto:hasTrigger onto:triggerArtifactGeneration ;
     rdfs:seeAlso <howto/webid-tls-port-5443-default.ttl#step-redirectHopNotUniversal> .
 
-# ── Step 244: x402 Python SDK requires jsonschema even for a plain fetch — validates server-offered extensions before signing ──
+# ── Step 259: x402 Python SDK requires jsonschema even for a plain fetch — validates server-offered extensions before signing ──
 
 :step-x402JsonschemaRequired a schema:HowToStep ;
-    schema:position 244 ;
+    schema:position 259 ;
     schema:name "The x402 Python SDK needs jsonschema + the extensions extra even when the caller uses no extensions — it validates whatever extension the SERVER'S challenge advertises before creating a payment payload"@en ;
     schema:text "2026-08-19: discovered running x402-buyer's first real end-to-end settlement. A challenge advertising eip2612GasSponsoring failed deep inside signing with ImportError: Extensions validation requires jsonschema — after the challenge had already decoded and the buyer address already printed, reading like a mid-run crash rather than a missing dependency. Fixed in every install line across the skill (docstring, SKILL.md, setup.md) plus a troubleshooting.md entry keyed on the exact error text." ;
     onto:hasTrigger onto:triggerArtifactGeneration, onto:triggerBehaviorGapIdentified ;
     rdfs:seeAlso <howto/webid-tls-port-5443-default.ttl#step-jsonschemaRequiredDependency> .
 
-# ── Step 245: verify a payment client's own success report independently against the chain before repeating it ──
+# ── Step 260: verify a payment client's own success report independently against the chain before repeating it ──
 
 :step-verifySettlementIndependently a schema:HowToStep ;
-    schema:position 245 ;
+    schema:position 260 ;
     schema:name "When a payment/settlement client reports success, verify independently against the underlying ledger before repeating the claim — never take the client's self-report as sufficient when real value (even testnet) moved"@en ;
     schema:text "2026-08-19: x402-buyer's first real settlement (ods-qa.openlinksw.com TestFile.txt, $9.99) reported success with a transaction hash. Verified independently via a direct eth_getTransactionReceipt RPC call to the SAME already-established Base Sepolia endpoint the script itself defaults to (never a fresh unverified URL) — confirmed status 0x1, correct ERC-20 Transfer event, correct from/to/amount matching the challenge exactly. A block-explorer URL (sepolia.basescan.org) was tried first, returned 403, and was NOT worked around with a substitute or fabricated URL — fell back to the already-verified RPC endpoint instead, per the no-fabricated-URLs rule. Also checked remaining wallet balance directly via balanceOf() rather than assuming from the settlement amount." ;
     onto:hasTrigger onto:triggerBehaviorGapIdentified, onto:triggerArtifactGeneration ;


### PR DESCRIPTION
Five `schema:position` values in `preferences.ttl` were each held by two `schema:HowToStep`s. That makes "Step N" ambiguous in prose and makes any position-ordered query over the memory graph return a nondeterministic pair.

**Result: 259 steps across 259 distinct positions, zero collisions.**

## How each pair was resolved

The number stays with the step that existing citations actually refer to — established by reading every citation, not by file order. The other moves to a fresh trailing number (max position was 257).

| Position | Keeps it | Why | Moved |
|---|---|---|---|
| 243 | `:step-explorerFollowsGlossary` | cited in `MEMORY.md` + 6 corpus references | `:step-webidTlsRedirectNotUniversal` → **258** |
| 244 | `:step-intelligenceNetworkAesthetic` | cited in `index.ttl` + 12 corpus references | `:step-x402JsonschemaRequired` → **259** |
| 245 | `:step-sparqlWorkbenchOpenByDefault` | cited by `intelligence-network-editorial-aesthetic.ttl` | `:step-verifySettlementIndependently` → **260** |
| 249 | `:step-virtuosoLicenseManagerRestartOrder` | owns its `# ── Step 249:` header comment | `:step-awkIgnorecaseNotPortable` → **261** |
| 250 | `:step-outputRootGateAppliesBeyondKgGenerator` | owns its `# ── Step 250:` header comment | `:step-hyperlinkSparqlUrls` → **262** |

Header comments of the moved steps were updated to their new numbers. Notably, the two moved steps at 249 and 250 **never had a header comment at all** — part of why the collision went unnoticed.

## Citation safety

Every `Step 243/244/245/249/250` reference in `preferences.ttl`, `index.ttl`, the `howto/` corpus, and `MEMORY.md` was read individually and confirmed to refer to the **keeper**. No citation is invalidated, so no external prose needed editing. The moved steps had no citation by number anywhere — only their own header comments.

`sessions/` was excluded as historical record.

`#step-` anchors are name-based, not position-based, so `rdfs:seeAlso` targets are unaffected. My earlier claim that renumbering "would move the `#step-` anchors other documents reference" was wrong — it's the human-facing "Step N" prose that's at risk, which is why the citation sweep above was the actual safety check.

## Precedent

`index.ttl` records an earlier session resolving a collision the same way — renumbering the colliding step to a fresh value (247). This follows that.

Parse-validated: 2422 triples.

Related: #105 adds the collision check that surfaced these, and corrects that check to query the graph rather than grep text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)