### PR TITLE
osdi-inclusion-engine: composite skins, and Path C for the chrome gate

### DIFF
--- a/agent-rdf-memory/howto/artifact-routing.ttl
+++ b/agent-rdf-memory/howto/artifact-routing.ttl
@@ -7,7 +7,7 @@
     schema:name "Artifact Routing — Output Directories and Terminology"@en ;
     schema:description "Rules for routing generated artifacts (RDF, HTML, Markdown) to the correct model-specific output directories, preserving active model identity, and applying the meshup vs mashup terminology rule."@en ;
     schema:dateCreated "2026-06-05T00:00:00Z"^^xsd:dateTime ;
-    schema:dateModified "2026-08-24T14:45:00Z"^^xsd:dateTime ;
+    schema:dateModified "2026-08-26T00:00:00Z"^^xsd:dateTime ;
     schema:author <https://linkedin.com/in/kidehen#this> ;
     schema:step :step-outputDirs, :step-gpt5ChatCodexOutputDirs,
         :step-mashupVsMeshup, :step-defaultOutputRoot, :step-modelOverEnvironment,
@@ -15,7 +15,8 @@
         :step-savedPromptsFolder, :step-vspsFolder,
         :step-screencastDistributionArtifacts,
         :step-screencastPresentationNaming,
-        :step-scopeFilesystemSearchesToLlmRoot, :step-outputRootGateAppliesBeyondKgGenerator ;
+        :step-scopeFilesystemSearchesToLlmRoot, :step-outputRootGateAppliesBeyondKgGenerator,
+        :step-buildFixtureIsStillAnArtifact ;
     rdfs:seeAlso <../preferences.ttl#step-outputDirs>, <../preferences.ttl#step-defaultOutputRoot>, <../preferences.ttl#step-gpt5ChatCodexOutputDirs>, <../preferences.ttl#step-modelOverEnvironment>, <../preferences.ttl#step-modelIdentityPreflight>, <../preferences.ttl#step-noPromptModelOverride>, <../preferences.ttl#step-mashupVsMeshup>, <../preferences.ttl#step-savedPromptsFolder>, <../preferences.ttl#step-vspArtifactsFolder>, <../preferences.ttl#step-screencastDistributionArtifacts>, <../preferences.ttl#step-screencastPresentationNaming>, <../preferences.ttl#step-chatResponsePortableLinks>, <../preferences.ttl#step-remoteRemovalOrder>, <remote-resource-removal.ttl> .
 
 # ── Step 1: Output Directory Routing ─────────────────────────────────────────
@@ -128,3 +129,24 @@ User preference recorded 2026-07-24 for all future screencast operations."""@en 
     schema:name "A drafted chat/forum-reply Markdown file is still a generated artifact subject to step-outputDirs/step-outputRootBlockingGate — scratchpad is never the final destination"@en ;
     schema:text """User correction (2026-08-24): asked to draft a reply for a community.openlinksw.com thread on Virtuoso GQL performance, the agent wrote the .md draft to the session scratchpad directory and left it there after delivering it. All prior recurrences logged under :step-outputRootBlockingGate involved kg-generator or rdf-infographic-skill workflows specifically, which may have narrowed the mental model of when the gate applies to 'KG/infographic generation tasks' rather than 'any generated Markdown/RDF/HTML artifact.' This instance had no kg-generator or rdf-infographic-skill framing at all — it was a plain drafted reply to a technical forum thread, produced by reasoning/research in-conversation, not a skill invocation — yet it is still a generated Markdown deliverable and belongs under {LLM_ROOT}/Claude Generated/md/ per :step-outputDirs, using the model-id filename convention (claude_sonnet_5, not the agent-environment name 'claude_code'), not the session scratchpad. Corrected same-session by moving the file to Claude Generated/md/virtuoso-gql-ingestion-array-optimization-claude_sonnet_5-reply.md and deleting the scratchpad copy. Generalization: the output-root blocking gate is scoped by artifact TYPE — any generated .md/.ttl/.html file meant to persist, be handed to the user as a deliverable, or be posted/sent externally — not by which skill or workflow produced it. A one-off drafted reply, a saved analysis, or a memory-adjacent write-up all qualify equally. Scratchpad remains valid only for genuinely disposable intermediate files that will not be delivered, referenced again, or handed to the user as the finished artifact."""@en ;
     rdfs:seeAlso <../preferences.ttl#step-outputRootGateAppliesBeyondKgGenerator>, <../preferences.ttl#step-outputRootBlockingGate>, <../preferences.ttl#step-outputDirs> .
+
+# ── Step 14: a build fixture inside a source repo is still a generated artifact ──
+
+:step-buildFixtureIsStillAnArtifact a schema:HowToStep ;
+    schema:position "14"^^xsd:integer ;
+    schema:name "Generator output written into a source repo as a 'test fixture' or 'build directory' is subject to step-outputDirs like any other artifact"@en ;
+    schema:text """User correction (2026-08-26): building composite-skin support for the OSDI Inclusion Engine, the agent wrote three kinds of generated output into the inclusion-engine working repo — a rebased RDF site graph (14 .ttl), de-chromed WebDAV content (16 .html), and the rendered site itself (16 .html) — all under infrastructure-tests/composite/{site,out}/, and left them there. User: "You should put production artifacts under the appropriate LLM root subfolder, as per usual."
+
+WHY THIS ONE SLIPPED PAST THE EXISTING GATE: every recurrence logged under :step-outputRootBlockingGate involved a single deliverable produced by an obvious generation workflow (kg-generator, rdf-infographic-skill, a drafted reply). This was different in three ways that each made the output feel like repo-internal scaffolding rather than a deliverable: (1) the files were produced BY scripts that legitimately live in the repo, so output and generator felt like one unit; (2) they sat in a directory named infrastructure-tests/, which reads as test scaffolding, not as a deliverable; (3) they were regenerable, and regenerable output feels like build residue rather than a product. None of those is a valid exemption. The site rendition WAS the deliverable — it was the acceptance test the user set for the whole task.
+
+THE RULE: routing is decided by artifact TYPE (generated .ttl/.md/.html), not by the directory's name, not by whether a generator script sits beside it, and not by whether it can be regenerated. A source repository holds hand-authored source — engine code, XSLT, skin bundles, generator scripts — and never their output. If a generator writes into the repo as an intermediate, gitignore the output directory and add an explicit packaging step that routes the finished artifact to {model-root}/{rdf,md,webpages}/ per :step-outputDirs.
+
+CORRECTED SAME-SESSION by adding infrastructure-tests/composite/package_artifacts.py, which re-renders with a relative asset base, copies the bundle to {LLM_ROOT}/Claude Generated/webpages/openlink-osdi-composite-skin-rendition-claude_opus_5/ and the site RDF to the matching rdf/ subfolder, and by gitignoring site/ and out/. A per-collection subfolder was used rather than 30 flat sibling files because the rendered pages link to each other relatively and need their directory structure preserved — the same grouping allowance :step-vspsFolder already makes for multi-file VSP deliverables.
+
+FILENAME NOTE: the slug carries claude_opus_5 (the active model per the system prompt), not claude_code (the agent environment), per :step-modelOverEnvironment."""@en ;
+    rdfs:seeAlso <../preferences.ttl#step-buildFixtureIsStillAnArtifact>,
+        <../preferences.ttl#step-outputRootBlockingGate>,
+        <../preferences.ttl#step-outputDirs>,
+        :step-outputRootBlockingGate,
+        :step-outputRootGateAppliesBeyondKgGenerator,
+        :step-vspsFolder .

--- a/agent-rdf-memory/preferences.ttl
+++ b/agent-rdf-memory/preferences.ttl
@@ -319,7 +319,7 @@
     schema:name "Destructive Command Guard"@en ;
     schema:description "Standing rule: never execute destructive shell commands. Covers git force operations, recursive deletion, filesystem wipes, fork bombs, and pipe-to-shell patterns."@en ;
     rdfs:seeAlso <howto/destructive-command-guard.ttl> ;
-    schema:step :step-destructiveCommandGuard .
+    schema:step :step-destructiveCommandGuard, :step-buildFixtureIsStillAnArtifact .
 
 # ═══════════════════════════════════════════════════════════════════════════
 # ── Step Definitions (referenced by sub-HowTos above) ────────────────────
@@ -3293,3 +3293,18 @@ Recorded in rdf-infographic-skill/SKILL.md harness item 10 as well as here."""@e
         <howto/remote-resource-removal.ttl>,
         :step-remoteUploadOrder,
         :step-remoteRemovalOrder .
+
+:step-buildFixtureIsStillAnArtifact a schema:HowToStep ;
+    schema:position "263"^^xsd:integer ;
+    schema:name "Generator output written into a source repo as a test fixture or build directory is STILL a generated artifact and routes to the LLM root"@en ;
+    schema:text """Routing is decided by artifact TYPE (a generated .ttl/.md/.html), never by the directory's name, never by the generator script sitting beside it, and never by the output being regenerable.
+
+Caught 2026-08-26 while building composite-skin support for the OSDI Inclusion Engine: a rebased RDF site graph, de-chromed WebDAV content, and a 16-page rendered site were all written into the inclusion-engine repo under infrastructure-tests/composite/{site,out}/ and left there. Three things made that output feel like repo scaffolding rather than a deliverable — the generators legitimately live in the repo, the parent directory is named infrastructure-tests/, and everything was regenerable — and none of them is a valid exemption. That rendered site WAS the deliverable; it was the acceptance test the user set for the task.
+
+PROCEDURE when a generator must write into a repo as an intermediate: gitignore the output directory, and add an explicit packaging step that routes the finished artifact to {model-root}/{rdf,md,webpages}/ per howto/artifact-routing.ttl#step-outputDirs. Group a multi-file collection in a per-artifact subfolder when its members link to each other relatively.
+
+A source repository holds hand-authored source — engine code, XSLT, skin bundles, generator scripts — and never their output."""@en ;
+    rdfs:seeAlso <howto/artifact-routing.ttl>,
+        <howto/artifact-routing.ttl#step-buildFixtureIsStillAnArtifact>,
+        :step-outputRootBlockingGate,
+        :step-outputDirs .

--- a/osdi-inclusion-engine/SKILL.md
+++ b/osdi-inclusion-engine/SKILL.md
@@ -1,27 +1,39 @@
 ---
 name: osdi-inclusion-engine
-description: Operate the OpenLink OSDI Inclusion Engine — the Virtuoso index.vsp + XSLT-skin system that renders openlinksw.com sub-sites (www, virtuoso, uda, ps, ode, shop) from WebDAV content. Use for site registration, config-graph inspection and edits, skin selection or per-URL skin overrides, homepage or page replacement deployment from DAV-hosted mockups, double-chrome conflict detection, cache flushing, and post-deploy verification. Trigger on phrases like "integrate this homepage replacement", "swap the skin for", "register a new OSDI site", "Inclusion Engine config", "flush the incleng cache", or any request to deploy content into an OSDI-based website.
+description: Operate the OpenLink OSDI Inclusion Engine — the Virtuoso index.vsp + skin system that renders openlinksw.com sub-sites (www, virtuoso, uda, ps, ode, shop) from WebDAV content. Use for site registration, config-graph inspection and edits, skin selection or per-URL skin overrides, composite-skin authoring and deployment (manifest + XHTML templates + SPARQL bindings), region suppression, homepage or page replacement deployment from DAV-hosted mockups, double-chrome conflict detection, cache flushing, and post-deploy verification. Trigger on phrases like "integrate this homepage replacement", "swap the skin for", "register a new OSDI site", "Inclusion Engine config", "build a composite skin", "flush the incleng cache", or any request to deploy content into an OSDI-based website.
 ---
 
 # OSDI Inclusion Engine
 
-Use this skill to inspect, configure, and deploy content into websites run by the OpenLink Inclusion Engine (OSDI): a Virtuoso-hosted system where a single `index.vsp` per site resolves `/{page}` requests to `content/{page}.html` in WebDAV, passes the document through HTML Tidy (unless its DOCTYPE is XHTML+RDFa), wraps it with a skin's XSLT (`PostProcess.xslt`), merges RDF data-islands, caches the rendered result in `incleng..cache`, and serves it.
+Use this skill to inspect, configure, and deploy content into websites run by the OpenLink Inclusion Engine (OSDI): a Virtuoso-hosted system where a single `index.vsp` per site resolves `/{page}` requests to `content/{page}.html` in WebDAV, passes the document through HTML Tidy (unless its DOCTYPE is XHTML+RDFa), wraps it with a skin, merges RDF data-islands, caches the rendered result in `incleng..cache`, and serves it.
 
 All configuration lives in the RDF quadstore graph `<urn:com.openlinksw.virtuoso.incleng>`, accessed via the `incleng..config_*` SQL API — **never** the legacy `incleng..sites` table. Read `references/config-api.md` before issuing any config SQL.
 
+## Two Kinds of Skin
+
+Which kind is in play determines almost everything else, so establish it first.
+
+**Legacy skins** (`openlink`, `responsive`, `matrix`, `bootstrap-2022`, `docs-v3`, …) are single hand-written `PostProcess.xslt` files with the site's navigation markup, asset paths and layout fused inside them. They **unconditionally inject** masthead and footer around whatever is in the source document's `<body>`. They are selected by the `xslt_sheet` config parameter.
+
+**Composite skins** are manifest-declared bundles — a `skin.ttl` naming a theme, a set of plain-XHTML templates carrying `data-osdi-*` binding attributes, and SPARQL bindings resolved against a named graph at render time. Navigation is data, the stylesheet is a manifest string, and chrome is a set of independently suppressible regions. They are selected by the `skin_manifest` config parameter, which overrides `xslt_sheet`. See `references/composite-skins.md`.
+
+Read the live config for the target URL before reasoning about either — never assume.
+
 ## Blocking Gate — Chrome Conflict Check Before Any Page Deployment
 
-Every chrome-bearing skin — legacy `openlink`/`responsive` in the inclusion-engine VAD, and modern `matrix`/`bootstrap-2022` in the **opl-skins VAD** — **unconditionally injects** the corporate masthead and footer around whatever is in the source document's `<body>`. If a replacement page carries its own `<nav>`, `<header>`, or `<footer>` markup, deploying it under those skins stacks two sets of chrome — and when the replacement's CSS deliberately mirrors the live site's design, the duplication is visually subtle and easy to miss in review.
+Every **legacy** chrome-bearing skin injects the corporate masthead and footer unconditionally. If a replacement page carries its own `<nav>`, `<header>`, or `<footer>`, deploying it under such a skin stacks two sets of chrome — and when the replacement's CSS deliberately mirrors the live site's design, the duplication is visually subtle and easy to miss in review.
 
 Therefore, before deploying ANY page into an OSDI site:
 
-1. Read the **live** `xslt_sheet` for the target URL (`config_get`) to learn which skin/VAD is actually active — never assume.
-2. Fetch the replacement document and run `scripts/check_chrome_conflict.py <file-or-url>`.
-3. If it reports self-contained chrome, elicit which remediation the user wants (see Path A/B below); never deploy a chrome-carrying page under a chrome-injecting skin without the user's explicit, informed choice.
+1. Read the **live** skin for the target URL (`config_get` for `skin_manifest`, then `xslt_sheet`) to learn what is actually active.
+2. Fetch the replacement document and run `scripts/check_chrome_conflict.py <file-or-url>`. It reports which chrome the page carries and recommends a path; it is a **recommender, not a blocker** — the choice below is the user's.
+3. If it reports self-contained chrome, elicit which remediation the user wants. Never deploy a chrome-carrying page under a chrome-injecting legacy skin without the user's explicit, informed choice.
 
-**Path A — passthrough override (page keeps its own chrome).** Per-URL `xslt_sheet` override to `/DAV/VAD/inclusion-engine/skin/passthrough/xslt/PostProcess.xslt`, which copies `/html/head/*` and `/html/body` through essentially verbatim while still merging RDFa/SPARQL data-islands and Markdown blocks. Fastest and page-atomic, but the page loses engine-supplied extras: feeds links, canonical, JSON-LD SearchAction, analytics, OPAL widget, and site-wide nav consistency.
+**Path C — region suppression (preferred whenever the site is on a composite skin).** Set `regions_off` at URL scope to the regions the page supplies itself (e.g. `nav,footer`). Pure config, page-atomic, and the page keeps every engine service: canonical, feed autodiscovery, JSON-LD SearchAction, data islands, analytics, OPAL widget. This is the option legacy skins cannot offer, and it is the reason to consider migrating a site to a composite skin rather than repeatedly working around the all-or-nothing wrap.
 
-**Path B — chrome-strip under the live skin (recommended when the replacement's CSS derives from the live site).** Remove the replacement's own masthead/nav/footer and any head includes the live skin already injects (under `matrix`: Bootstrap 5.3.3 CSS/JS, Inter font, jQuery, `/skin/matrix/css/style.css` — `tidyups.xslt` dedupes many of these automatically); keep its `<style>` blocks and content sections. No config change at all — a pure WebDAV PUT. Matrix copies body children as-is when a `.container` structure exists, so wrap stripped content accordingly. Preserves site-wide chrome, feeds, search, analytics, and OPAL integration.
+**Path A — passthrough override (legacy sites; page keeps its own chrome).** Per-URL `xslt_sheet` override to `/DAV/VAD/inclusion-engine/skin/passthrough/xslt/PostProcess.xslt`, which copies `/html/head/*` and `/html/body` through essentially verbatim while still merging RDFa/SPARQL data-islands and Markdown blocks. Fast and page-atomic, but the page forfeits the engine-supplied extras listed above and loses site-wide nav consistency.
+
+**Path B — chrome-strip under the live skin (legacy sites; recommended when the replacement's CSS derives from the live site).** Remove the replacement's own masthead/nav/footer and any head includes the live skin already injects (under `matrix`: Bootstrap 5.3.3 CSS/JS, Inter font, jQuery, `/skin/matrix/css/style.css` — `tidyups.xslt` dedupes many automatically); keep its `<style>` blocks and content sections. No config change at all — a pure WebDAV PUT. Matrix copies body children as-is when a `.container` structure exists, so wrap stripped content accordingly.
 
 ## Elicitations — Establish Before Acting
 
@@ -33,34 +45,51 @@ Ask (or confirm from context) each of the following before running SQL or WebDAV
 4. **Actual `webdav_base` per site**: always read it live via `incleng..config_get(null, '<site>', 'webdav_base')` — never assume the path.
 5. **Source document(s)**: URL or local path of each replacement page, and which target page each one replaces (homepage → `content/index.html`; other pages → `content/{name}.html`).
 6. **Override scope**: per-URL (recommended for homepage swaps — leaves all other pages on the site's normal skin), per-site, or global.
-7. **Chrome remediation & skin choice**: Path A (passthrough override, page keeps own chrome) vs Path B (strip page chrome, deploy under live skin). Available skins span two VADs: `/DAV/VAD/inclusion-engine/skin/` (legacy: `openlink`, `responsive`, `passthrough`, …) and `/DAV/VAD/opl-skins/` (modern: `matrix`, `bootstrap-2022`, `docs-v3`, …). Read the live `xslt_sheet` first to know the active skin.
-8. **Backup/rollback policy**: whether to preserve the current `content/index.html` (default: yes — copy to `content/index.html.pre-<YYYYMMDD>` or a user-designated location before overwriting).
-9. **Go-live confirmation**: deploying to a public site requires explicit user go-ahead per site. Preparing a validated bundle without deploying is a valid stopping point when credentials or approval are absent.
+7. **Chrome remediation & skin choice**: Path C (region suppression, composite sites), Path A (passthrough override), or Path B (strip page chrome). Read the live skin first to know which are available.
+8. **For composite-skin work**: the manifest's DAV path (`skin_manifest`), the site's named graph (`site_graph`), and whether the site graph already exists or must be built.
+9. **Backup/rollback policy**: whether to preserve the current `content/index.html` (default: yes — copy to `content/index.html.pre-<YYYYMMDD>` or a user-designated location before overwriting).
+10. **Go-live confirmation**: deploying to a public site requires explicit user go-ahead per site. Preparing a validated bundle without deploying is a valid stopping point when credentials or approval are absent.
 
 ## Workflow — Homepage / Page Replacement
 
 1. **Elicit** the values above. Fetch each source document; verify HTTP 200 and non-trivial size.
-2. **Classify** each document with `scripts/check_chrome_conflict.py`: fragment vs full document; self-contained chrome or not; external asset references (CDN fonts, stylesheets) that must resolve from the live origin.
-3. **Read live config**: enumerate sites, read each target site's `webdav_base` and current `xslt_sheet` resolution for the target URL (`references/config-api.md` has the queries).
+2. **Classify** each document with `scripts/check_chrome_conflict.py`: fragment vs full document; which chrome regions it carries; external asset references that must resolve from the live origin.
+3. **Read live config**: enumerate sites, read each target site's `webdav_base`, and resolve the target URL's `skin_manifest` / `xslt_sheet` (`references/config-api.md` has the queries).
 4. **Back up** the current target file via WebDAV GET before overwriting, unless the user declines.
-5. **Apply skin override** (config change) when the gate requires it, scoped per the elicited choice — see `templates/skin-override.sql`.
+5. **Apply the elicited remediation**: `regions_off` (Path C), `xslt_sheet` override (Path A), or nothing (Path B) — see `templates/skin-override.sql`.
 6. **Deploy content**: WebDAV PUT the replacement as `content/index.html` (or the elicited target path) under the site's `webdav_base`. Use curl per the standing curl-first rule; MCP tools only when no CLI path exists.
-7. **Flush cache once** after any config change: `select incleng..config_flush_cache();`. Content-only changes self-invalidate on mtime and need no flush. If skin XSLT files themselves were edited, run `select incleng..staleall();` instead (Virtuoso caches compiled XSLT).
-8. **Verify**: fetch each live homepage; confirm single chrome (exactly one masthead/nav/footer), title correctness, resolvable external assets, and that at least one *other* page on the site still renders with the normal skin (proves the override stayed scoped).
+7. **Flush once** after any config change: `select incleng..config_flush_cache();`. Content-only changes self-invalidate on mtime. If skin XSLT or a composite manifest changed, run `select incleng..staleall();` instead — and re-run `incleng..osdi_skin_load()` after any manifest edit.
+8. **Verify in a browser**, not only by diffing markup. Confirm single chrome, correct title, resolvable stylesheet (a `401` from a freshly PUT asset is the common one), and that at least one *other* page still renders normally, proving the override stayed scoped.
 9. **Report** per site: config statements executed, files PUT (with backup locations), verification results. Never claim success without step 8.
+
+## Workflow — Composite Skin
+
+Full detail, including the manifest and directive vocabularies, is in `references/composite-skins.md`. The shape:
+
+1. Author or upload the bundle (`skin.ttl`, `template/`, `css/`, `js/`) to its DAV collection.
+2. Make the bundle world-readable and give it a vdir matching its `osdi:assetBase`.
+3. Load the site's RDF into the named graph; set `site_graph`.
+4. `select incleng..osdi_skin_load('<manifest>');` — the manifest deployment step, re-run after **every** manifest edit.
+5. `config_set` `skin_manifest` at the chosen scope; set `url_trailing_slash 0` if the site presents `.html` URLs.
+6. `select incleng..staleall();`
+7. Verify in a browser.
+
+`templates/composite-skin-register.sql` is a parameterised version of steps 2–6.
 
 ## Other Supported Operations
 
-- **Site registration/removal**: `incleng..config_add_site('<shortname>', '<baseURL>', '<webdavbase>')` / `incleng..config_remove_site('<shortname>')`, plus vhost/vdir notes in `references/engine-architecture.md`.
-- **Config parameter management**: get/set/unset of `debug_level`, `notfoundurl`, `inline_ttl`, `inline_jsonld`, `search_graphs`, `search_requrl`, `search_site_graphs`, `xslt_sheet`, `allow_edit` at URL, site, or global scope.
-- **Cache and XSLT maintenance**: `config_flush_cache()` vs `staleall()` — see step 7 for which applies.
+- **Site registration/removal**: `incleng..config_add_site('<shortname>', '<baseURL>', '<webdavbase>')` / `incleng..config_remove_site('<shortname>')`. `baseURL` must be the **absolute** public prefix — `config_url_to_site` matches it with `fn:starts-with` against the request URL, and `url_davfile` strips it. Note `config_add_site` swallows errors and will not update an existing site's `foaf:homepage`; delete the old triple first.
+- **Config parameter management**: get/set/unset of `debug_level`, `notfoundurl`, `inline_ttl`, `inline_jsonld`, `search_graphs`, `search_requrl`, `search_site_graphs`, `xslt_sheet`, `skin_manifest`, `site_graph`, `regions_off`, `url_trailing_slash`, `allow_edit` at URL, site, or global scope.
+- **Cache and XSLT maintenance**: `config_flush_cache()` vs `staleall()` — see step 7 above.
 - **index.vsp propagation**: after `common/index.vsp` changes, `incleng..config_propagate_index_vsp(user, password)` copies it to every registered site's base collection.
-- **Troubleshooting**: double chrome (skin/content conflict), stale pages (cache/XSLT), 404 handling (`notfoundurl`, `incleng..rewrite`), missing images (`/images` vdir opt-out), raw VSP served (vdir default-page misconfig) — see `references/engine-architecture.md`.
+- **Troubleshooting**: double chrome, stale pages, 404 handling, missing images, raw VSP served, `401` on skin assets — see `references/engine-architecture.md`.
 
 ## References
 
+- `references/composite-skins.md` — the manifest and directive vocabularies, config parameters, SQL API, deployment checklist, and the authoring gotchas that only a browser load catches.
 - `references/engine-architecture.md` — how index.vsp, skins, tidy, caching, vhosts/vdirs, and opt-outs fit together; skin inventory and per-skin chrome behavior.
-- `references/config-api.md` — config graph structure, all `incleng..config_*` signatures, resolution order (URL → site → global), ready-to-run inspection queries.
+- `references/config-api.md` — config graph structure, all `incleng..config_*` and `incleng..osdi_*` signatures, resolution order (URL → site → global), ready-to-run inspection queries.
 - `references/homepage-replacement-playbook.md` — the worked virtuoso/uda/ps homepage-swap scenario end to end, including the chrome-conflict findings that motivated the gate.
-- `templates/skin-override.sql` — parameterized SQL for per-URL/per-site skin overrides and rollback.
-- `scripts/check_chrome_conflict.py` — classifies a replacement document and emits a deploy recommendation.
+- `templates/skin-override.sql` — parameterized SQL for per-URL/per-site skin overrides, region suppression, and rollback.
+- `templates/composite-skin-register.sql` — parameterized composite-skin registration and teardown.
+- `scripts/check_chrome_conflict.py` — classifies a replacement document, names the regions it carries, and recommends Path A/B/C.

--- a/osdi-inclusion-engine/references/composite-skins.md
+++ b/osdi-inclusion-engine/references/composite-skins.md
@@ -1,0 +1,142 @@
+# OSDI Composite Skins
+
+A composite skin is a **loosely coupled bundle of three independently authored artifacts** — a theme (CSS/JS/fonts), a set of plain-XHTML templates, and a set of SPARQL bindings resolved against a named graph at render time. A manifest declares all three, and it is the only place they meet.
+
+This is the alternative to a legacy skin, where navigation markup, asset paths and page layout are all fused inside one hand-written `PostProcess.xslt` per skin — which is why site structure is duplicated across skins (`skin/responsive/xslt/masthead.xslt` is 347 lines of literal menu, restated again in `navbar-left.xslt` and again in `skin/openlink/xslt/navbar.xslt`), why swapping a stylesheet means editing XSLT, and why chrome can only be taken all-or-nothing.
+
+**Legacy skins are unaffected.** A site with no `skin_manifest` set behaves exactly as before.
+
+---
+
+## Bundle Layout
+
+```
+/DAV/VAD/opl-skins/{skin}/
+  skin.ttl                    the manifest — the entire coupling surface
+  template/{layout}.html      whole-page layouts
+  template/region/{name}.html reusable fragments (nav, footer, …)
+  css/  js/  images/          the theme
+```
+
+There is **no XSLT in a composite skin bundle.** One shared, generic composer serves every composite skin:
+
+- `/DAV/VAD/inclusion-engine/skin/composite/xslt/PostProcess.xslt` — entry point
+- `/DAV/VAD/inclusion-engine/skin/common/xslt/osdi-compose.xslt` — directive expander
+
+---
+
+## Manifest Vocabulary (`osdi:`)
+
+Namespace `http://www.openlinksw.com/ontology/osdi#`, defined in `inclusion-engine/common/osdi-skin-ontology.ttl`.
+
+| Term | Purpose |
+|---|---|
+| `osdi:Skin` | The manifest subject, conventionally `<>` |
+| `osdi:assetBase` | URL prefix for the bundle's own assets. **Absolute** (`/skin-foo/`) is used as-is; **relative** (`assets/`) resolves against each page's own base, which is what a static export needs |
+| `osdi:asset` → `osdi:kind` `osdi:href` `osdi:external` `osdi:crossorigin` `osdi:position` | One stylesheet / script / icon / preconnect. `kind` ∈ {stylesheet, script, icon, preconnect}. `external=true` means do not prefix with `assetBase`. **`osdi:position` is required** — head order is significant and a SPARQL result set is unordered |
+| `osdi:template` → `osdi:name` `osdi:file` | A whole-page layout, selected per URL by the route data (below) |
+| `osdi:region` → `osdi:name` `osdi:file` | A reusable fragment, referenced by `data-osdi-region`. Regions are the unit of chrome suppression |
+| `osdi:dataSource` → `osdi:name` `osdi:sparql` `osdi:scalar` | A named SELECT whose bindings become an addressable result set. `scalar=true` marks a single-row set addressed as `set.field` |
+| `osdi:prefixes` | PREFIX preamble prepended to every `osdi:sparql`. Also the skin's declaration of what it expects of a site graph |
+| `osdi:markdown` | Enables the engine's client-side Markdown block rendering |
+| `osdi:lang` | `<html lang>` |
+
+Two substitution tokens are expanded in every `osdi:sparql` before execution:
+
+- `<{URL}>` — the request URL as an IRI (the engine's existing convention, cf. `search_url`, `fct_url`)
+- `{SLUG}` — the page slug, i.e. the request path relative to the site base minus `.html`, empty meaning `index`
+
+---
+
+## Template Directive Vocabulary
+
+Directives are attributes in no namespace, so a template stays a valid, browser-openable HTML document before composition.
+
+| Directive | Effect |
+|---|---|
+| `data-osdi-region="NAME"` | Replace this element with region template NAME |
+| `data-osdi-region-from="REF"` | As above, but the region name comes from the data — a page's RDF chooses its own partial |
+| `data-osdi-content` | Replace with the WebDAV source document's `<body>` children |
+| `data-osdi-repeat="SET"` | Emit this element once per row of result set SET |
+| `data-osdi-repeat-where="F=R"` | Restrict that repeat to rows whose field F equals reference R resolved in the enclosing row — the master/detail primitive (footer columns each iterating their own links) |
+| `data-osdi-text="REF"` | Replace element content with REF's value, escaped |
+| `data-osdi-html="REF"` | As above, but the value is markup |
+| `data-osdi-attr-NAME="REF"` | Set attribute NAME (`data-osdi-attr-aria-label` works) |
+| `data-osdi-addclass="REF"` | Append REF's value to the class list |
+| `data-osdi-if="REF"` / `data-osdi-ifnot="REF"` | Drop the element when REF is empty / non-empty |
+| `data-osdi-unwrap` | Emit only this element's children |
+
+**Reference syntax.** `set.field` always resolves against that named set's first row. A bare `field` resolves against the current `data-osdi-repeat` row. Qualified refs still reach the global sets from inside a repeat, so a row template can mix row data with site-wide data freely.
+
+**Put decisions in the query, not the template.** The current-page nav highlight, a primary-vs-ghost button class, a link's target attribute — compute them as a bound column and render with `data-osdi-addclass`. That is what keeps the template free of page logic and therefore restyleable without touching behaviour.
+
+**Template files must be well-formed XML.** Named HTML entities are not: use numeric (`&#8212;`, not `&mdash;`). Each file may carry a leading comment; the loader strips it.
+
+---
+
+## Config Parameters
+
+| Param | Scope | Meaning |
+|---|---|---|
+| `skin_manifest` | URL / site / global | DAV path to `skin.ttl`. **Setting this switches the site to composite rendering** and overrides `xslt_sheet` |
+| `site_graph` | URL / site / global | Named graph the manifest's SPARQL is scoped to. This is what lets one skin dress several sites off different graphs |
+| `regions_off` | URL / site / global | Comma-delimited region names to omit for this scope — per-page chrome suppression |
+
+## SQL API
+
+```sql
+incleng..osdi_skin_load(manifest)                  -- parse skin.ttl into its own graph; RE-RUN AFTER EVERY MANIFEST EDIT
+incleng..osdi_skin_theme(manifest)                 -- -> <skintheme>
+incleng..osdi_skin_templates(manifest)             -- -> <skintemplate>
+incleng..osdi_skin_data(manifest, graph, url, slug)-- -> <skindata>
+incleng..osdi_skin_layout(skindata [, default])    -- layout named by the route row
+incleng..osdi_url_slug(url, sitebase)              -- request path -> slug
+```
+
+The manifest is parsed into `urn:osdi:skin:{manifest-path}`, one graph per manifest resource, so two sites can use two skins — or two revisions of one skin — side by side.
+
+---
+
+## Deploying a Composite Skin
+
+1. **Upload the bundle** to its DAV collection (curl per the curl-first rule).
+2. **Make it publicly readable.** Files PUT over WebDAV are owned by the uploading account and are **not** world-readable; a browser fetching the stylesheet gets `401`, not `200`. Set `RES_PERMS`/`COL_PERMS` to `111101101NN` across the bundle.
+3. **Give the bundle a vdir** whose lpath equals `osdi:assetBase`. Do not assume `/skin` is free — on a stock instance it resolves to *different* collections on the plain and SSL vhosts.
+4. **Load the site graph** and set `site_graph`.
+5. **`osdi_skin_load(manifest)`** — this is the manifest deployment step.
+6. **`config_set` `skin_manifest`** at the chosen scope.
+7. **`staleall()`**, not just `config_flush_cache()` — the composer is XSLT and Virtuoso caches compiled XSLT.
+8. **Verify in a browser**, not only by diffing markup. See the gotchas below for what only a browser load catches.
+
+---
+
+## Gotchas
+
+Each of these cost real debugging time; all are fixed in the shipped engine code, but they shape how a skin must be authored and verified.
+
+**Serialisation.** The composer emits `method="xml"` and guarantees no non-void element is ever emitted empty. It has to: an XML serialiser writes `<script src="x"/>`, which every browser reads as an unterminated script that swallows the rest of the document — and `<div/>`, `<a/>`, `<span/>` are mis-parsed too. `method="xhtml"` is *not* a portable fix: libxslt builds vary in accepting it, and a rejected output method **silently falls back to xml while still exiting 0**. Never treat a generator's exit code as proof it rendered correctly.
+
+**Entities in RDF literals.** A literal reaches the page either escaped (`xsl:value-of`, for `<title>` and `meta content`) or raw (`disable-output-escaping`, for markup-bearing fields). `&amp;` survives only the second path and appears verbatim in the first. **Store the real character** — it is correct on both paths.
+
+**Virtuoso re-evaluates an OPTIONAL when a FILTER references a variable bound inside it.** A nav query that wrapped its route join in `OPTIONAL` and then filtered on a variable from it had the base-path variable unbind on exactly the row being filtered, so one link lost its `../` prefix while its siblings kept theirs. Keep a join non-optional when every row genuinely has it.
+
+**Trailing slashes.** The engine canonicalises to a trailing slash by default. A site presenting `.html` URLs must set `url_trailing_slash 0` or every request 302s.
+
+**`.vsp` execute bits.** A dispatcher uploaded without execute permission is served as a static resource and redirects in search of a collection — a silent, confusing failure.
+
+**Data-island placeholders.** With no statements about a page, `inline_html5md` and `inline_rdfa` emit visible placeholder prose ("This document is empty and basically useless…"). Set both to `0` unless the site graph actually describes its pages.
+
+**`debug_level`.** Leave it set and a debug trailer renders as visible text on every page. Unset it before declaring done.
+
+---
+
+## When to Use Which
+
+| Situation | Approach |
+|---|---|
+| New site, or a site whose structure you control | Composite skin |
+| One page needs its own layout on an otherwise legacy site | `regions_off` if the site is already composite; otherwise Path A/B from SKILL.md |
+| Page's design derives from the live site's | Composite skin with `data-osdi-content`, or Path B |
+| Existing legacy site, no appetite for migration | Leave it; nothing changes |
+
+A composite skin does **not** face the passthrough skin's trade-off. Because its chrome is regions rather than an unconditional wrap, a page can keep its own body *and* keep canonical, feed autodiscovery, data islands and the rest.

--- a/osdi-inclusion-engine/references/config-api.md
+++ b/osdi-inclusion-engine/references/config-api.md
@@ -21,6 +21,12 @@ All configuration lives in the quadstore graph `<urn:com.openlinksw.virtuoso.inc
 | `search_requrl` | 1 → also search the request-URL-as-graph |
 | `search_site_graphs` | 1 → also search all site homepages as graphs |
 | `allow_edit` | DAV user's password to enable in-site editing (leave unset in production) |
+| `skin_manifest` | DAV path to a composite skin's `skin.ttl`. **Setting this switches the scope to composite rendering and overrides `xslt_sheet`** |
+| `site_graph` | Named graph a composite skin's SPARQL bindings are scoped to — what lets one skin dress several sites |
+| `regions_off` | Comma-delimited composite-skin region names to omit for this scope (per-page chrome suppression) |
+| `url_trailing_slash` | 1 (default) canonicalises every request to a trailing slash. **Set 0 for a site presenting `.html` URLs**, or every request 302s |
+| `tidy` | 0 skips the HTML Tidy pass — correct when content is already well-formed XHTML |
+| `inline_html5md` / `inline_rdfa` | >0 embeds HTML-Microdata / RDFa islands. With no statements about a page these emit **visible placeholder prose**; set 0 unless the site graph describes its pages |
 
 ## Functions
 
@@ -41,6 +47,36 @@ incleng..staleall()            -- flush compiled XSLT + cache table
 incleng..config_propagate_index_vsp(user, password)   -- defaults 'dav'
 incleng..config_migrate(in dangerous integer := 0)
 ```
+
+## Composite Skin Functions
+
+Defined in `inclusion-engine/common/skin-api.sql`. See `references/composite-skins.md` for the manifest vocabulary these read.
+
+```sql
+-- Parse skin.ttl into urn:osdi:skin:{manifest}. Idempotent (clears first).
+-- RE-RUN AFTER EVERY MANIFEST EDIT — this is the manifest deployment step.
+incleng..osdi_skin_load(in manifest varchar)
+
+-- The three XML trees handed to the generic composer.
+incleng..osdi_skin_theme(in manifest varchar)                   -- <skintheme>
+incleng..osdi_skin_templates(in manifest varchar)               -- <skintemplate>
+incleng..osdi_skin_data(in manifest varchar, in site_graph varchar,
+                        in url varchar, in slug varchar)        -- <skindata>
+
+-- Helpers
+incleng..osdi_skin_layout(inout skindata any, in dflt varchar := 'default')
+incleng..osdi_url_slug(in url varchar, in sitebase varchar)
+incleng..osdi_skin_graph(in manifest varchar)
+incleng..osdi_skin_dir(in manifest varchar)
+```
+
+A manifest edit needs BOTH `osdi_skin_load()` and `staleall()`: the first re-parses the manifest, the second clears Virtuoso's compiled-XSLT cache. `config_flush_cache()` alone is not sufficient for either.
+
+### Site registration caveats
+
+`config_add_site(sname, baseURL, webdavbase)` writes the site into the config graph but has a blanket `exit handler` that returns null on any error, and it **inserts** rather than updates — re-running it on an existing site adds a second `foaf:homepage` triple instead of replacing the first. Delete the old triple before re-registering.
+
+`baseURL` must be the **absolute** public prefix (`http://host:port/path/`), not a bare path: `config_url_to_site` matches it with `fn:starts-with` against the full request URL, and `url_davfile` strips it from the URL to derive the content path. A path-only value silently yields a mangled DAV path.
 
 `config_set` scoping: pass the **request URL** as `uri` for a per-URL override (site may still be passed for context); pass `null` uri + site shortname for site scope; `null`/`null` for global. `config_get` mirrors this in its lookup order, which is what makes a homepage-only skin override safe: every other page falls through to the site/global `xslt_sheet`.
 

--- a/osdi-inclusion-engine/references/engine-architecture.md
+++ b/osdi-inclusion-engine/references/engine-architecture.md
@@ -7,7 +7,7 @@
 3. It resolves the request path to a source document: `{webdav_base}/content/{request}.html` — the engine appends `.html`. `/` → `content/index.html`; `/news` → `content/news.html`; `/news/foo.html` → `content/news/foo.html`.
 4. The document is passed through HTML Tidy **unless** its DOCTYPE is XHTML+RDFa. Tidy accepts anything from a bare line of text to a full HTML document and normalizes it into valid XHTML.
 5. Optional SPARQL queries pull page metadata from configured graphs (`search_graphs`, `search_requrl`, `search_site_graphs`); Turtle/JSON-LD script-tag data islands are merged per `inline_ttl` / `inline_jsonld`.
-6. The result is transformed by the skin XSLT named in `xslt_sheet` (a `virt://WS.WS.SYS_DAV_RES...` path into DAV).
+6. The result is transformed by a skin. **If `skin_manifest` is set** for this URL/site/global scope, the engine resolves that composite skin's manifest — building `<skintheme>`, `<skintemplate>` and `<skindata>` (the last by running the manifest's SPARQL against `site_graph`) — and hands all three to the single generic composer at `skin/composite/xslt/PostProcess.xslt`. **Otherwise** it uses the legacy skin XSLT named in `xslt_sheet` (a `virt://WS.WS.SYS_DAV_RES...` path into DAV).
 7. The fully rendered page is stored in `incleng..cache` and emitted. Only found pages are cached (caching 404s would be a DoS vector).
 8. If the page is not found, `incleng..rewrite` rules are consulted; failing that, redirect to `notfoundurl`.
 
@@ -16,6 +16,14 @@
 - Content change (`content/*.html` mtime newer than cache row) → automatic re-render; no action needed.
 - Config change (skin override, search graphs, etc.) → run `select incleng..config_flush_cache();`.
 - Skin XSLT file edited → Virtuoso caches compiled XSLT internally; run `select incleng..staleall();` (also empties the cache table).
+
+## Composite Skins
+
+A second kind of skin, selected by `skin_manifest` rather than `xslt_sheet`. A composite skin bundle contains **no XSLT of its own** — only `skin.ttl`, plain-XHTML templates carrying `data-osdi-*` binding attributes, and the theme. One shared composer (`skin/composite/xslt/PostProcess.xslt` + `skin/common/xslt/osdi-compose.xslt`) serves all of them.
+
+The practical difference is that its chrome is a set of **independently suppressible regions** (`regions_off`) rather than an unconditional wrap, so a page can supply its own masthead and still receive canonical, feed autodiscovery, data islands, analytics and the OPAL widget — the trade-off the passthrough skin forces. Navigation is data in the site graph, and the stylesheet is a manifest string, so restructuring the nav or reskinning does not touch a template, and re-laying-out a page does not touch a query.
+
+Full detail in `references/composite-skins.md`.
 
 ## Skin Inventory and Chrome Behavior
 
@@ -60,7 +68,12 @@ Anything that must bypass `index.vsp` gets its own vdir: `/skin`, `/images`, `/j
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| Two mastheads/navs/footers on a page | Chrome-carrying content deployed under chrome-injecting skin | Per-URL `xslt_sheet` override to `passthrough`, then `config_flush_cache()` |
+| Two mastheads/navs/footers on a page | Chrome-carrying content deployed under chrome-injecting skin | Composite site: `regions_off` at URL scope. Legacy site: per-URL `xslt_sheet` override to `passthrough`, or strip the page's chrome. Then `config_flush_cache()` |
+| Manifest edit has no effect | Manifest is parsed into its own graph at deploy time | `incleng..osdi_skin_load('<manifest>')` **and** `staleall()` |
+| `401` on a skin stylesheet or script | Files PUT over WebDAV are owned by the uploading account and are not world-readable | Set `RES_PERMS`/`COL_PERMS` to `111101101NN` across the bundle |
+| Every request 302s to a trailing slash | `url_trailing_slash` defaults to 1 | `config_set` `url_trailing_slash` 0 for a site presenting `.html` URLs |
+| "This document is empty and basically useless…" as visible page text | `inline_html5md` / `inline_rdfa` placeholder bodies | Set both 0 unless the site graph describes its pages |
+| Debug trailer rendered as visible text | `debug_level` left set | `config_set` `debug_level` 0 |
 | Edits to content not appearing | Should self-invalidate; if not, clock skew or config-level cache staleness | `config_flush_cache()` |
 | Skin edits not appearing | Compiled-XSLT cache | `staleall()` |
 | 404s on moved pages | No rewrite rule | Insert into `incleng..rewrite(site, old_url, new_url)`; note a rule never fires if `content/{old}.html` exists |

--- a/osdi-inclusion-engine/references/homepage-replacement-playbook.md
+++ b/osdi-inclusion-engine/references/homepage-replacement-playbook.md
@@ -2,6 +2,8 @@
 
 Worked scenario (2026-07): replacing the homepages of virtuoso.openlinksw.com, uda.openlinksw.com, and ps.openlinksw.com with three self-styled mockups hosted on an intranet DAV server. Generalizes to any "drop this finished HTML design in as page X" request.
 
+> **Dated scope.** This playbook predates composite skins and its remediations are the legacy Path A / Path B pair, which is still correct for any site selected by `xslt_sheet`. If the target site is on a composite skin (`skin_manifest` set), Path C — region suppression via `regions_off` — is available and preferred: it is the only option that lets the page keep its own chrome *and* the engine's head services. Read the live `skin_manifest` for the target URL before applying anything here. See `composite-skins.md`.
+
 ## Why this scenario needs the gate
 
 Analysis of the three replacement documents (`scripts/check_chrome_conflict.py`) showed:

--- a/osdi-inclusion-engine/scripts/check_chrome_conflict.py
+++ b/osdi-inclusion-engine/scripts/check_chrome_conflict.py
@@ -3,15 +3,24 @@
 
 Reports:
   - structure: full document vs fragment (tidy will normalize fragments)
-  - chrome: whether the page carries its own nav/header/footer/masthead
+  - chrome: which regions the page supplies itself (nav / header / footer)
   - external assets that must resolve from the live origin
-  - deploy recommendation (passthrough skin vs default skin)
+  - a recommendation across the three remediation paths
+
+This is a RECOMMENDER, not a gate. It cannot see the live config, so it does
+not know whether the target site is on a composite skin (where Path C applies)
+or a legacy one (where the choice is A or B). Read the live skin_manifest and
+xslt_sheet for the target URL, then put the choice to the user.
 
 Usage:
-  check_chrome_conflict.py <file-or-url> [--insecure]
+  check_chrome_conflict.py <file-or-url> [--insecure] [--composite]
 
-Exit codes: 0 = no chrome conflict (default skin OK)
-            2 = self-contained chrome detected (passthrough skin required)
+  --composite   the target site is known to be on a composite skin, so
+                Path C (regions_off) is available; prints the exact
+                regions_off value to set.
+
+Exit codes: 0 = no self-contained chrome (safe under any skin)
+            2 = self-contained chrome detected (remediation choice required)
             1 = fetch/parse error
 """
 import re
@@ -19,11 +28,26 @@ import ssl
 import sys
 import urllib.request
 
-CHROME_TAG = re.compile(r"<(nav|header|footer)\b[^>]*>", re.I)
-CHROME_CLASS = re.compile(
-    r'(?:class|id)\s*=\s*"[^"]*\b(masthead|navbar|site-header|site-footer|topbar|top-bar)\b[^"]*"',
-    re.I,
-)
+# Region names match the conventional region names in a composite skin bundle,
+# so the detected set can be handed straight to regions_off.
+REGION_PATTERNS = {
+    "nav": [
+        re.compile(r"<nav\b", re.I),
+        re.compile(r'(?:class|id)\s*=\s*"[^"]*\b(?:navbar|site-nav|topbar|top-bar)\b', re.I),
+    ],
+    "header": [
+        re.compile(r"<header\b", re.I),
+        re.compile(r'(?:class|id)\s*=\s*"[^"]*\b(?:masthead|site-header)\b', re.I),
+    ],
+    "footer": [
+        re.compile(r"<footer\b", re.I),
+        re.compile(r'(?:class|id)\s*=\s*"[^"]*\b(?:site-footer|colophon)\b', re.I),
+    ],
+    "announcement": [
+        re.compile(r'(?:class|id)\s*=\s*"[^"]*\b(?:annc|announcement|banner-strip)\b', re.I),
+    ],
+}
+
 EXTERNAL_ASSET = re.compile(
     r'(?:href|src)\s*=\s*"(https?://[^"]+\.(?:css|js|woff2?)[^"]*|https?://fonts\.[^"]+)"',
     re.I,
@@ -40,8 +64,10 @@ def load(source: str, insecure: bool) -> str:
 
 
 def main() -> int:
-    args = [a for a in sys.argv[1:] if a != "--insecure"]
-    insecure = "--insecure" in sys.argv[1:]
+    argv = sys.argv[1:]
+    insecure = "--insecure" in argv
+    composite = "--composite" in argv
+    args = [a for a in argv if not a.startswith("--")]
     if len(args) != 1:
         print(__doc__)
         return 1
@@ -57,31 +83,45 @@ def main() -> int:
     full_doc = has_doctype and has_html and has_body
     rdfa_doctype = bool(re.search(r"<!doctype[^>]*rdfa", html, re.I))
 
-    chrome_tags = sorted({m.group(1).lower() for m in CHROME_TAG.finditer(html)})
-    chrome_classes = sorted({m.group(1).lower() for m in CHROME_CLASS.finditer(html)})
+    regions = [name for name, pats in REGION_PATTERNS.items()
+               if any(p.search(html) for p in pats)]
     assets = sorted({m.group(1) for m in EXTERNAL_ASSET.finditer(html)})
-
-    has_chrome = bool(chrome_tags or chrome_classes)
 
     print(f"source        : {args[0]}")
     print(f"size          : {len(html)} bytes")
     print(f"structure     : {'full document' if full_doc else 'fragment (tidy will wrap it)'}")
     if rdfa_doctype:
         print("doctype       : XHTML+RDFa — engine SKIPS tidy for this document")
-    print(f"chrome tags   : {', '.join(chrome_tags) or 'none'}")
-    print(f"chrome classes: {', '.join(chrome_classes) or 'none'}")
+    print(f"chrome regions: {', '.join(regions) or 'none'}")
     print(f"external assets ({len(assets)}):")
     for a in assets:
         print(f"  - {a}")
 
-    if has_chrome:
-        print("\nRECOMMENDATION: self-contained chrome detected.")
-        print("Deploy under the passthrough skin via a per-URL xslt_sheet override")
-        print("(templates/skin-override.sql). Deploying under openlink/responsive")
-        print("skins would stack duplicate masthead/nav/footer chrome.")
-        return 2
-    print("\nRECOMMENDATION: no self-contained chrome detected; default site skin is safe.")
-    return 0
+    if not regions:
+        print("\nRECOMMENDATION: no self-contained chrome detected.")
+        print("The page is safe under any skin; no remediation needed.")
+        return 0
+
+    print("\nSelf-contained chrome detected. Three remediations — the choice is the")
+    print("user's, and depends on the LIVE skin for this URL, which this script")
+    print("cannot see. Read skin_manifest, then xslt_sheet, before recommending.\n")
+
+    if composite:
+        print(f"  Path C (preferred here): regions_off = '{','.join(regions)}'")
+        print("      Pure config, page-atomic. The page keeps canonical, feeds,")
+        print("      data islands, analytics and the OPAL widget.")
+    else:
+        print("  Path C: NOT available — target is not known to be on a composite")
+        print("      skin. Re-run with --composite once you have confirmed")
+        print(f"      skin_manifest is set; the value would be '{','.join(regions)}'.")
+
+    print("\n  Path A: per-URL xslt_sheet override to the passthrough skin.")
+    print("      Page keeps its layout but forfeits canonical, feeds, JSON-LD")
+    print("      SearchAction, data islands, analytics, OPAL widget and site nav.")
+    print("\n  Path B: strip the page's own chrome and deploy under the live skin.")
+    print(f"      Remove its {', '.join(regions)}; keep <style> blocks and content")
+    print("      sections. No config change — a pure WebDAV PUT.")
+    return 2
 
 
 if __name__ == "__main__":

--- a/osdi-inclusion-engine/templates/composite-skin-register.sql
+++ b/osdi-inclusion-engine/templates/composite-skin-register.sql
@@ -1,0 +1,97 @@
+-- Register a site against a composite skin.
+--
+-- Replace before running via isql:
+--   {SITE}       site shortname in the config graph
+--   {BASEURL}    site's ABSOLUTE public prefix, e.g. https://www.openlinksw.com/
+--                (NOT a bare path — config_url_to_site matches it with
+--                 fn:starts-with against the full request URL)
+--   {DAVBASE}    site's DAV base collection, e.g. /DAV/www2.openlinksw.com
+--   {MANIFEST}   DAV path to skin.ttl, e.g. /DAV/VAD/opl-skins/{skin}/skin.ttl
+--   {SKINCOL}    the bundle's DAV collection, e.g. /DAV/VAD/opl-skins/{skin}/
+--   {ASSETPATH}  vdir lpath matching the manifest's osdi:assetBase, e.g. /skin-{skin}
+--   {SITEGRAPH}  named graph the manifest's SPARQL is scoped to
+--
+-- Elicit every one of these from the user or from the live config graph.
+-- Documentation examples are NOT live values.
+--
+-- Prerequisite: the bundle and the site's content/ are already in WebDAV, and
+-- the site's RDF is loaded into {SITEGRAPH}.
+
+use incleng;
+
+-- ---------------------------------------------------------------------------
+-- 1. Site record. config_add_site INSERTS rather than updates and swallows
+--    errors, so re-registering an existing site would leave two foaf:homepage
+--    triples. Remove the old one first.
+-- ---------------------------------------------------------------------------
+sparql delete from <urn:com.openlinksw.virtuoso.incleng>
+ { <urn:com.openlinksw.virtuoso.incleng:s:{SITE}> <http://xmlns.com/foaf/0.1/homepage> ?o }
+ where { <urn:com.openlinksw.virtuoso.incleng:s:{SITE}> <http://xmlns.com/foaf/0.1/homepage> ?o };
+
+incleng..config_add_site('{SITE}', '{BASEURL}', '{DAVBASE}');
+
+-- ---------------------------------------------------------------------------
+-- 2. Composite skin binding. skin_manifest overrides xslt_sheet for this scope.
+-- ---------------------------------------------------------------------------
+incleng..config_set(null, '{SITE}', 'skin_manifest', '{MANIFEST}');
+incleng..config_set(null, '{SITE}', 'site_graph',    '{SITEGRAPH}');
+incleng..config_set(null, '{SITE}', 'regions_off',   '');
+
+-- ---------------------------------------------------------------------------
+-- 3. Site-shape settings. Adjust to the site, do not apply blindly.
+--    url_trailing_slash 0 is required for a site presenting .html URLs.
+--    inline_html5md/inline_rdfa emit visible placeholder prose on pages the
+--    site graph says nothing about.
+-- ---------------------------------------------------------------------------
+incleng..config_set(null, '{SITE}', 'url_trailing_slash', 0);
+incleng..config_set(null, '{SITE}', 'inline_html5md', 0);
+incleng..config_set(null, '{SITE}', 'inline_rdfa', 0);
+-- incleng..config_set(null, '{SITE}', 'tidy', 0);   -- only if content is already XHTML
+
+-- ---------------------------------------------------------------------------
+-- 4. Bundle readability. Files PUT over WebDAV are owned by the uploading
+--    account and are NOT world-readable, so a browser fetching the stylesheet
+--    gets 401 rather than 200 — a failure the markup looks perfectly fine for.
+-- ---------------------------------------------------------------------------
+update ws..sys_dav_res set RES_PERMS = '111101101NN'
+ where RES_FULL_PATH like '{SKINCOL}%';
+update ws..sys_dav_col set COL_PERMS = '111101101NN'
+ where COL_FULL_PATH like '{SKINCOL}%';
+
+-- ---------------------------------------------------------------------------
+-- 5. Parse the manifest into its own graph. THIS IS THE MANIFEST DEPLOYMENT
+--    STEP — re-run it after every skin.ttl edit.
+-- ---------------------------------------------------------------------------
+select incleng..osdi_skin_load('{MANIFEST}') as manifest_triples;
+
+-- ---------------------------------------------------------------------------
+-- 6. Asset vdir. Its lpath must equal the manifest's osdi:assetBase. Do not
+--    assume /skin is free: on a stock instance it resolves to different
+--    collections on the plain and SSL vhosts.
+-- ---------------------------------------------------------------------------
+DB.DBA.VHOST_REMOVE(lpath=>'{ASSETPATH}');
+DB.DBA.VHOST_DEFINE(lpath=>'{ASSETPATH}', ppath=>'{SKINCOL}', is_dav=>1,
+                    vsp_user=>'dba');
+
+-- ---------------------------------------------------------------------------
+-- 7. Clear compiled XSLT and the page cache. config_flush_cache() alone is not
+--    sufficient — the composer is XSLT and Virtuoso caches it compiled.
+-- ---------------------------------------------------------------------------
+select incleng..staleall() as xslt_cache_cleared;
+select incleng..config_flush_cache() as page_cache_flushed;
+
+-- ---------------------------------------------------------------------------
+-- 8. Verify. Confirm the resolved values, then load a page IN A BROWSER —
+--    markup can diff clean while the stylesheet 401s or a debug trailer
+--    renders as visible text.
+-- ---------------------------------------------------------------------------
+select incleng..config_get(null, '{SITE}', 'skin_manifest') as manifest;
+select incleng..config_get(null, '{SITE}', 'site_graph') as site_graph;
+select incleng..site2baseurl('{SITE}') as base_url;
+select incleng..osdi_url_slug('{BASEURL}index', incleng..site2baseurl('{SITE}')) as slug_of_root;
+
+-- Teardown
+-- incleng..config_unset(null, '{SITE}', 'skin_manifest');
+-- incleng..config_unset(null, '{SITE}', 'site_graph');
+-- incleng..config_unset(null, '{SITE}', 'regions_off');
+-- select incleng..staleall();

--- a/osdi-inclusion-engine/templates/skin-override.sql
+++ b/osdi-inclusion-engine/templates/skin-override.sql
@@ -1,8 +1,36 @@
--- OSDI skin override templates.
--- Replace {URL}, {SITE}, {SKIN} before running via isql.
--- {SKIN} is a directory under /DAV/VAD/inclusion-engine/skin/ , e.g. passthrough, openlink, responsive.
+-- OSDI skin override and region-suppression templates.
+-- Replace {URL}, {SITE}, {SKIN}, {REGIONS} before running via isql.
 -- Elicit {URL} and {SITE} from the live config graph first (see references/config-api.md);
 -- documentation examples are NOT live values.
+--
+-- Read the live skin for the URL BEFORE choosing between these:
+--   select incleng..config_get('{URL}', '{SITE}', 'skin_manifest');   -- composite?
+--   select incleng..config_get('{URL}', '{SITE}', 'xslt_sheet');      -- legacy skin
+
+
+-- ---------------------------------------------------------------------------
+-- PATH C — region suppression. Composite-skin sites only, and the preferred
+-- remediation where available: the page supplies its own chrome yet keeps
+-- canonical, feeds, data islands, analytics and the OPAL widget.
+-- {REGIONS} is a comma-delimited list of region names as declared in the
+-- skin's manifest, e.g. 'nav,footer'. scripts/check_chrome_conflict.py
+-- --composite prints the exact value for a given document.
+-- ---------------------------------------------------------------------------
+select incleng..config_set('{URL}', '{SITE}', 'regions_off', '{REGIONS}');
+select incleng..config_flush_cache();
+
+-- Rollback
+-- select incleng..config_unset('{URL}', '{SITE}', 'regions_off');
+-- select incleng..config_flush_cache();
+
+
+-- ---------------------------------------------------------------------------
+-- PATH A — passthrough override. Legacy-skin sites. The page keeps its own
+-- layout but forfeits the engine-supplied head services listed above.
+-- {SKIN} is a directory under /DAV/VAD/inclusion-engine/skin/ (passthrough,
+-- openlink, responsive, clean, …) or under /DAV/VAD/opl-skins/ (matrix,
+-- bootstrap-2022, docs-v3, …) — adjust the path accordingly.
+-- ---------------------------------------------------------------------------
 
 -- Per-URL override (recommended for single-page swaps: all other pages keep the site skin)
 select incleng..config_set('{URL}', '{SITE}', 'xslt_sheet',
@@ -12,12 +40,23 @@ select incleng..config_set('{URL}', '{SITE}', 'xslt_sheet',
 -- select incleng..config_set(null, '{SITE}', 'xslt_sheet',
 --   'virt://WS.WS.SYS_DAV_RES.RES_FULL_PATH.RES_CONTENT:/DAV/VAD/inclusion-engine/skin/{SKIN}/xslt/PostProcess.xslt');
 
--- Required after any config change (content-only changes self-invalidate; this does not)
+-- Required after any config change (content-only changes self-invalidate; this does not).
+-- Use staleall() instead if a skin's XSLT file itself was edited — Virtuoso
+-- caches compiled XSLT and config_flush_cache() does not clear it.
 select incleng..config_flush_cache();
 
--- Verify what a URL now resolves to
+-- Verify what the URL now resolves to
+select incleng..config_get('{URL}', '{SITE}', 'skin_manifest');
 select incleng..config_get('{URL}', '{SITE}', 'xslt_sheet');
+select incleng..config_get('{URL}', '{SITE}', 'regions_off');
 
 -- Rollback the per-URL override
 -- select incleng..config_unset('{URL}', '{SITE}', 'xslt_sheet');
 -- select incleng..config_flush_cache();
+
+
+-- ---------------------------------------------------------------------------
+-- PATH B needs no SQL at all: strip the page's own masthead/nav/footer and the
+-- head includes the live skin already injects, then WebDAV PUT it. Content-only
+-- changes self-invalidate on mtime, so no flush is required.
+-- ---------------------------------------------------------------------------


### PR DESCRIPTION
Revises the `osdi-inclusion-engine` skill for composite-skin support added to the inclusion-engine VAD (separate MR on devhub), where a skin becomes a manifest-declared bundle of three loosely coupled artifacts — theme, plain-XHTML templates, and SPARQL bindings against a named graph — instead of one hand-written `PostProcess.xslt` with the site's navigation, asset paths and layout fused inside it.

The skill inherits the config API, cache semantics, site registration and the deploy workflow unchanged. What needed revising is the part built around the limitation composite skins remove.

## Chrome gate: a third path

The blocking gate offered a binary:

- **Path A** — passthrough override. Page keeps its chrome but forfeits canonical, feeds, JSON-LD SearchAction, data islands, analytics and the OPAL widget.
- **Path B** — strip the page's own chrome by hand.

Composite skins add **Path C** — `regions_off` at URL scope. Pure config, page-atomic, and the only option that keeps both the page's own layout *and* the engine's head services. Path C leads where the site is composite; A and B are unchanged and remain correct for legacy sites.

`check_chrome_conflict.py` is demoted from deploy **blocker** to **recommender**. It reports chrome by region name rather than as a boolean, so `--composite` prints the exact `regions_off` value for a document, and its docstring states plainly that it cannot see the live config and therefore cannot choose a path.

## Changes

| File | |
|---|---|
| `references/composite-skins.md` | **New.** Manifest (`osdi:`) and `data-osdi-*` directive vocabularies, config parameters, SQL API, deployment checklist, and a Gotchas section |
| `SKILL.md` | New "Two Kinds of Skin" framing; three-path gate; composite elicitations and workflow |
| `references/config-api.md` | Seven parameters, six `incleng..osdi_*` functions, `config_add_site` caveats |
| `references/engine-architecture.md` | Composite branch of the request lifecycle; five troubleshooting rows |
| `templates/composite-skin-register.sql` | **New.** Parameterised registration |
| `templates/skin-override.sql` | Reorganised around Path C/A/B |
| `references/homepage-replacement-playbook.md` | Dated-scope note so its A/B remediations aren't read as current guidance for a composite site |

## Verification

Path C was verified end to end against a live composite site rather than by review: `regions_off='nav'` at URL scope removed the nav from that page only, left the neighbouring page untouched, and the page kept its footer, hero, `rel="canonical"` and Turtle data island.

Deployment step 8 now says **verify in a browser**, not only by diffing markup — every gotcha now documented passed a clean markup diff first.

## Also in this PR

Records the artifact-routing lapse this work surfaced (`preferences.ttl` step 263, `artifact-routing.ttl` step 14): generator output written into a source repo as a "test fixture" or "build directory" is still a generated artifact and routes to the model-specific LLM root. Routing is decided by artifact **type**, not by the directory's name, an adjacent generator script, or regenerability.

Unrelated in-progress changes in the working tree (`agent-rdf-memory/index.ttl`, `rdf-infographic-skill/scripts/`) were deliberately left uncommitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)