### PR TITLE
osdi-inclusion-engine: two composite-skin behaviours found after the docs

### DIFF
--- a/osdi-inclusion-engine/references/composite-skins.md
+++ b/osdi-inclusion-engine/references/composite-skins.md
@@ -114,6 +114,8 @@ The manifest is parsed into `urn:osdi:skin:{manifest-path}`, one graph per manif
 
 Each of these cost real debugging time; all are fixed in the shipped engine code, but they shape how a skin must be authored and verified.
 
+**Virtuoso rejects `EXISTS` inside `BIND`.** rdflib accepts it, so a data source developed against the offline harness can fail outright on the server with `syntax error at EXISTS` — and because the whole data source fails, the page 500s rather than degrading. `FILTER NOT EXISTS` is best avoided for the same reason. Compute structural facts where they are already known (at build time, or when the graph is authored) and record them as triples: a `topLevel`, `hasChildren` or `coversSlug` flag costs one triple and removes the portability question entirely. This is the single most likely way a working offline skin breaks when deployed.
+
 **Serialisation.** The composer emits `method="xml"` and guarantees no non-void element is ever emitted empty. It has to: an XML serialiser writes `<script src="x"/>`, which every browser reads as an unterminated script that swallows the rest of the document — and `<div/>`, `<a/>`, `<span/>` are mis-parsed too. `method="xhtml"` is *not* a portable fix: libxslt builds vary in accepting it, and a rejected output method **silently falls back to xml while still exiting 0**. Never treat a generator's exit code as proof it rendered correctly.
 
 **Entities in RDF literals.** A literal reaches the page either escaped (`xsl:value-of`, for `<title>` and `meta content`) or raw (`disable-output-escaping`, for markup-bearing fields). `&amp;` survives only the second path and appears verbatim in the first. **Store the real character** — it is correct on both paths.
@@ -129,6 +131,16 @@ Each of these cost real debugging time; all are fixed in the shipped engine code
 **`debug_level`.** Leave it set and a debug trailer renders as visible text on every page. Unset it before declaring done.
 
 ---
+
+## Interaction with `?skin=`
+
+`?skin=<name>` is a per-impression override, resolved before any config. Precedence, highest first:
+
+1. **`?skin=` naming an opl-skins bundle with `xslt/PostProcess.xslt`** — an explicit *legacy* skin override wins even on a composite site. Previewing another skin on a page is the point of the parameter, and it would be useless if composite config shadowed it.
+2. **`?skin=` naming a bundle with `skin.ttl`** — the same override, for a composite skin.
+3. **the configured `skin_manifest`** for that URL / site / global scope.
+
+So a composite site stays previewable under any legacy skin, and a composite skin can be previewed on a site that is not yet configured for it. Note the request URL reaches `incleng..transform` with `skin=` still on it; the parameter is stripped only for content and config resolution, so the page cache keys on it and previews do not poison the cached page.
 
 ## When to Use Which
 

--- a/osdi-inclusion-engine/references/config-api.md
+++ b/osdi-inclusion-engine/references/config-api.md
@@ -48,6 +48,15 @@ incleng..config_propagate_index_vsp(user, password)   -- defaults 'dav'
 incleng..config_migrate(in dangerous integer := 0)
 ```
 
+### `?skin=` — the per-impression override
+
+Not a config parameter, but it resolves ahead of every one of them. `?skin=<name>` selects a bundle under `/DAV/VAD/opl-skins/`: a legacy skin if the directory has `xslt/PostProcess.xslt`, a composite one if it has `skin.ttl`. Either **overrides `skin_manifest`**, so a composite site remains previewable under any other skin. See `references/composite-skins.md`.
+
+```sql
+incleng..skin_param_to_xslt(in skin varchar)      -- -> legacy PostProcess.xslt, or null
+incleng..skin_param_to_manifest(in skin varchar)  -- -> composite skin.ttl, or null
+```
+
 ## Composite Skin Functions
 
 Defined in `inclusion-engine/common/skin-api.sql`. See `references/composite-skins.md` for the manifest vocabulary these read.


### PR DESCRIPTION
Follows #109. Both of these were found while building the openlink composite site — *after* `references/composite-skins.md` was written — and both will bite the next person.

## Virtuoso rejects `EXISTS` inside `BIND`

rdflib accepts it, so a data source developed against the offline harness can fail outright on the server with `syntax error at EXISTS`. Because the whole data source fails, the page **500s rather than degrading**. `FILTER NOT EXISTS` is best avoided for the same reason.

The fix isn't a cleverer query — it's to compute structural facts where they're already known and record them as triples. A `topLevel` / `hasChildren` / `coversSlug` flag costs one triple and removes the portability question entirely.

This is the most likely way a working offline skin breaks on deployment, so it leads the Gotchas section.

## `?skin=` overrides `skin_manifest`

`?skin=` resolves ahead of every config parameter. Precedence, highest first:

1. `?skin=` naming a **legacy** bundle — wins even on a composite site
2. `?skin=` naming a **composite** bundle
3. the configured `skin_manifest`

So a composite site stays previewable under any legacy skin, and a composite skin can be previewed on a site not yet configured for it. Documented in `composite-skins.md` with the caching note, and in `config-api.md` beside the parameters it takes precedence over — that's where someone will actually look.

## Engine side

The corresponding engine work is on devhub (bare gitolite, no PR mechanism), pushed to a personal fork for the maintainer to fetch:

```
git@devhub.openlinksw.com:public/kidehen/inclusion-engine
branch: feature/20260826-composite-skins   (7 commits)
diff against: develop
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)