### PR TITLE
Add generic XMLA client skill

### DIFF
--- a/xmla-client/README.md
+++ b/xmla-client/README.md
@@ -1,0 +1,125 @@
+# XMLA Client Showcases
+
+These examples were verified against the public OpenLink Virtuoso XMLA service at `https://demo.openlinksw.com/XMLA` using `DSN=Local_Instance`.
+
+They demonstrate two distinct capabilities:
+
+1. SQL over XMLA against a Virtuoso catalog table.
+2. SPASQL over XMLA, with SPARQL-FED delegating part of the query to DBpedia.
+
+## Setup
+
+Run commands from the `xmla-client` directory. Supply credentials through environment variables so they do not appear in the command line, SOAP evidence, or shell history:
+
+```bash
+export XMLA_PROPERTY_USERNAME='<XMLA username>'
+read -rs XMLA_PROPERTY_PASSWORD
+export XMLA_PROPERTY_PASSWORD
+```
+
+The OpenLink demo tests used the endpoint's public demo account. Obtain or confirm current credentials from the endpoint operator rather than embedding them in scripts.
+
+## Showcase 1: SQL against `Demo..Customers`
+
+This bounded query retrieves ten customer records:
+
+```bash
+python3 scripts/xmla_client.py \
+  --endpoint https://demo.openlinksw.com/XMLA \
+  --data-source-info 'DSN=Local_Instance' \
+  --catalog Demo \
+  execute \
+  --statement 'SELECT TOP 10 * FROM Demo..Customers' \
+  --output-format json
+```
+
+Verified result: 10 rows with these columns:
+
+```text
+CustomerID, CompanyName, ContactName, ContactTitle, Address, City,
+Region, PostalCode, Country, CountryCode, Phone, Fax
+```
+
+Sample rows:
+
+| CustomerID | CompanyName | City | Country |
+|---|---|---|---|
+| `ALFKI` | Alfreds Futterkiste | Berlin | Germany |
+| `ANATR` | Ana Trujillo Emparedados y helados | México D.F. | Mexico |
+| `ANTON` | Antonio Moreno Taquería | México D.F. | Mexico |
+| `AROUT` | Around the Horn | London | United Kingdom |
+| `BERGS` | Berglunds snabbköp | Luleå | Sweden |
+
+The client represents XML `xsi:nil="1"` values as an `@attributes` object in normalized JSON, preserving the distinction between a null field and an empty string.
+
+## Showcase 2: SPASQL and SPARQL-FED against DBpedia
+
+This query is SQL at the outer layer, SPARQL inside the derived table, and SPARQL-FED at the `SERVICE` boundary. The inner `LIMIT` bounds work performed by the remote DBpedia endpoint.
+
+```bash
+python3 scripts/xmla_client.py \
+  --endpoint https://demo.openlinksw.com/XMLA \
+  --data-source-info 'DSN=Local_Instance' \
+  --catalog DB \
+  --timeout 45 \
+  execute --stdin --output-format json <<'SQL'
+SELECT movie
+FROM (SPARQL
+  PREFIX dbr: <http://dbpedia.org/resource/>
+  PREFIX dbo: <http://dbpedia.org/ontology/>
+  SELECT ?movie
+  WHERE {
+    SERVICE <https://dbpedia.org/sparql> {
+      SELECT DISTINCT ?movie
+      WHERE {
+        ?movie a dbo:Film ;
+               dbo:director dbr:Spike_Lee .
+      }
+      ORDER BY ?movie
+      LIMIT 20
+    }
+  }
+) AS movies
+ORDER BY movie
+SQL
+```
+
+Verified result: 20 DBpedia movie IRIs, including:
+
+```text
+http://dbpedia.org/resource/25th_Hour
+http://dbpedia.org/resource/4_Little_Girls
+http://dbpedia.org/resource/Bamboozled
+http://dbpedia.org/resource/BlacKkKlansman
+http://dbpedia.org/resource/Chi-Raq
+http://dbpedia.org/resource/Crooklyn
+http://dbpedia.org/resource/Da_5_Bloods
+http://dbpedia.org/resource/Do_the_Right_Thing
+http://dbpedia.org/resource/He_Got_Game
+http://dbpedia.org/resource/Inside_Man
+```
+
+The successful execution chain was:
+
+```text
+XMLA Execute
+  -> Virtuoso SQL
+    -> SPASQL derived table
+      -> SPARQL-FED SERVICE
+        -> DBpedia SPARQL endpoint
+```
+
+### Federation portability note
+
+Projecting DBpedia's language-tagged `rdfs:label` directly through this specific federation path produced Virtuoso error `SR549` while materializing the RDF literal. Converting that label with a computed alias inside the remote `SERVICE` subquery then produced `SP031`, because the remote service binding did not advertise support for that result-set extension.
+
+Projecting the movie IRIs is the demonstrated interoperable form. Resolve labels separately when the provider can do so without crossing this literal-conversion boundary.
+
+## Protocol notes
+
+- XMLA is tested with a SOAP `POST`; a browser-style `GET /XMLA` may return 404 even when XMLA works.
+- Start endpoint inspection with `DISCOVER_DATASOURCES`, then `DISCOVER_SCHEMA_ROWSETS` and `DISCOVER_PROPERTIES`.
+- The OpenLink demo advertises `UserName` and `Password` as XMLA `PropertyList` values. The client sources these from `XMLA_PROPERTY_USERNAME` and `XMLA_PROPERTY_PASSWORD`.
+- Preserve `--response-out` when diagnosing provider faults; the client writes the raw SOAP response even when the HTTP status is 500.
+
+See [SKILL.md](SKILL.md) for operating instructions and [references/xmla-protocol.md](references/xmla-protocol.md) for protocol details.

--- a/xmla-client/SKILL.md
+++ b/xmla-client/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: xmla-client
+description: Interrogate XML for Analysis (XMLA) SOAP endpoints, discover data sources and schema rowsets, and execute MDX or other provider-supported statements. Use for XMLA endpoint inspection, OLAP metadata discovery, connectivity diagnosis, or structured query execution; do not use for unrelated SOAP services.
+---
+
+# XMLA Client
+
+Use `scripts/xmla_client.py` to speak XMLA directly over SOAP 1.1. It uses only the Python standard library.
+
+## Workflow
+
+1. Start with `DISCOVER_DATASOURCES`. Do not reject an endpoint because HTTP `GET` returns 404; XMLA is exercised by a SOAP `POST` and a service may accept only that method.
+2. Inspect the returned `DataSourceInfo`, provider name, provider type, URL, and authentication mode.
+3. Continue with `DISCOVER_SCHEMA_ROWSETS` for the selected data source. Then use an advertised schema rowset such as `DBSCHEMA_CATALOGS`, `MDSCHEMA_CUBES`, or `MDSCHEMA_MEASURES` with appropriate restrictions.
+4. Use `execute` only when the user wants a statement run. XMLA providers may accept MDX, SQL, or another command dialect. Treat data-changing statements as mutations and require explicit authorization before sending them.
+5. On failure, preserve the HTTP status and SOAP Fault. Retry only when a changed binding, credential, property, or restriction is supported by evidence.
+
+Read [references/xmla-protocol.md](references/xmla-protocol.md) when choosing discovery rowsets, properties, output handling, or authentication. Read [references/demo-openlink-proof.md](references/demo-openlink-proof.md) for the live OpenLink proof that motivated this client.
+
+Read [README.md](README.md) when the user wants runnable, verified SQL or SPASQL/SPARQL-FED examples.
+
+## Commands
+
+Discover data sources:
+
+```bash
+python3 scripts/xmla_client.py \
+  --endpoint https://example.com/XMLA \
+  discover --request-type DISCOVER_DATASOURCES
+```
+
+Discover catalogs for one advertised data source:
+
+```bash
+python3 scripts/xmla_client.py \
+  --endpoint https://example.com/XMLA \
+  --data-source-info 'DSN=Local_Instance' \
+  discover --request-type DBSCHEMA_CATALOGS
+```
+
+Execute a statement from a file:
+
+```bash
+python3 scripts/xmla_client.py \
+  --endpoint https://example.com/XMLA \
+  --data-source-info 'DSN=Local_Instance' \
+  --catalog Demo \
+  execute --statement-file query.mdx --output-format pretty-xml
+```
+
+Use repeated `--restriction NAME=VALUE` and `--property NAME=VALUE` arguments for provider-specific discovery. Use `--dry-run --output-format pretty-xml` to inspect the SOAP envelope without sending it.
+
+## Credentials and TLS
+
+- Basic authentication: set `XMLA_USERNAME` and `XMLA_PASSWORD`. The environment variable names can be changed with `--username-env` and `--password-env`.
+- Bearer authentication: set `XMLA_BEARER_TOKEN` or select another variable with `--bearer-token-env`.
+- XMLA `PropertyList` authentication: set `XMLA_PROPERTY_USERNAME` and `XMLA_PROPERTY_PASSWORD`. Change the variable names with `--xmla-username-env` and `--xmla-password-env`. Use this when `DISCOVER_PROPERTIES` advertises `UserName` and `Password` properties or a SOAP Fault explicitly requests them.
+- Never place passwords or bearer tokens in command arguments, generated XML, logs, or skill files.
+- Prefer normal certificate validation. Use `--ca-cert` for a private CA. Use `--insecure` only for an explicitly approved diagnostic against a known endpoint.
+- For mutual TLS, use `--client-cert` and, when separate, `--client-key`.
+
+## Result discipline
+
+Default JSON output contains normalized rowset rows and a row count. Use `--output-format xml` when exact server bytes matter and `pretty-xml` for inspection. `--response-out` preserves the unmodified response independently of formatted stdout. Do not claim a query succeeded unless the response is HTTP-successful and contains no SOAP Fault.

--- a/xmla-client/agents/openai.yaml
+++ b/xmla-client/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "XMLA Client"
+  short_description: "Discover XMLA metadata and execute statements."
+  default_prompt: "Use $xmla-client to inspect an XMLA endpoint and return structured results."

--- a/xmla-client/references/demo-openlink-proof.md
+++ b/xmla-client/references/demo-openlink-proof.md
@@ -1,0 +1,32 @@
+# Live proof: OpenLink demo XMLA endpoint
+
+Validated on 2026-08-29 against `https://demo.openlinksw.com/XMLA`.
+
+The proof was an XMLA SOAP 1.1 `Discover` request with `RequestType` set to `DISCOVER_DATASOURCES`, not an HTTP `GET`. The service returned:
+
+- HTTP status: `200 OK`
+- Content type: `text/xml; charset=utf-8`
+- Response size: 12,772 bytes
+- XMLA operation: `DiscoverResponse`
+- Provider name: `Virtuoso XML for Analysis`
+- Advertised endpoint URL: `https://demo.openlinksw.com/XMLA`
+- Local data-source selector: `DSN=Local_Instance`
+- Authentication mode: `Authenticated`
+- Data-source rows normalized by the packaged client: 22
+
+The rowset also advertised data sources backed by Databricks, Informix, Oracle, MySQL, PostgreSQL, Presto, SQL Server, Neo4j, Snowflake, and other configured DSNs. This establishes that a generic XMLA client can bootstrap from the endpoint without prior catalog knowledge.
+
+Two further read-only requests used the advertised `DSN=Local_Instance` selector:
+
+- `DISCOVER_SCHEMA_ROWSETS` returned 13 supported rowsets: `DBSCHEMA_CATALOGS`, `DBSCHEMA_TABLES`, `DBSCHEMA_TABLES_INFO`, `DBSCHEMA_COLUMNS`, `DBSCHEMA_PRIMARY_KEYS`, `DBSCHEMA_FOREIGN_KEYS`, `DBSCHEMA_PROVIDER_TYPES`, `DISCOVER_DATASOURCES`, `DISCOVER_PROPERTIES`, `DISCOVER_SCHEMA_ROWSETS`, `DISCOVER_ENUMERATORS`, `DISCOVER_KEYWORDS`, and `DISCOVER_LITERALS`.
+- `DBSCHEMA_CATALOGS` returned 92 catalog rows, including `DB`, `Demo`, `TPCH`, `School`, `stores_demo`, `postgres12`, and `mysql5`.
+
+Final packaged-client smoke run:
+
+| Request type | Rows | Response bytes | SHA-256 |
+|---|---:|---:|---|
+| `DISCOVER_DATASOURCES` | 22 | 12,772 | `99e7a6c663d680ef8478956b69120a8e1339f45e292e43ea25dc39f342f94206` |
+| `DISCOVER_SCHEMA_ROWSETS` | 13 | 6,259 | `4950a2ade2d5bd960eb5470ca2e3626928de897499a034e1d1404aa9164ea2b7` |
+| `DBSCHEMA_CATALOGS` | 92 | 13,208 | `5f8652a8d4641bda2eb4bb1b75ab3e09395f4dd761afca1e2abfd60c086fef6c` |
+
+Important observed behavior: a browser-style `GET /XMLA` returned 404 while the XMLA SOAP `POST /XMLA` returned the valid XMLA rowset. Client validation must therefore speak XMLA rather than use GET availability as the protocol test.

--- a/xmla-client/references/xmla-protocol.md
+++ b/xmla-client/references/xmla-protocol.md
@@ -1,0 +1,38 @@
+# XMLA protocol notes
+
+XML for Analysis (XMLA) uses SOAP operations in the namespace `urn:schemas-microsoft-com:xml-analysis`.
+
+## Operations
+
+- `Discover` requests a named metadata rowset. Its body contains `RequestType`, `Restrictions/RestrictionList`, and `Properties/PropertyList`.
+- `Execute` submits `Command/Statement` plus `Properties/PropertyList`. Providers commonly interpret the statement as MDX, but some expose SQL or another dialect.
+
+The SOAP 1.1 action is `urn:schemas-microsoft-com:xml-analysis:Discover` or `urn:schemas-microsoft-com:xml-analysis:Execute`. Use `Content-Type: text/xml; charset=utf-8`.
+
+## Discovery progression
+
+1. `DISCOVER_DATASOURCES` identifies service bindings, data-source information strings, provider types, and authentication modes.
+2. `DISCOVER_SCHEMA_ROWSETS` lists the metadata rowsets supported by the selected provider.
+3. Relational providers often expose `DBSCHEMA_CATALOGS`, `DBSCHEMA_SCHEMATA`, `DBSCHEMA_TABLES`, and `DBSCHEMA_COLUMNS`.
+4. Multidimensional providers often expose `MDSCHEMA_CUBES`, `MDSCHEMA_DIMENSIONS`, `MDSCHEMA_HIERARCHIES`, `MDSCHEMA_LEVELS`, `MDSCHEMA_MEASURES`, and `MDSCHEMA_MEMBERS`.
+
+Do not assume every provider supports every rowset. Ask `DISCOVER_SCHEMA_ROWSETS` and use its restriction metadata.
+
+## Properties and restrictions
+
+Common properties include:
+
+- `DataSourceInfo`: provider connection selector returned by `DISCOVER_DATASOURCES`.
+- `Catalog`: selected relational or multidimensional catalog.
+- `Content`: response detail, commonly `SchemaData`.
+- `Format`: provider-supported rowset or multidimensional response format.
+
+Restrictions are rowset-specific. Common examples include `CATALOG_NAME`, `SCHEMA_NAME`, `TABLE_NAME`, `TABLE_TYPE`, `CUBE_NAME`, and `MEASURE_NAME`. Preserve case and spelling advertised by the service.
+
+## Response handling
+
+Discovery usually returns an inline XML Schema followed by `<row>` elements in `urn:schemas-microsoft-com:xml-analysis:rowset`. Execute may return a rowset or a multidimensional dataset. A successful HTTP status can still carry a SOAP Fault, so inspect both transport and envelope.
+
+## Authentication
+
+XMLA authentication may be an HTTP concern or may use provider properties. This client supports HTTP Basic, bearer tokens, mutual TLS, private certificate authorities, normal anonymous access, and the `UserName`/`Password` XMLA properties through environment variables. Inspect `DISCOVER_PROPERTIES` and SOAP Faults before selecting the mode. Keep secrets in environment variables and never embed them in command arguments or saved SOAP request files.

--- a/xmla-client/scripts/xmla_client.py
+++ b/xmla-client/scripts/xmla_client.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Small dependency-free XMLA SOAP 1.1 client."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any, Iterable
+from xml.dom import minidom
+
+SOAP_NS = "http://schemas.xmlsoap.org/soap/envelope/"
+XMLA_NS = "urn:schemas-microsoft-com:xml-analysis"
+ROWSET_NS = "urn:schemas-microsoft-com:xml-analysis:rowset"
+
+ET.register_namespace("soap", SOAP_NS)
+ET.register_namespace("xmla", XMLA_NS)
+
+
+class ClientError(RuntimeError):
+    """Expected request, transport, or XMLA response failure."""
+
+
+def qname(namespace: str, local: str) -> str:
+    return f"{{{namespace}}}{local}"
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def parse_assignments(values: Iterable[str], label: str) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    for value in values:
+        if "=" not in value:
+            raise ClientError(f"{label} must use NAME=VALUE: {value!r}")
+        name, item_value = value.split("=", 1)
+        name = name.strip()
+        if not name:
+            raise ClientError(f"{label} name cannot be empty")
+        parsed[name] = item_value
+    return parsed
+
+
+def add_properties(parent: ET.Element, properties: dict[str, str]) -> None:
+    properties_element = ET.SubElement(parent, qname(XMLA_NS, "Properties"))
+    property_list = ET.SubElement(properties_element, qname(XMLA_NS, "PropertyList"))
+    for name, value in properties.items():
+        ET.SubElement(property_list, qname(XMLA_NS, name)).text = value
+
+
+def envelope_with(operation: ET.Element) -> ET.Element:
+    envelope = ET.Element(qname(SOAP_NS, "Envelope"))
+    ET.SubElement(envelope, qname(SOAP_NS, "Header"))
+    body = ET.SubElement(envelope, qname(SOAP_NS, "Body"))
+    body.append(operation)
+    return envelope
+
+
+def build_discover(request_type: str, restrictions: dict[str, str], properties: dict[str, str]) -> bytes:
+    operation = ET.Element(qname(XMLA_NS, "Discover"))
+    ET.SubElement(operation, qname(XMLA_NS, "RequestType")).text = request_type
+    restrictions_element = ET.SubElement(operation, qname(XMLA_NS, "Restrictions"))
+    restriction_list = ET.SubElement(restrictions_element, qname(XMLA_NS, "RestrictionList"))
+    for name, value in restrictions.items():
+        ET.SubElement(restriction_list, qname(XMLA_NS, name)).text = value
+    add_properties(operation, properties)
+    return ET.tostring(envelope_with(operation), encoding="utf-8", xml_declaration=True)
+
+
+def build_execute(statement: str, properties: dict[str, str]) -> bytes:
+    operation = ET.Element(qname(XMLA_NS, "Execute"))
+    command = ET.SubElement(operation, qname(XMLA_NS, "Command"))
+    ET.SubElement(command, qname(XMLA_NS, "Statement")).text = statement
+    add_properties(operation, properties)
+    return ET.tostring(envelope_with(operation), encoding="utf-8", xml_declaration=True)
+
+
+def pretty_xml(payload: bytes) -> str:
+    try:
+        return minidom.parseString(payload).toprettyxml(indent="  ")
+    except Exception as exc:
+        raise ClientError(f"response is not valid XML: {exc}") from exc
+
+
+def child_value(element: ET.Element) -> Any:
+    children = list(element)
+    text = (element.text or "").strip()
+    attributes = {local_name(name): value for name, value in element.attrib.items()}
+    if not children and not attributes:
+        return text
+    result: dict[str, Any] = {}
+    if attributes:
+        result["@attributes"] = attributes
+    for child in children:
+        name = local_name(child.tag)
+        value = child_value(child)
+        if name in result:
+            current = result[name]
+            result[name] = current + [value] if isinstance(current, list) else [current, value]
+        else:
+            result[name] = value
+    if text:
+        result["_text"] = text
+    return result
+
+
+def find_fault(root: ET.Element) -> dict[str, Any] | None:
+    fault = next((item for item in root.iter() if local_name(item.tag) == "Fault"), None)
+    if fault is None:
+        return None
+    return {local_name(child.tag): child_value(child) for child in fault}
+
+
+def normalize_response(payload: bytes) -> dict[str, Any]:
+    try:
+        root = ET.fromstring(payload)
+    except ET.ParseError as exc:
+        raise ClientError(f"response is not valid XML: {exc}") from exc
+    fault = find_fault(root)
+    if fault is not None:
+        return {"fault": fault}
+    rows = []
+    for element in root.iter():
+        if element.tag == qname(ROWSET_NS, "row") or local_name(element.tag) == "row":
+            rows.append({local_name(child.tag): child_value(child) for child in element})
+    if rows:
+        return {"row_count": len(rows), "rows": rows}
+    body = next((item for item in root.iter() if local_name(item.tag) == "Body"), root)
+    return {"row_count": 0, "response": child_value(body)}
+
+
+def ssl_context(args: argparse.Namespace) -> ssl.SSLContext:
+    if args.insecure:
+        context = ssl._create_unverified_context()
+    else:
+        context = ssl.create_default_context(cafile=args.ca_cert)
+    if args.client_cert:
+        context.load_cert_chain(args.client_cert, args.client_key)
+    return context
+
+
+def auth_header(args: argparse.Namespace) -> str | None:
+    bearer = os.environ.get(args.bearer_token_env)
+    if bearer:
+        return f"Bearer {bearer}"
+    username = os.environ.get(args.username_env)
+    password = os.environ.get(args.password_env)
+    if username is None and password is None:
+        return None
+    if username is None or password is None:
+        raise ClientError(
+            f"basic authentication requires both {args.username_env} and {args.password_env}"
+        )
+    encoded = base64.b64encode(f"{username}:{password}".encode()).decode("ascii")
+    return f"Basic {encoded}"
+
+
+def send(args: argparse.Namespace, operation: str, payload: bytes) -> tuple[int, str, str, bytes]:
+    headers = {
+        "Content-Type": "text/xml; charset=utf-8",
+        "Accept": "text/xml, application/xml",
+        "SOAPAction": f'"{XMLA_NS}:{operation}"',
+        "User-Agent": "xmla-client-skill/1.0",
+    }
+    authorization = auth_header(args)
+    if authorization:
+        headers["Authorization"] = authorization
+    request = urllib.request.Request(args.endpoint, data=payload, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(request, timeout=args.timeout, context=ssl_context(args)) as response:
+            return response.status, response.reason, response.headers.get("Content-Type", ""), response.read()
+    except urllib.error.HTTPError as exc:
+        response_body = exc.read()
+        content_type = exc.headers.get("Content-Type", "") if exc.headers else ""
+        return exc.code, str(exc.reason), content_type, response_body
+    except urllib.error.URLError as exc:
+        raise ClientError(f"transport failure: {exc.reason}") from exc
+
+
+def write_output(text: str, destination: str | None) -> None:
+    if destination:
+        Path(destination).write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+        if text and not text.endswith("\n"):
+            sys.stdout.write("\n")
+
+
+def render(payload: bytes, output_format: str) -> str:
+    if output_format == "xml":
+        return payload.decode("utf-8", errors="replace")
+    if output_format == "pretty-xml":
+        return pretty_xml(payload)
+    return json.dumps(normalize_response(payload), indent=2, ensure_ascii=False)
+
+
+def statement_from(args: argparse.Namespace) -> str:
+    sources = sum(value is not None for value in (args.statement, args.statement_file)) + int(args.stdin)
+    if sources != 1:
+        raise ClientError("execute requires exactly one of --statement, --statement-file, or --stdin")
+    if args.statement is not None:
+        return args.statement
+    if args.statement_file is not None:
+        return Path(args.statement_file).read_text(encoding="utf-8")
+    return sys.stdin.read()
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description="Speak XMLA over SOAP 1.1")
+    result.add_argument("--endpoint", required=True, help="XMLA HTTP(S) endpoint")
+    result.add_argument("--data-source-info", help="XMLA DataSourceInfo property, e.g. DSN=Local_Instance")
+    result.add_argument("--catalog", help="XMLA Catalog property")
+    result.add_argument("--timeout", type=float, default=30.0, help="request timeout in seconds")
+    result.add_argument("--username-env", default="XMLA_USERNAME")
+    result.add_argument("--password-env", default="XMLA_PASSWORD")
+    result.add_argument("--bearer-token-env", default="XMLA_BEARER_TOKEN")
+    result.add_argument("--xmla-username-env", default="XMLA_PROPERTY_USERNAME")
+    result.add_argument("--xmla-password-env", default="XMLA_PROPERTY_PASSWORD")
+    result.add_argument("--ca-cert", help="CA bundle for server validation")
+    result.add_argument("--client-cert", help="PEM client certificate or combined certificate/key")
+    result.add_argument("--client-key", help="PEM client key when separate from --client-cert")
+    result.add_argument("--insecure", action="store_true", help="disable TLS validation for approved diagnostics")
+    result.add_argument("--dry-run", action="store_true", help="emit request without sending")
+    result.add_argument("--show-request", action="store_true", help="pretty-print request to stderr")
+    result.add_argument("--response-out", help="write the unmodified response bytes to this file")
+    result.add_argument("--output", help="write formatted output to this file instead of stdout")
+
+    subparsers = result.add_subparsers(dest="command", required=True)
+    discover = subparsers.add_parser("discover", help="send an XMLA Discover request")
+    discover.add_argument("--request-type", required=True)
+    discover.add_argument("--restriction", action="append", default=[], metavar="NAME=VALUE")
+    discover.add_argument("--property", action="append", default=[], metavar="NAME=VALUE")
+    discover.add_argument("--output-format", choices=("json", "xml", "pretty-xml"), default="json")
+
+    execute = subparsers.add_parser("execute", help="send an XMLA Execute request")
+    statement_group = execute.add_mutually_exclusive_group()
+    statement_group.add_argument("--statement")
+    statement_group.add_argument("--statement-file")
+    statement_group.add_argument("--stdin", action="store_true")
+    execute.add_argument("--property", action="append", default=[], metavar="NAME=VALUE")
+    execute.add_argument("--output-format", choices=("json", "xml", "pretty-xml"), default="json")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        properties = parse_assignments(args.property, "property")
+        if args.data_source_info is not None:
+            properties["DataSourceInfo"] = args.data_source_info
+        if args.catalog is not None:
+            properties["Catalog"] = args.catalog
+        xmla_username = os.environ.get(args.xmla_username_env)
+        xmla_password = os.environ.get(args.xmla_password_env)
+        if (xmla_username is None) != (xmla_password is None):
+            raise ClientError(
+                f"XMLA property authentication requires both {args.xmla_username_env} "
+                f"and {args.xmla_password_env}"
+            )
+        if xmla_username is not None:
+            properties.setdefault("UserName", xmla_username)
+            properties.setdefault("Password", xmla_password or "")
+        properties.setdefault("Content", "SchemaData")
+
+        if args.command == "discover":
+            restrictions = parse_assignments(args.restriction, "restriction")
+            payload = build_discover(args.request_type, restrictions, properties)
+            operation = "Discover"
+        else:
+            payload = build_execute(statement_from(args), properties)
+            operation = "Execute"
+
+        if args.show_request:
+            sys.stderr.write(pretty_xml(payload))
+        if args.dry_run:
+            write_output(render(payload, args.output_format), args.output)
+            return 0
+
+        status, reason, content_type, response = send(args, operation, payload)
+        if args.response_out:
+            Path(args.response_out).write_bytes(response)
+        try:
+            normalized = normalize_response(response)
+        except ClientError:
+            if status >= 400:
+                raise ClientError(f"HTTP {status} {reason}; response is not XML")
+            raise
+        if "fault" in normalized:
+            raise ClientError(
+                f"HTTP {status} {reason}; SOAP Fault: "
+                f"{json.dumps(normalized['fault'], ensure_ascii=False)}"
+            )
+        if status >= 400:
+            raise ClientError(f"HTTP {status} {reason}")
+        if args.show_request:
+            sys.stderr.write(f"HTTP {status}; Content-Type: {content_type}\n")
+        write_output(render(response, args.output_format), args.output)
+        return 0
+    except (ClientError, OSError) as exc:
+        sys.stderr.write(f"xmla-client: {exc}\n")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a dependency-free XMLA SOAP 1.1 client skill with Discover and Execute support
- support rowset JSON normalization, raw and pretty XML, SOAP Fault preservation, HTTP and XMLA property authentication, TLS, and mTLS
- document verified SQL and SPASQL/SPARQL-FED showcases against the OpenLink demo service
- include protocol notes, live proof, and Codex metadata

## Validation
- skill-creator quick_validate.py: PASS
- Python syntax compilation: PASS
- live SQL showcase: SELECT TOP 10 from Demo..Customers returned 10 rows
- live SPASQL/SPARQL-FED showcase: DBpedia Spike Lee films returned 20 IRIs