### PR TITLE
Add ucp-client RDF offer discovery and auth negotiation

### DIFF
--- a/ucp-client/SKILL.md
+++ b/ucp-client/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: ucp-client
+description: Purchase an HTTP-protected resource by discovering an RDF schema:Offer, authenticating an identity (WebID-TLS/mTLS, OAuth Bearer/DPoP, Digest, or headers), mapping the offer to UCP checkout, handing payment to Machine Payments Protocol (MPP) with Stripe support, verifying the receipt, and retrieving the resource. Use when a user supplies a resource URL and wants flexible identity-first ACL handling, UCP checkout, HTTP 402 payment, or an auditable RDF-to-commerce purchase flow.
+---
+
+# UCP Client
+
+Use the resource URL as the primary identifier. Keep RDF as the authoritative offer description, UCP as the commerce/checkout protocol, MPP as the HTTP 402 payment protocol, and Stripe as a payment processor. Do not collapse these layers.
+
+## Core workflow
+
+1. Accept a protected `resource_url` and establish the request identity without putting secrets on the command line. For the selected ODS-QA direct-execution profile, use the [`mtls-curl`](/Users/kidehen/Documents/Management/Development/ai-agent-skills/mtls-curl/SKILL.md) skill with a PKCS#12 or PEM client certificate and `curl`. The client also accepts an OAuth access token (Bearer or DPoP), Digest credentials, environment-backed headers, or an already-established ambient identity session. Discover OAuth metadata from the resource origin's [OAuth 2.0 Authorization Server Metadata](https://www.rfc-editor.org/rfc/rfc8414) endpoint when using OAuth; the server OAuth backend is assumed to already exist and is not implemented by this skill.
+2. Probe the resource before commerce. Interpret the server response as an identity-first state machine: `401` means authentication is missing or failed and may advertise one or more authentication schemes; `200` means the authenticated identity passes the resource ACL; `402` means the authenticated identity failed the ACL and payment can grant access; `403` is a terminal policy denial without a payable challenge. A `401` may therefore trigger Digest, WebID-TLS/mTLS, or OAuth token acquisition; it is never itself a payment challenge.
+3. Accept `402` only when identity was established and the response includes at least one `WWW-Authenticate: Payment` challenge. Parse repeated `WWW-Authenticate` and `Link` fields, preserving Payment challenge parameters, `Payment-Receipt`, `Location`, content type, and links such as `rel=offer`, `describedby`, `alternate`, or `payment`. A naked `402`, or `402` before identity, is a protocol error.
+4. Query the merchant RDF knowledge graph for a `schema:Offer` associated with the resource IRI. Accept both Schema.org namespace forms (`http://schema.org/` and `https://schema.org/`). Match direct `schema:itemOffered`, `schema:url`, `schema:contentUrl`, or `schema:identifier` links and item-mediated links such as Offer → License/Product → resource. Use `--resource-predicate IRI` for additional explicit merchant relations. Use `--sparql-endpoint` when known; otherwise try `<merchant-origin>/sparql`; then use response-linked or explicit RDF metadata.
+5. Extract offer identity, item identity, price, currency, availability, seller, and UCP item identifier. Read price/currency either directly or through `schema:priceSpecification`. Prefer `schema:sku`, then `schema:productID`, then literal `schema:identifier`; known explicit merchant identifiers such as `oplofr:offerNumber` may follow. For another merchant vocabulary use repeatable `--item-id-predicate IRI`, or supply a verified `--item-id VALUE`. Never infer an ID from a URL path. `schema:potentialAction` query parameters remain opt-in via `--allow-action-item-id`.
+6. Discover the merchant UCP profile at `/.well-known/ucp` and read the advertised `dev.ucp.shopping` REST checkout capability/version.
+7. Create a UCP checkout session using the mapped item ID and quantity. Treat the checkout response as authoritative for final price, totals, eligibility, and status. Before spending money, surface the checkout amount/currency and payment boundary unless the user explicitly authorized the purchase and any required spending limit is satisfied.
+8. Fulfill one server-advertised Payment challenge using an MPP implementation such as `mppx`. Preserve identity independently through WebID-TLS/mTLS, an authenticated session cookie, or a server-side challenge binding; Basic/Digest/Bearer/DPoP and Payment cannot both occupy the single `Authorization` field. After entitlement binding, retry the resource with the original identity context and capture `Payment-Receipt` plus the final status.
+9. Reconcile the MPP receipt with the UCP checkout only through a merchant-supported binding. Return the resource plus provenance: identity-gate state, resource URL, offer IRI, checkout ID/status, amount/currency, Payment method/intent, receipt, and final HTTP status.
+
+### Response-driven authentication selection
+
+Treat `401 Unauthorized` as an authentication-protocol negotiation point. Inspect every `WWW-Authenticate` challenge and authentication `Link` metadata before choosing a retry. Select Digest when Digest is advertised; select OAuth when Bearer/DPoP or OAuth metadata is advertised; or negotiate WebID-TLS/mTLS at the TLS layer when a certificate listener is available. Do not infer that Digest is the only possible method merely because it is the only challenge in one response. A successful identity retry proceeds to ACL evaluation; only an authenticated ACL miss can become `402 Payment Required`.
+
+## RDF offer rules
+
+Prefer Schema.org IRIs (`https://schema.org/`), while accepting the historically equivalent `http://schema.org/` vocabulary in merchant data. A minimal offer should expose:
+
+```turtle
+@prefix schema: <https://schema.org/> .
+
+<https://merchant.example/offers/report-123>
+    a schema:Offer ;
+    schema:itemOffered <https://merchant.example/DAV/report-123.pdf> ;
+    schema:sku "report-123" ;
+    schema:price "5.00" ;
+    schema:priceCurrency "USD" ;
+    schema:availability schema:InStock .
+```
+
+Treat IRIs as first-class identifiers. Preserve the offer IRI and resource IRI even when UCP requires a compact merchant item ID.
+
+If multiple offers match, rank exact `schema:itemOffered == resource_url` first, then an explicit relation from the offered item, then a direct offer-to-resource relation; prefer offers with explicit price/currency. If ambiguity remains, do not purchase until a single offer is selected.
+
+## UCP rules
+
+Use the UCP profile rather than hard-coded checkout paths. For REST, discover the service endpoint from `/.well-known/ucp` and issue standard checkout operations relative to it. Read `references/protocol-notes.md` for version and payment-boundary cautions.
+
+Use `scripts/ucp_resource_client.py` for deterministic RDF discovery, UCP profile discovery, checkout creation, MPP handoff orchestration, and provenance output.
+
+For the identity-first response contract and secure CLI identity options, read `references/protocol-notes.md` and `references/api_reference.md`.
+
+Typical dry run:
+
+```bash
+python scripts/ucp_resource_client.py \
+  --resource-url https://merchant.example/DAV/report.pdf \
+  --rdf-url https://merchant.example/offers/report.ttl \
+  --sparql-endpoint https://merchant.example/sparql \
+  --dry-run
+```
+
+SPARQL offer discovery is attempted before `--rdf-url`; the endpoint is optional because the default is the merchant origin plus `/sparql`. The result records whether the offer came from SPARQL or RDF dereferencing, including the fallback reason when applicable. UCP discovery accepts both list-based profiles (`transport: rest`) and current nested profiles (`dev.ucp.shopping.rest.endpoint`), plus dictionary- or array-shaped capability manifests.
+
+For live MPP payment, install an MPP-aware client such as `mppx` and provide an executable command template with `--mpp-command`. The script substitutes `{url}` with the protected resource URL. Example:
+
+```bash
+python scripts/ucp_resource_client.py \
+  --resource-url https://merchant.example/DAV/report.pdf \
+  --rdf-url https://merchant.example/offers/report.ttl \
+  --mpp-command 'npx mppx {url}'
+```
+
+Never place Stripe secret keys, card numbers, private keys, bearer tokens, or MPP secrets in skill files or logs. Use environment variables, OS keychain facilities, or the payment SDK's secure configuration.
+
+## Safety and spending controls
+
+Require explicit purchase authorization before executing a non-test payment. Respect user-specified price/currency constraints. If the UCP checkout total differs materially from the RDF offer, stop and report the discrepancy. Do not auto-pay a different origin than the resource/merchant origins without explicit authorization.
+
+Prefer Stripe test mode/sandbox credentials for testing. Treat MPP Payment authentication as an emerging Internet-Draft protocol and preserve the exact challenge/receipt data for debugging and provenance.
+
+## Output
+
+Return a compact machine-readable result where possible, plus a human summary. Include:
+
+- `resource_url`
+- `offer_iri`
+- `ucp_item_id`
+- `rdf_price` / `rdf_currency`
+- `checkout_id` / `checkout_status`
+- authoritative checkout total when available
+- `mpp_method` / `mpp_intent`
+- payment receipt identifier/header when available
+- final resource HTTP status and content location
+- warnings or unresolved protocol-state differences
+
+For protocol details and mapping conventions, read `references/protocol-notes.md`.
+
+### Direct WebID-TLS/mTLS execution (ODS-QA)
+
+Use [`mtls-curl`](/Users/kidehen/Documents/Management/Development/ai-agent-skills/mtls-curl/SKILL.md) for the certificate transport, including PKCS#12 bundles. Keep the password in an environment variable and carry the same certificate context through RDF/UCP discovery and the post-payment retry. A live ODS-QA request without a certificate may return only `WWW-Authenticate: Digest`; that is one available authentication challenge, not a statement that OAuth or WebID-TLS is unsupported and not an MPP `402`. The observed pattern is public port `443` → `401`/Digest, while the mTLS listener on `5443` accepts the certificate and returns `302` followed by an identity-qualified `402` Payment challenge.
+
+### OAuth browser handoff (alternate)
+
+When direct TLS is unavailable, discover the resource origin's [OAuth 2.0 Authorization Server Metadata](https://www.rfc-editor.org/rfc/rfc8414), use Authorization Code + [PKCE](https://www.rfc-editor.org/rfc/rfc7636) in a browser, and pass the resulting access token via `--bearer-token-env`. Use `Authorization: Bearer` or `DPoP` plus a per-request `DPoP` proof. Tokens never appear in arguments, logs, checkout metadata, or provenance output; the token issuer must match the protected resource origin.

--- a/ucp-client/SKILL.md
+++ b/ucp-client/SKILL.md
@@ -23,6 +23,8 @@ Use the resource URL as the primary identifier. Keep RDF as the authoritative of
 
 Treat `401 Unauthorized` as an authentication-protocol negotiation point. Inspect every `WWW-Authenticate` challenge and authentication `Link` metadata before choosing a retry. Select Digest when Digest is advertised; select OAuth when Bearer/DPoP or OAuth metadata is advertised; or negotiate WebID-TLS/mTLS at the TLS layer when a certificate listener is available. Do not infer that Digest is the only possible method merely because it is the only challenge in one response. A successful identity retry proceeds to ACL evaluation; only an authenticated ACL miss can become `402 Payment Required`.
 
+When running interactively, stop at the first `401` and prompt the user: “Authentication is required. Choose Digest, OAuth Bearer/DPoP, WebID-TLS/mTLS, or cancel.” Show the advertised schemes and metadata links, explain the required credential or browser step, and wait for the user's choice before retrying. Never silently fall back between protocols. In non-interactive mode, return the choices as `authentication_schemes` and authentication links and stop without guessing.
+
 ## RDF offer rules
 
 Prefer Schema.org IRIs (`https://schema.org/`), while accepting the historically equivalent `http://schema.org/` vocabulary in merchant data. A minimal offer should expose:

--- a/ucp-client/agents/openai.yaml
+++ b/ucp-client/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "UCP Client"
+  short_description: "Buy RDF-described protected resources via UCP + MPP"

--- a/ucp-client/references/api_reference.md
+++ b/ucp-client/references/api_reference.md
@@ -25,6 +25,8 @@
 - `--accept-payment VALUE` — send `Accept-Payment`, for example `stripe/charge`.
 - `--access-probe-only` — execute the authenticated resource request, classify `200`/`401`/`402`/`403`, parse response metadata, and stop before commerce.
 
+Interactive callers must pause on `401`, present the discovered authentication choices to the user, and obtain an explicit protocol selection before retrying. Non-interactive callers must stop and return the parsed `authentication_schemes` and authentication links; they must not select Digest or OAuth implicitly.
+
 For `402`, the result contains parsed `payment_challenges`, typed `links`, `Payment-Receipt`, `Location`, and protocol errors. A linked `rel=describedby`/`alternate` RDF document and `rel=ucp`/`service-desc` UCP profile are used automatically when present.
 
 For direct WebID-TLS/mTLS with PKCS#12, compose this skill with [`mtls-curl`](/Users/kidehen/Documents/Management/Development/ai-agent-skills/mtls-curl/SKILL.md); the Python client retains PEM support while curl owns PKCS#12 transport and header capture. OAuth browser authorization is external: this skill consumes the resulting token and assumes the server OAuth backend is already deployed.

--- a/ucp-client/references/api_reference.md
+++ b/ucp-client/references/api_reference.md
@@ -1,0 +1,43 @@
+# UCP resource client command reference
+
+`scripts/ucp_resource_client.py` performs RDF offer discovery, UCP profile discovery, optional checkout creation, and optional MPP handoff.
+
+## Discovery and mapping options
+
+- `--resource-url URL` — protected resource IRI; required.
+- `--rdf-url URL` — explicit RDF offer document used after SPARQL fallback.
+- `--sparql-endpoint URL` — merchant SPARQL endpoint; defaults to `/sparql` on the merchant origin.
+- `--merchant-origin URL` — origin used for `/.well-known/ucp` discovery.
+- `--resource-predicate IRI` — additional predicate that explicitly links an Offer or its offered item to the resource; repeatable.
+- `--item-id-predicate IRI` — additional predicate containing a literal UCP item identifier; repeatable.
+- `--item-id VALUE` — verified UCP item identifier override.
+- `--allow-action-item-id` — opt in to an `item`, `sku`, `product`, or `product_id` query parameter from `schema:potentialAction`.
+
+## Identity and ACL probe options
+
+- `--identity-header-env HEADER=ENV_VAR` — set an identity-bearing request header from an environment variable; repeatable. The secret value is never emitted.
+- `--digest-user-env ENV_VAR` and `--digest-password-env ENV_VAR` — perform HTTP Digest authentication using environment-backed values. Supply both.
+- `--bearer-token-env ENV_VAR` — send an OAuth access token from an environment variable as `Authorization: Bearer ...` (or `DPoP ...`); the value is never emitted.
+- `--oauth-token-type {Bearer,DPoP}` — select the OAuth authorization scheme; defaults to `Bearer`.
+- `--dpop-proof-env ENV_VAR` — per-request DPoP proof JWT when `--oauth-token-type DPoP` is selected.
+- `--client-cert PATH` and optional `--client-key PATH` — use a PEM client certificate and key.
+- `--identity-established` — assert that an ambient session establishes identity without exposing credentials. This assertion does not itself authenticate the request.
+- `--accept-payment VALUE` — send `Accept-Payment`, for example `stripe/charge`.
+- `--access-probe-only` — execute the authenticated resource request, classify `200`/`401`/`402`/`403`, parse response metadata, and stop before commerce.
+
+For `402`, the result contains parsed `payment_challenges`, typed `links`, `Payment-Receipt`, `Location`, and protocol errors. A linked `rel=describedby`/`alternate` RDF document and `rel=ucp`/`service-desc` UCP profile are used automatically when present.
+
+For direct WebID-TLS/mTLS with PKCS#12, compose this skill with [`mtls-curl`](/Users/kidehen/Documents/Management/Development/ai-agent-skills/mtls-curl/SKILL.md); the Python client retains PEM support while curl owns PKCS#12 transport and header capture. OAuth browser authorization is external: this skill consumes the resulting token and assumes the server OAuth backend is already deployed.
+
+## Checkout and payment options
+
+- `--quantity N` — positive checkout quantity; defaults to 1.
+- `--agent-profile URL` — value advertised in the `UCP-Agent` header.
+- `--dry-run` — probe access, discover the offer, and render the checkout request without creating a checkout or invoking payment. It continues discovery after `401` for diagnostics while preserving the failed authentication state.
+- `--mpp-command TEMPLATE` — external MPP client command; `{url}` is replaced with the protected resource URL.
+
+## Compatibility behavior
+
+The client accepts both Schema.org namespace variants, direct and item-mediated resource relations, direct and `schema:priceSpecification` pricing, legacy and nested UCP REST-service declarations, and dictionary- or array-shaped capability manifests. Every selected UCP item ID includes `ucp_item_id_source` in the result.
+
+The client never converts an HTTP path into a merchant item ID. When the RDF does not contain an accepted identifier, supply a verified predicate or explicit value rather than guessing.

--- a/ucp-client/references/protocol-notes.md
+++ b/ucp-client/references/protocol-notes.md
@@ -41,6 +41,8 @@ The client treats server response headers as the REST discovery surface. A `401`
 
 For direct WebID-TLS, use [`mtls-curl`](/Users/kidehen/Documents/Management/Development/ai-agent-skills/mtls-curl/SKILL.md) with a PEM or PKCS#12 certificate. This is the preferred ODS-QA execution profile. The server OAuth backend is assumed to be implemented already; this skill only discovers metadata and consumes tokens. Preserve the certificate context across redirects and post-payment retries.
 
+An interactive client must turn this discovery into a user choice at the first `401`: list the advertised schemes, linked metadata, and the credential or browser action each requires, then wait for confirmation. If no choice is made, stop. This prevents an unadvertised Digest or OAuth fallback from changing the user's intended identity.
+
 ### Identity-first ACL state machine
 
 The protected resource is ACL-gated and payment is evaluated for an authenticated identity. Use this response sequence:

--- a/ucp-client/references/protocol-notes.md
+++ b/ucp-client/references/protocol-notes.md
@@ -1,0 +1,89 @@
+# Protocol notes
+
+## UCP
+
+Current UCP REST discovery uses `/.well-known/ucp`. The business profile advertises a `dev.ucp.shopping` REST service endpoint and capabilities such as `dev.ucp.shopping.checkout`. Checkout operations are relative to the discovered endpoint and include create/get/update/complete/cancel session operations.
+
+Profiles in the wild have at least two relevant shapes. Accept a list of transport records containing `transport: rest` and `endpoint`, or a service object containing `rest.endpoint`. Capabilities may be keyed dictionaries or arrays of objects with a `name`. Preserve the advertised service/capability version rather than normalizing it to a hard-coded release.
+
+UCP checkout line items use merchant commerce item identifiers. RDF resource IRIs and offer IRIs must therefore be preserved separately from the merchant item ID. This skill maps the UCP item ID from Schema.org in this order:
+
+1. `schema:sku`
+2. `schema:productID`
+3. literal `schema:identifier`
+4. configured explicit merchant identifier predicates such as `oplofr:offerNumber`
+5. an explicit operator-supplied item ID
+6. a `schema:potentialAction` item parameter only when the operator opts in
+
+Never infer an opaque UCP item ID from a URL path.
+
+UCP checkout and MPP are separate protocols. Do not mark a checkout completed merely because MPP returned a payment receipt. Completion requires a merchant-supported binding between the external/MPP payment proof and the checkout session.
+
+## RDF / Schema.org offer matching
+
+Accept both `http://schema.org/` and `https://schema.org/`. An offer matches a resource when the resource IRI appears as:
+
+- `schema:itemOffered` (strongest)
+- `schema:url`
+- `schema:contentUrl`
+- a URI-valued `schema:identifier` (only if explicitly modeled as such)
+- an explicit relation from the offered Product/License to the resource, including a merchant predicate supplied with `--resource-predicate`
+
+Extract `schema:price`, `schema:priceCurrency`, `schema:availability`, `schema:seller`, and item identifiers. Price and currency may occur directly on the Offer or on its `schema:priceSpecification`. Numeric price comparison must use decimal arithmetic.
+
+## MPP / HTTP Payment authentication
+
+MPP uses the HTTP `402 Payment Required` response with `WWW-Authenticate: Payment` challenges. The client fulfills one challenge and retries using `Authorization: Payment`; success may include a `Payment-Receipt` response header. `401 Unauthorized` is an authentication discovery/challenge response, not a Digest-only response: it can advertise Digest, WebID-TLS/mTLS-related metadata, Bearer, or DPoP. The client may use a `401` to begin OAuth authorization and obtain a token, but must not rewrite that `401` as `402` until authentication has succeeded and the authenticated identity has failed the ACL.
+
+### Identity discovery and execution modes
+
+The client treats server response headers as the REST discovery surface. A `401` may contain multiple `WWW-Authenticate` schemes (including Digest) and a `Link: rel="service-desc"` pointing to authentication metadata. If OAuth is selected, fetch the resource origin's [OAuth 2.0 Authorization Server Metadata](https://www.rfc-editor.org/rfc/rfc8414), use browser Authorization Code + [PKCE](https://www.rfc-editor.org/rfc/rfc7636), and return the resulting access token through an environment variable. Bearer uses `Authorization: Bearer`; DPoP uses `Authorization: DPoP` plus a `DPoP` proof header. The issuer must match the protected resource origin.
+
+For direct WebID-TLS, use [`mtls-curl`](/Users/kidehen/Documents/Management/Development/ai-agent-skills/mtls-curl/SKILL.md) with a PEM or PKCS#12 certificate. This is the preferred ODS-QA execution profile. The server OAuth backend is assumed to be implemented already; this skill only discovers metadata and consumes tokens. Preserve the certificate context across redirects and post-payment retries.
+
+### Identity-first ACL state machine
+
+The protected resource is ACL-gated and payment is evaluated for an authenticated identity. Use this response sequence:
+
+1. Authenticate the request identity.
+2. Evaluate that identity against the resource ACL.
+3. Return `200` when the ACL grants access.
+4. Return `401` with the applicable non-payment authentication challenge when identity authentication is missing or fails.
+5. When authentication succeeds but the ACL does not grant access, return `402` with at least one `WWW-Authenticate: Payment` challenge that is explicitly correlated with that identity and resource.
+6. After payment, bind the receipt/entitlement to the authenticated identity, repeat the ACL decision, and return `200` plus `Payment-Receipt` when access is granted. Use `403` only for a terminal policy denial that payment cannot resolve.
+
+Required payment response shape:
+
+```http
+HTTP/1.1 402 Payment Required
+Cache-Control: no-store
+WWW-Authenticate: Payment id="...", realm="...", method="stripe", intent="charge", request="..."
+Link: <https://merchant.example/offers/report.ttl>; rel="describedby"; type="text/turtle"
+Link: <https://merchant.example/.well-known/ucp>; rel="service-desc"; type="application/json"
+Content-Type: application/problem+json
+```
+
+The status code alone is not sufficient. The client parses repeated `WWW-Authenticate` and `Link` fields and treats these as protocol errors:
+
+- `402` before the client has established identity;
+- `402` without a `Payment` challenge;
+- a Payment challenge that cannot be correlated with the resource and authenticated identity;
+- `401` presented as though it were a payment response.
+
+The MPP retry must reuse the same authenticated identity context. A Payment credential does not replace the identity credential; it supplies payment proof for that identity's missing ACL entitlement.
+
+Basic, Digest, Bearer, and DPoP identity credentials compete with Payment for the HTTP `Authorization` field, so do not design the retry as two simultaneous Authorization credentials. Preserve identity continuity using one of these patterns:
+
+- authenticate independently at the transport layer, such as WebID-TLS/mTLS, while `Authorization: Payment` carries payment proof;
+- establish a secure authenticated session cookie during the identity exchange, then send that cookie with `Authorization: Payment`;
+- bind the Payment challenge ID server-side to the authenticated identity, resource IRI, ACL decision, amount, currency, and expiry, then update the identity's entitlement after verification and require a fresh resource GET using the original identity authentication.
+
+The third pattern is especially suitable when UCP checkout and MPP settlement occur at separate REST resources. The original protected-resource endpoint remains stateless from the client's perspective: its `402` response provides links and challenge metadata, payment updates the entitlement resource, and the client retries the protected GET with the same identity.
+
+The Payment authentication framework is payment-method agnostic. Stripe can be offered as a method such as `stripe/charge`. Use an MPP implementation (for example `mppx`) to handle method-specific challenge parsing, payment credential creation, Stripe Shared Payment Token/card flows, retry, and receipt verification.
+
+Do not implement Stripe card handling directly in this skill. Delegate payment-sensitive operations to the MPP SDK/client so PCI-sensitive details do not enter the agent workflow.
+
+## Versioning
+
+UCP is evolving. Always obey the version and endpoint advertised by the merchant profile instead of assuming a fixed dated schema. MPP Payment authentication is also evolving; preserve raw challenge and receipt headers for reproducibility.

--- a/ucp-client/scripts/test_ucp_resource_client.py
+++ b/ucp-client/scripts/test_ucp_resource_client.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+import importlib.util, pathlib
+from rdflib import Graph
+
+p = pathlib.Path(__file__).with_name('ucp_resource_client.py')
+spec = importlib.util.spec_from_file_location('client', p)
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+
+ttl = '''@prefix schema: <https://schema.org/> .
+<https://shop.example/offers/r1> a schema:Offer ;
+ schema:itemOffered <https://shop.example/DAV/r1.pdf> ;
+ schema:price "5.00" ; schema:priceCurrency "USD" .
+<https://shop.example/DAV/r1.pdf> schema:sku "r1" .
+'''
+g = Graph().parse(data=ttl, format='turtle')
+o = m.find_offer(g, 'https://shop.example/DAV/r1.pdf')
+r = m.offer_to_record(g, o, 'https://shop.example/DAV/r1.pdf')
+assert r['offer_iri'] == 'https://shop.example/offers/r1'
+assert r['ucp_item_id'] == 'r1'
+assert r['rdf_price'] == '5.00'
+assert r['rdf_currency'] == 'USD'
+
+direct_ttl = '''@prefix schema: <http://schema.org/> .
+<https://shop.example/offers/direct> a schema:Offer ;
+ schema:url <https://shop.example/DAV/direct.pdf> ; schema:sku "direct-item" .
+'''
+dg = Graph().parse(data=direct_ttl, format='turtle')
+do = m.find_offer(dg, 'https://shop.example/DAV/direct.pdf')
+dr = m.offer_to_record(dg, do, 'https://shop.example/DAV/direct.pdf')
+assert dr['item_offered'] == 'https://shop.example/DAV/direct.pdf'
+assert dr['ucp_item_id'] == 'direct-item'
+
+hotpot_ttl = '''@prefix schema: <http://schema.org/> .
+@prefix opllic: <http://www.openlinksw.com/ontology/licenses#> .
+@prefix oplofr: <http://www.openlinksw.com/ontology/offers#> .
+<http://data.example/offer/hotpot> a schema:Offer ;
+ schema:itemOffered <http://data.example/license/hotpot> ;
+ schema:priceSpecification <http://data.example/price/hotpot> ;
+ oplofr:offerNumber "ODSQA-FA-HOTPOT-0001" .
+<http://data.example/license/hotpot>
+ opllic:uriParameter <https://shop.example/DAV/Proper%20Lancashire%20Hotpot.pdf> .
+<http://data.example/price/hotpot>
+ schema:price "2.99" ; schema:priceCurrency "USD" .
+'''
+hg = Graph().parse(data=hotpot_ttl, format='turtle')
+ho = m.find_offer(hg, 'https://shop.example/DAV/Proper%20Lancashire%20Hotpot.pdf')
+hr = m.offer_to_record(hg, ho, 'https://shop.example/DAV/Proper%20Lancashire%20Hotpot.pdf')
+assert hr['offer_iri'] == 'http://data.example/offer/hotpot'
+assert hr['ucp_item_id'] == 'ODSQA-FA-HOTPOT-0001'
+assert hr['ucp_item_id_source'] == str(m.OPLOFR_OFFER_NUMBER)
+assert hr['rdf_price'] == '2.99' and hr['rdf_currency'] == 'USD'
+assert hr['price_specification'] == 'http://data.example/price/hotpot'
+
+action_ttl = '''@prefix schema: <https://schema.org/> .
+<https://shop.example/offers/action> a schema:Offer ;
+ schema:itemOffered <https://shop.example/DAV/action.pdf> ;
+ schema:potentialAction <https://shop.example/cart?item=https%3A%2F%2Fshop.example%2Foffers%2Faction> .
+'''
+ag = Graph().parse(data=action_ttl, format='turtle')
+ao = m.find_offer(ag, 'https://shop.example/DAV/action.pdf')
+try:
+    m.offer_to_record(ag, ao, 'https://shop.example/DAV/action.pdf')
+    raise AssertionError('potentialAction must remain opt-in')
+except RuntimeError:
+    pass
+ar = m.offer_to_record(ag, ao, 'https://shop.example/DAV/action.pdf', allow_action_item_id=True)
+assert ar['ucp_item_id'] == 'https://shop.example/offers/action'
+
+class HeaderList:
+    def __init__(self, values): self.values = values
+    def getlist(self, name): return self.values.get(name.lower(), [])
+
+class RawHeaders:
+    def __init__(self, values): self.headers = HeaderList(values)
+
+class AccessResponse:
+    def __init__(self, status, headers=None, header_lists=None):
+        self.status_code = status
+        self.headers = headers or {}
+        self.raw = RawHeaders(header_lists or {})
+
+auth_401 = AccessResponse(401, {'WWW-Authenticate': 'Digest realm="dav", nonce="abc"'})
+assert m.resource_access_metadata(auth_401, 'https://shop.example/DAV/r1.pdf')['state'] == 'authentication_required'
+assert m.resource_access_metadata(auth_401, 'https://shop.example/DAV/r1.pdf', True)['state'] == 'authentication_failed'
+
+granted = AccessResponse(200, {'Content-Type': 'application/pdf'})
+assert m.resource_access_metadata(granted, 'https://shop.example/DAV/r1.pdf', True)['state'] == 'access_granted'
+
+payment_header = ('Payment id="challenge-1", realm="dav", method="stripe", '
+                  'intent="charge", request="eyJhbW91bnQiOiIyOTkifQ"')
+payment_402 = AccessResponse(402, {
+    'WWW-Authenticate': payment_header,
+    'Link': '<https://shop.example/offers/r1.ttl>; rel="describedby"; type="text/turtle"',
+})
+payment_meta = m.resource_access_metadata(payment_402, 'https://shop.example/DAV/r1.pdf', True)
+assert payment_meta['state'] == 'payment_required'
+assert payment_meta['payment_challenges'][0]['method'] == 'stripe'
+assert payment_meta['payment_challenges'][0]['intent'] == 'charge'
+assert payment_meta['links'][0]['rels'] == ('describedby',)
+assert m.resource_access_metadata(payment_402, 'https://shop.example/DAV/r1.pdf')['state'] == 'protocol_error'
+
+bare_402 = AccessResponse(402, {})
+bare_meta = m.resource_access_metadata(bare_402, 'https://shop.example/DAV/r1.pdf', True)
+assert bare_meta['state'] == 'protocol_error'
+assert 'lacks WWW-Authenticate' in bare_meta['protocol_errors'][0]
+
+denied_403 = AccessResponse(403, {})
+assert m.resource_access_metadata(denied_403, 'https://shop.example/DAV/r1.pdf', True)['state'] == 'access_denied'
+
+class FakeResponse:
+    def __init__(self, payload): self.payload = payload
+    def raise_for_status(self): pass
+    def json(self): return self.payload
+
+class FakeSession:
+    def __init__(self): self.calls = []
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        if url.endswith('/sparql'):
+            return FakeResponse({'results': {'bindings': [{
+                'offer': {'type': 'uri', 'value': 'https://shop.example/offers/r1'},
+                'item': {'type': 'uri', 'value': 'https://shop.example/DAV/r1.pdf'},
+                'itemSku': {'type': 'literal', 'value': 'r1'},
+                'price': {'type': 'literal', 'value': '5.00'},
+                'currency': {'type': 'literal', 'value': 'USD'},
+            }]}})
+        raise AssertionError('RDF dereference should not run after SPARQL match')
+
+fs = FakeSession()
+sg, so, meta = m.discover_offer(fs, 'https://shop.example/DAV/r1.pdf', rdf_url='https://shop.example/offers/r1.ttl')
+assert meta['method'] == 'sparql'
+assert m.offer_to_record(sg, so, 'https://shop.example/DAV/r1.pdf')['ucp_item_id'] == 'r1'
+assert len(fs.calls) == 1 and fs.calls[0][0] == 'https://shop.example/sparql'
+
+legacy_profile = {'ucp': {
+    'services': {'dev.ucp.shopping': [
+        {'transport': 'rest', 'endpoint': 'https://shop.example/ucp', 'version': 'v1'}]},
+    'capabilities': {'dev.ucp.shopping.checkout': [{}]}}}
+current_profile = {
+    'ucp': {
+        'version': '2026-01-11',
+        'services': {'dev.ucp.shopping': {
+            'version': '2026-01-11',
+            'rest': {'endpoint': 'https://shop.example/ucp'}}},
+        'capabilities': [{'name': 'dev.ucp.shopping.checkout', 'version': '2026-01-11'}]},
+    'payment': {'handlers': [{'id': 'mock_payment_handler'}]}}
+
+class ProfileSession:
+    def __init__(self, profile): self.profile = profile
+    def get(self, url, **kwargs): return FakeResponse(self.profile)
+
+lu = m.discover_ucp(ProfileSession(legacy_profile), 'https://shop.example')
+assert lu['endpoint'] == 'https://shop.example/ucp' and lu['version'] == 'v1'
+cu = m.discover_ucp(ProfileSession(current_profile), 'https://shop.example')
+assert cu['endpoint'] == 'https://shop.example/ucp'
+assert cu['version'] == '2026-01-11'
+assert cu['payment_handlers'][0]['id'] == 'mock_payment_handler'
+print('ok')

--- a/ucp-client/scripts/ucp_resource_client.py
+++ b/ucp-client/scripts/ucp_resource_client.py
@@ -1,0 +1,602 @@
+#!/usr/bin/env python3
+import argparse, json, os, re, subprocess, sys
+from urllib.parse import parse_qs, unquote, urlparse, urljoin
+
+import requests
+from requests.auth import HTTPDigestAuth
+from rdflib import Graph, URIRef, Literal
+from rdflib.namespace import RDF
+
+SCHEMA = "https://schema.org/"
+SCHEMA_BASES = (SCHEMA, "http://schema.org/")
+S = lambda term: URIRef(SCHEMA + term)
+schema_terms = lambda term: tuple(URIRef(base + term) for base in SCHEMA_BASES)
+
+OPLLIC_URI_PARAMETER = URIRef("http://www.openlinksw.com/ontology/licenses#uriParameter")
+OPLOFR_OFFER_NUMBER = URIRef("http://www.openlinksw.com/ontology/offers#offerNumber")
+DEFAULT_RESOURCE_PREDICATES = (
+    *schema_terms("url"), *schema_terms("contentUrl"), *schema_terms("identifier"),
+    OPLLIC_URI_PARAMETER,
+)
+DEFAULT_ITEM_ID_PREDICATES = (OPLOFR_OFFER_NUMBER,)
+
+
+def _parse_rdf_response(response, url):
+    ctype = response.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+    fmts = {"text/turtle": "turtle", "application/ld+json": "json-ld",
+            "application/rdf+xml": "xml", "application/n-triples": "nt"}
+    fmt = fmts.get(ctype)
+    if fmt:
+        g = Graph(); g.parse(data=response.text, format=fmt, publicID=url); return g
+    last = None
+    for candidate in ("turtle", "json-ld", "xml", "nt"):
+        try:
+            g = Graph(); g.parse(data=response.text, format=candidate, publicID=url); return g
+        except Exception as e: last = e
+    raise RuntimeError(f"Unable to parse RDF from {url}: {last}")
+
+
+def _header_values(response, name):
+    raw_headers = getattr(getattr(response, "raw", None), "headers", None)
+    if raw_headers is not None and hasattr(raw_headers, "getlist"):
+        values = raw_headers.getlist(name)
+        if values:
+            return values
+    value = response.headers.get(name)
+    return [value] if value else []
+
+
+def _link_records(response, base_url):
+    records = []
+    for header in _header_values(response, "Link"):
+        for match in re.finditer(r"<([^>]+)>\s*;\s*([^,]+)", header):
+            target, params = match.groups()
+            rel = re.search(r"(?:^|;)\s*rel=\"?([^;\",]+)", ";" + params, re.I)
+            typ = re.search(r"(?:^|;)\s*type=\"?([^;\",]+)", ";" + params, re.I)
+            rels = tuple((rel.group(1).lower().split() if rel else []))
+            records.append({"url": urljoin(base_url, target), "rels": rels,
+                            "type": typ.group(1) if typ else None})
+    return records
+
+
+def _rdf_links(response, base_url):
+    links = []
+    for record in _link_records(response, base_url):
+        rels = set(record["rels"])
+        typ = record["type"]
+        if rels.intersection({"describedby", "alternate", "offer", "payment"}) and (not typ or "rdf" in typ.lower() or "turtle" in typ.lower() or "json" in typ.lower()):
+            links.append(record["url"])
+    return links
+
+
+def _authentication_challenges(response):
+    challenges = []
+    scheme_start = re.compile(r"(?:^|,\s*)([A-Za-z][A-Za-z0-9._~-]*)\s+")
+    for header in _header_values(response, "WWW-Authenticate"):
+        matches = list(scheme_start.finditer(header))
+        if not matches:
+            continue
+        for index, match in enumerate(matches):
+            start = match.start(1)
+            end = matches[index + 1].start() if index + 1 < len(matches) else len(header)
+            raw = header[start:end].strip().rstrip(",")
+            challenges.append({"scheme": match.group(1), "raw": raw})
+    return challenges
+
+
+def _auth_params(raw_challenge):
+    body = raw_challenge.split(None, 1)[1] if " " in raw_challenge else ""
+    params = {}
+    pattern = re.compile(r'([A-Za-z][A-Za-z0-9_-]*)=(?:"((?:\\.|[^"\\])*)"|([^,\s]+))')
+    for match in pattern.finditer(body):
+        params[match.group(1).lower()] = (match.group(2) if match.group(2) is not None else match.group(3))
+    return params
+
+
+def resource_access_metadata(response, resource_url, identity_established=False):
+    challenges = _authentication_challenges(response)
+    payment_challenges = [dict(_auth_params(c["raw"]), raw=c["raw"])
+                          for c in challenges if c["scheme"].lower() == "payment"]
+    links = _link_records(response, resource_url)
+    status = response.status_code
+    errors = []
+    if 200 <= status < 300:
+        state = "access_granted"
+    elif status == 401:
+        state = "authentication_failed" if identity_established else "authentication_required"
+    elif status == 402:
+        if not identity_established:
+            state = "protocol_error"
+            errors.append("payment challenge was issued before authenticated identity was established")
+        elif not payment_challenges:
+            state = "protocol_error"
+            errors.append("402 response lacks WWW-Authenticate: Payment challenge metadata")
+        else:
+            state = "payment_required"
+    elif status == 403:
+        state = "access_denied"
+    elif 300 <= status < 400:
+        state = "redirect"
+    else:
+        state = "unexpected_response"
+    return {
+        "status": status,
+        "state": state,
+        "identity_established": bool(identity_established),
+        "authentication_schemes": [c["scheme"] for c in challenges],
+        "payment_challenges": payment_challenges,
+        "links": links,
+        "payment_receipt": response.headers.get("Payment-Receipt"),
+        "location": response.headers.get("Location"),
+        "content_type": response.headers.get("Content-Type"),
+        "protocol_errors": errors,
+    }
+
+
+def probe_resource(session, resource_url, identity_established=False):
+    response = session.get(resource_url, stream=True, allow_redirects=False, timeout=30)
+    try:
+        return resource_access_metadata(response, resource_url, identity_established)
+    finally:
+        response.close()
+
+
+def configure_identity(session, args):
+    established = bool(args.identity_established)
+    bearer_token = os.environ.get(args.bearer_token_env) if args.bearer_token_env else None
+    if args.bearer_token_env and bearer_token is None:
+        raise ValueError("OAuth access-token environment variable is missing")
+    dpop_proof = os.environ.get(args.dpop_proof_env) if args.dpop_proof_env else None
+    if bearer_token and (args.digest_user_env or args.digest_password_env):
+        raise ValueError("Bearer/DPoP and Digest cannot share the Authorization header; choose one identity scheme")
+    if bearer_token:
+        token_type = (args.oauth_token_type or "Bearer").strip()
+        if token_type.lower() not in ("bearer", "dpop"):
+            raise ValueError("--oauth-token-type must be Bearer or DPoP")
+        session.headers["Authorization"] = f"{token_type} {bearer_token}"
+        if token_type.lower() == "dpop":
+            if not dpop_proof:
+                raise ValueError("--dpop-proof-env is required when --oauth-token-type DPoP")
+            session.headers["DPoP"] = dpop_proof
+        established = True
+    elif dpop_proof:
+        raise ValueError("--dpop-proof-env requires an OAuth access token")
+    for mapping in args.identity_header_env:
+        if "=" not in mapping:
+            raise ValueError("--identity-header-env requires HEADER=ENV_VAR")
+        header, env_name = mapping.split("=", 1)
+        value = os.environ.get(env_name)
+        if not header.strip() or value is None:
+            raise ValueError(f"Missing identity header name or environment variable: {env_name}")
+        session.headers[header.strip()] = value
+        established = True
+    if args.digest_user_env or args.digest_password_env:
+        if not (args.digest_user_env and args.digest_password_env):
+            raise ValueError("both --digest-user-env and --digest-password-env are required")
+        username = os.environ.get(args.digest_user_env)
+        password = os.environ.get(args.digest_password_env)
+        if username is None or password is None:
+            raise ValueError("Digest credential environment variable is missing")
+        session.auth = HTTPDigestAuth(username, password)
+        established = True
+    if args.client_cert:
+        session.cert = (args.client_cert, args.client_key) if args.client_key else args.client_cert
+        established = True
+    if args.accept_payment:
+        session.headers["Accept-Payment"] = args.accept_payment
+    return established
+
+
+def fetch_rdf(url, session):
+    headers = {"Accept": "text/turtle, application/ld+json, application/rdf+xml, application/n-triples;q=0.9, */*;q=0.1"}
+    r = session.get(url, headers=headers, timeout=30)
+    # Protected resources may expose RDF metadata on any authentication/payment
+    # error, not only 402. Inspect RDF bodies and typed Link relations first.
+    if r.status_code >= 400:
+        ctype = r.headers.get("content-type", "").lower()
+        rdf_body = any(token in ctype for token in ("turtle", "ld+json", "rdf+xml", "n-triples"))
+        try:
+            graph = _parse_rdf_response(r, url) if rdf_body else None
+            if graph:
+                return graph
+        except Exception:
+            pass
+        for linked in _rdf_links(r, url):
+            try:
+                return fetch_rdf(linked, session)
+            except Exception:
+                continue
+        r.raise_for_status()
+    r.raise_for_status()
+    return _parse_rdf_response(r, url)
+
+
+def first_obj(g, subj, pred):
+    return next(iter(g.objects(subj, pred)), None)
+
+
+def first_obj_any(g, subj, predicates):
+    if subj is None:
+        return None, None
+    for pred in predicates:
+        value = first_obj(g, subj, pred)
+        if value is not None:
+            return value, pred
+    return None, None
+
+
+def _offer_subjects(g):
+    offers = set()
+    for offer_type in schema_terms("Offer"):
+        offers.update(g.subjects(RDF.type, offer_type))
+    return offers
+
+
+def _item_offered(g, offer):
+    return first_obj_any(g, offer, schema_terms("itemOffered"))[0]
+
+
+def _offer_value(g, offer, term):
+    value, pred = first_obj_any(g, offer, schema_terms(term))
+    if value is not None:
+        return value, pred, None
+    specification, _ = first_obj_any(g, offer, schema_terms("priceSpecification"))
+    value, pred = first_obj_any(g, specification, schema_terms(term))
+    return value, pred, specification
+
+
+def find_offer(g, resource_url, resource_predicates=None):
+    resource = URIRef(resource_url)
+    resource_predicates = tuple(resource_predicates or DEFAULT_RESOURCE_PREDICATES)
+    candidates = []
+    for offer in _offer_subjects(g):
+        score = 0
+        item = _item_offered(g, offer)
+        if item == resource:
+            score = max(score, 120)
+        for pred in resource_predicates:
+            if (offer, pred, resource) in g:
+                score = max(score, 100)
+            if item is not None and (item, pred, resource) in g:
+                score = max(score, 110)
+        if score:
+            if _offer_value(g, offer, "price")[0] is not None: score += 5
+            if _offer_value(g, offer, "priceCurrency")[0] is not None: score += 5
+            candidates.append((score, str(offer), offer))
+    if not candidates:
+        raise RuntimeError("No schema:Offer in RDF matches the supplied resource URL")
+    candidates.sort(reverse=True)
+    if len(candidates) > 1 and candidates[0][0] == candidates[1][0]:
+        raise RuntimeError("Multiple equally ranked schema:Offer resources match; explicit selection required")
+    return candidates[0][2]
+
+
+def _values(iris):
+    return " ".join(f"<{iri}>" for iri in iris)
+
+
+def sparql_offer_graph(session, endpoint, resource_url, resource_predicates=None):
+    """Query direct and item-mediated resource relations across Schema.org namespaces."""
+    if urlparse(resource_url).scheme not in ("http", "https"):
+        raise ValueError("resource URL must be an HTTP(S) IRI")
+    resource_predicates = tuple(resource_predicates or DEFAULT_RESOURCE_PREDICATES)
+    query = f"""SELECT ?offer ?item ?matchedNode ?matchPredicate ?priceSpec ?currencySpec
+       ?offerSku ?offerProductID ?offerIdentifier ?offerNumber
+       ?itemSku ?itemProductID ?itemIdentifier ?price ?currency ?availability ?seller
+WHERE {{
+  VALUES ?offerType {{ {_values(schema_terms("Offer"))} }}
+  VALUES ?itemOfferedPred {{ {_values(schema_terms("itemOffered"))} }}
+  ?offer a ?offerType .
+  OPTIONAL {{ ?offer ?itemOfferedPred ?item }}
+  {{ FILTER(?item = <{resource_url}>) BIND(?item AS ?matchedNode) BIND(?itemOfferedPred AS ?matchPredicate) }}
+  UNION
+  {{ VALUES ?resourcePred {{ {_values(resource_predicates)} }}
+     ?offer ?resourcePred <{resource_url}> .
+     BIND(?offer AS ?matchedNode) BIND(?resourcePred AS ?matchPredicate) }}
+  UNION
+  {{ VALUES ?resourcePred {{ {_values(resource_predicates)} }}
+     ?item ?resourcePred <{resource_url}> .
+     BIND(?item AS ?matchedNode) BIND(?resourcePred AS ?matchPredicate) }}
+  OPTIONAL {{ VALUES ?offerSkuPred {{ {_values(schema_terms("sku"))} }} ?offer ?offerSkuPred ?offerSku }}
+  OPTIONAL {{ VALUES ?offerProductIDPred {{ {_values(schema_terms("productID"))} }} ?offer ?offerProductIDPred ?offerProductID }}
+  OPTIONAL {{ VALUES ?offerIdentifierPred {{ {_values(schema_terms("identifier"))} }} ?offer ?offerIdentifierPred ?offerIdentifier }}
+  OPTIONAL {{ ?offer <{OPLOFR_OFFER_NUMBER}> ?offerNumber }}
+  OPTIONAL {{ VALUES ?itemSkuPred {{ {_values(schema_terms("sku"))} }} ?item ?itemSkuPred ?itemSku }}
+  OPTIONAL {{ VALUES ?itemProductIDPred {{ {_values(schema_terms("productID"))} }} ?item ?itemProductIDPred ?itemProductID }}
+  OPTIONAL {{ VALUES ?itemIdentifierPred {{ {_values(schema_terms("identifier"))} }} ?item ?itemIdentifierPred ?itemIdentifier }}
+  OPTIONAL {{
+    {{ VALUES ?pricePred {{ {_values(schema_terms("price"))} }} ?offer ?pricePred ?price }}
+    UNION
+    {{ VALUES ?specPred {{ {_values(schema_terms("priceSpecification"))} }}
+       VALUES ?pricePred {{ {_values(schema_terms("price"))} }}
+       ?offer ?specPred ?priceSpec . ?priceSpec ?pricePred ?price }}
+  }}
+  OPTIONAL {{
+    {{ VALUES ?currencyPred {{ {_values(schema_terms("priceCurrency"))} }} ?offer ?currencyPred ?currency }}
+    UNION
+    {{ VALUES ?specPred {{ {_values(schema_terms("priceSpecification"))} }}
+       VALUES ?currencyPred {{ {_values(schema_terms("priceCurrency"))} }}
+       ?offer ?specPred ?currencySpec . ?currencySpec ?currencyPred ?currency }}
+  }}
+  OPTIONAL {{ VALUES ?availabilityPred {{ {_values(schema_terms("availability"))} }} ?offer ?availabilityPred ?availability }}
+  OPTIONAL {{ VALUES ?sellerPred {{ {_values(schema_terms("seller"))} }} ?offer ?sellerPred ?seller }}
+}} LIMIT 50"""
+    r = session.get(endpoint, params={"query": query, "format": "application/sparql-results+json"}, timeout=30)
+    r.raise_for_status()
+    try:
+        rows = r.json().get("results", {}).get("bindings", [])
+    except ValueError as e:
+        raise RuntimeError(f"SPARQL endpoint did not return JSON results: {e}") from e
+    g = Graph()
+    for row in rows:
+        offer, item = row.get("offer", {}).get("value"), row.get("item", {}).get("value")
+        if not offer:
+            continue
+        offer_ref = URIRef(offer)
+        item_ref = URIRef(item) if item else None
+        g.add((offer_ref, RDF.type, S("Offer")))
+        if item_ref is not None:
+            g.add((offer_ref, S("itemOffered"), item_ref))
+        matched = row.get("matchedNode", {}).get("value")
+        if matched and matched != resource_url:
+            g.add((URIRef(matched), S("url"), URIRef(resource_url)))
+        fields = (("offerSku", offer_ref, "sku"), ("offerProductID", offer_ref, "productID"),
+                  ("offerIdentifier", offer_ref, "identifier"), ("itemSku", item_ref, "sku"),
+                  ("itemProductID", item_ref, "productID"), ("itemIdentifier", item_ref, "identifier"),
+                  ("availability", offer_ref, "availability"), ("seller", offer_ref, "seller"))
+        for key, subj, pred_name in fields:
+            if subj is None:
+                continue
+            binding = row.get(key)
+            if not binding or not binding.get("value"):
+                continue
+            value = binding["value"]
+            term = URIRef(value) if binding.get("type") == "uri" else Literal(value)
+            g.add((subj, S(pred_name), term))
+        specification_value = (row.get("priceSpec", {}).get("value") or
+                               row.get("currencySpec", {}).get("value"))
+        price_subject = offer_ref
+        if specification_value:
+            price_subject = URIRef(specification_value)
+            g.add((offer_ref, S("priceSpecification"), price_subject))
+        for key, pred_name in (("price", "price"), ("currency", "priceCurrency")):
+            binding = row.get(key)
+            if binding and binding.get("value"):
+                value = binding["value"]
+                term = URIRef(value) if binding.get("type") == "uri" else Literal(value)
+                g.add((price_subject, S(pred_name), term))
+        offer_number = row.get("offerNumber")
+        if offer_number and offer_number.get("value"):
+            g.add((offer_ref, OPLOFR_OFFER_NUMBER, Literal(offer_number["value"])))
+    return g
+
+
+def discover_offer(session, resource_url, rdf_url=None, merchant_origin=None,
+                   sparql_endpoint=None, resource_predicates=None):
+    """Use merchant SPARQL first, then dereference RDF when needed."""
+    endpoint = sparql_endpoint or urljoin((merchant_origin or origin(resource_url)).rstrip("/") + "/", "sparql")
+    try:
+        graph = sparql_offer_graph(session, endpoint, resource_url, resource_predicates)
+        if graph:
+            return graph, find_offer(graph, resource_url, resource_predicates), {"method": "sparql", "endpoint": endpoint}
+        reason = "no matching schema:Offer"
+    except Exception as exc:
+        reason = str(exc)
+    rdf_source = rdf_url or resource_url
+    graph = fetch_rdf(rdf_source, session)
+    return graph, find_offer(graph, resource_url, resource_predicates), {
+        "method": "rdf_dereference", "url": rdf_source, "sparql_fallback_reason": reason}
+
+
+def _potential_action_item_id(g, offer):
+    action, _ = first_obj_any(g, offer, schema_terms("potentialAction"))
+    if not isinstance(action, URIRef):
+        return None
+    query = parse_qs(urlparse(str(action)).query)
+    for key in ("item", "sku", "product", "product_id"):
+        values = query.get(key)
+        if values and values[0].strip():
+            return unquote(values[0].strip())
+    return None
+
+
+def offer_to_record(g, offer, resource_url, item_id_override=None,
+                    item_id_predicates=None, allow_action_item_id=False):
+    item = _item_offered(g, offer)
+    item_id = item_id_override.strip() if item_id_override else None
+    item_id_source = "cli_override" if item_id else None
+    # Prefer identifiers on itemOffered if it is a resource, then on Offer.
+    subjects = [item, offer] if item is not None else [offer]
+    if not item_id:
+        for term in ("sku", "productID", "identifier"):
+            for subj in subjects:
+                v, pred = first_obj_any(g, subj, schema_terms(term))
+                if isinstance(v, Literal) and str(v).strip():
+                    item_id = str(v).strip()
+                    item_id_source = str(pred)
+                    break
+            if item_id: break
+    if not item_id:
+        for pred in tuple(item_id_predicates or DEFAULT_ITEM_ID_PREDICATES):
+            for subj in subjects:
+                v = first_obj(g, subj, pred) if subj is not None else None
+                if isinstance(v, Literal) and str(v).strip():
+                    item_id = str(v).strip()
+                    item_id_source = str(pred)
+                    break
+            if item_id: break
+    if not item_id and allow_action_item_id:
+        item_id = _potential_action_item_id(g, offer)
+        item_id_source = "schema:potentialAction query parameter" if item_id else None
+    if not item_id:
+        raise RuntimeError("Offer lacks an accepted UCP item identifier; use schema:sku/productID/identifier, a configured --item-id-predicate, or explicit --item-id")
+    price, _, price_spec = _offer_value(g, offer, "price")
+    currency, _, currency_spec = _offer_value(g, offer, "priceCurrency")
+    availability, _, _ = _offer_value(g, offer, "availability")
+    seller, _, _ = _offer_value(g, offer, "seller")
+    return {
+        "resource_url": resource_url,
+        "offer_iri": str(offer),
+        "item_offered": str(item) if item is not None else resource_url,
+        "ucp_item_id": item_id,
+        "ucp_item_id_source": item_id_source,
+        "rdf_price": str(price) if price is not None else None,
+        "rdf_currency": str(currency) if currency is not None else None,
+        "price_specification": str(price_spec or currency_spec) if (price_spec or currency_spec) else None,
+        "availability": str(availability) if availability is not None else None,
+        "seller": str(seller) if seller is not None else None,
+    }
+
+
+def origin(url):
+    p = urlparse(url)
+    return f"{p.scheme}://{p.netloc}"
+
+
+def discover_ucp(session, base_origin, profile_url=None):
+    u = profile_url or urljoin(base_origin.rstrip("/") + "/", ".well-known/ucp")
+    r = session.get(u, headers={"Accept": "application/json"}, timeout=30)
+    r.raise_for_status()
+    profile = r.json()
+    ucp = profile.get("ucp", profile)
+    services = ucp.get("services", {})
+    shopping = services.get("dev.ucp.shopping") if isinstance(services, dict) else None
+    if shopping is None and isinstance(services, list):
+        shopping = next((s for s in services if s.get("name") == "dev.ucp.shopping" or s.get("id") == "dev.ucp.shopping"), None)
+    rest = None
+    service_version = None
+    if isinstance(shopping, list):
+        rest = next((s for s in shopping if s.get("transport") == "rest" and s.get("endpoint")), None)
+    elif isinstance(shopping, dict):
+        service_version = shopping.get("version")
+        if isinstance(shopping.get("rest"), dict):
+            rest = shopping["rest"]
+        elif shopping.get("transport") in (None, "rest") and shopping.get("endpoint"):
+            rest = shopping
+    if not rest:
+        raise RuntimeError("UCP profile does not advertise a dev.ucp.shopping REST endpoint")
+    caps = ucp.get("capabilities", {})
+    if isinstance(caps, dict):
+        checkout_capability = caps.get("dev.ucp.shopping.checkout")
+    elif isinstance(caps, list):
+        checkout_capability = next((c for c in caps if isinstance(c, dict) and c.get("name") == "dev.ucp.shopping.checkout"), None)
+    else:
+        checkout_capability = None
+    if checkout_capability is None:
+        raise RuntimeError("UCP profile does not advertise dev.ucp.shopping.checkout")
+    return {"profile_url": u, "endpoint": rest["endpoint"].rstrip("/"),
+            "version": rest.get("version") or service_version or ucp.get("version"),
+            "checkout_capability": checkout_capability,
+            "payment_handlers": profile.get("payment", {}).get("handlers", []),
+            "profile": profile}
+
+
+def create_checkout(session, endpoint, item_id, quantity, agent_profile=None):
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if agent_profile:
+        headers["UCP-Agent"] = f'profile="{agent_profile}"'
+    body = {"line_items": [{"item": {"id": item_id}, "quantity": quantity}]}
+    r = session.post(endpoint + "/checkout-sessions", headers=headers, json=body, timeout=30)
+    r.raise_for_status()
+    return r.json()
+
+
+def checkout_summary(obj):
+    out = {"checkout_id": obj.get("id"), "checkout_status": obj.get("status")}
+    # Preserve likely totals without assuming one dated schema.
+    for k in ("total", "totals", "currency", "payment", "messages", "continue_url"):
+        if k in obj: out[k] = obj[k]
+    return out
+
+
+def run_mpp(command_template, resource_url):
+    command = command_template.replace("{url}", resource_url)
+    proc = subprocess.run(command, shell=True, capture_output=True, text=True)
+    return {"command": command, "exit_code": proc.returncode, "stdout": proc.stdout, "stderr": proc.stderr}
+
+
+def main():
+    ap = argparse.ArgumentParser(description="RDF offer -> UCP checkout -> MPP protected-resource purchase")
+    ap.add_argument("--resource-url", required=True)
+    ap.add_argument("--rdf-url", help="RDF description URL; defaults to resource URL")
+    ap.add_argument("--sparql-endpoint", help="Merchant SPARQL endpoint; defaults to <merchant-origin>/sparql")
+    ap.add_argument("--merchant-origin", help="Origin containing /.well-known/ucp; defaults to resource origin")
+    ap.add_argument("--quantity", type=int, default=1)
+    ap.add_argument("--agent-profile")
+    ap.add_argument("--identity-header-env", action="append", default=[], metavar="HEADER=ENV_VAR",
+                    help="Send an identity header whose value comes from an environment variable; repeatable")
+    ap.add_argument("--digest-user-env", help="Environment variable containing the Digest username")
+    ap.add_argument("--digest-password-env", help="Environment variable containing the Digest password")
+    ap.add_argument("--bearer-token-env", help="Environment variable containing an OAuth access token (never emitted)")
+    ap.add_argument("--oauth-token-type", choices=("Bearer", "DPoP"), default="Bearer",
+                    help="OAuth HTTP authorization scheme; defaults to Bearer")
+    ap.add_argument("--dpop-proof-env", help="Environment variable containing the per-request DPoP proof JWT")
+    ap.add_argument("--client-cert", help="PEM client certificate path for identity authentication")
+    ap.add_argument("--client-key", help="PEM client private-key path used with --client-cert")
+    ap.add_argument("--identity-established", action="store_true",
+                    help="Assert that ambient session state establishes identity without exposing credentials")
+    ap.add_argument("--accept-payment", help="Advertise supported payment methods, e.g. stripe/charge")
+    ap.add_argument("--access-probe-only", action="store_true",
+                    help="Test authentication/ACL/payment response metadata and stop")
+    ap.add_argument("--resource-predicate", action="append", default=[], metavar="IRI",
+                    help="Additional RDF predicate that explicitly links an offer/item to the resource; repeatable")
+    ap.add_argument("--item-id-predicate", action="append", default=[], metavar="IRI",
+                    help="Additional RDF predicate containing a literal UCP item ID; repeatable")
+    ap.add_argument("--item-id", help="Explicit merchant UCP item ID override")
+    ap.add_argument("--allow-action-item-id", action="store_true",
+                    help="Allow item/sku/product query parameter from schema:potentialAction as the UCP item ID")
+    ap.add_argument("--mpp-command", help="MPP-aware command template; use {url} placeholder, e.g. 'npx mppx {url}'")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    if args.quantity < 1: raise SystemExit("quantity must be >= 1")
+    s = requests.Session()
+    try:
+        identity_established = configure_identity(s, args)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    access = probe_resource(s, args.resource_url, identity_established)
+    result = {"resource_url": args.resource_url, "resource_access": access}
+    if args.access_probe_only:
+        print(json.dumps(result, indent=2)); return
+    if not args.dry_run and access["state"] != "payment_required":
+        result["mpp"] = {"status": "not_executed", "reason": access["state"]}
+        print(json.dumps(result, indent=2))
+        if access["state"] not in ("access_granted",):
+            sys.exit(3)
+        return
+    resource_predicates = DEFAULT_RESOURCE_PREDICATES + tuple(URIRef(v) for v in args.resource_predicate)
+    item_id_predicates = DEFAULT_ITEM_ID_PREDICATES + tuple(URIRef(v) for v in args.item_id_predicate)
+    linked_rdf_url = next((link["url"] for link in access["links"]
+                           if set(link["rels"]).intersection({"describedby", "alternate"})), None)
+    linked_ucp_profile = next((link["url"] for link in access["links"]
+                               if set(link["rels"]).intersection({"ucp", "service-desc"})), None)
+    g, offer, discovery = discover_offer(s, args.resource_url, args.rdf_url or linked_rdf_url, args.merchant_origin,
+                                         args.sparql_endpoint, resource_predicates)
+    rec = offer_to_record(g, offer, args.resource_url, args.item_id,
+                          item_id_predicates, args.allow_action_item_id)
+    ucp = discover_ucp(s, args.merchant_origin or origin(args.resource_url), linked_ucp_profile)
+    result.update({"offer": rec, "offer_discovery": discovery,
+                   "ucp": {k:v for k,v in ucp.items() if k != "profile"}})
+
+    if args.dry_run:
+        result["checkout_request"] = {"line_items": [{"item": {"id": rec["ucp_item_id"]}, "quantity": args.quantity}]}
+        result["mpp"] = {"status": "not_executed", "reason": "dry_run"}
+        print(json.dumps(result, indent=2)); return
+
+    checkout = create_checkout(s, ucp["endpoint"], rec["ucp_item_id"], args.quantity, args.agent_profile)
+    result["checkout"] = checkout_summary(checkout)
+
+    if not args.mpp_command:
+        result["mpp"] = {"status": "handoff_required", "resource_url": args.resource_url,
+                         "note": "Run with --mpp-command using an MPP-aware client to fulfill HTTP 402 payment."}
+        print(json.dumps(result, indent=2)); return
+
+    mpp = run_mpp(args.mpp_command, args.resource_url)
+    result["mpp"] = mpp
+    result["warning"] = "MPP payment success does not by itself imply UCP checkout completion; reconcile only through a merchant-supported receipt/payment-handler binding."
+    print(json.dumps(result, indent=2))
+    if mpp["exit_code"] != 0: sys.exit(mpp["exit_code"])
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add the `ucp-client` skill for RDF `schema:Offer` discovery and UCP checkout orchestration
- query merchant RDF via SPARQL using the supplied resource IRI before HTTP/RDF fallback
- handle 401 authentication negotiation and 402 payment metadata, including WebID-TLS/mTLS composition guidance
- preserve MPP payment handoff and protocol-state provenance

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python3 ucp-client/scripts/test_ucp_resource_client.py` — passed

This PR is source-only and contains no generated archive or unrelated worktree changes.
